### PR TITLE
v0.16.0 — megaplan chain subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## v0.16.0 — 2026-04-15
+
+### Chain driver (`megaplan chain`)
+
+New first-class subcommand that drives an ordered pipeline of milestone plans described by a YAML spec. Replaces ad-hoc bash orchestration (`chain.sh`) so plan-state logic lives in megaplan instead of fragile shell polling.
+
+- **Spec-driven**: `megaplan chain --spec path/to/chain.yaml` reads milestones, optional seed plan, and failure/escalate policies from YAML.
+- **Resumable**: progress is persisted to `chain_state.json` next to the spec (`current_milestone_index`, `current_plan_name`, `last_state`, `completed`). A relaunched process reads this file and picks up where the previous run stopped.
+- **State-aware in the right layer**: each milestone is driven via the existing `megaplan.auto.drive` entry point, so phase selection (`plan → prep → critique → ... → review`) stays in megaplan. Shell wrappers no longer need to classify `next_step`.
+- **`megaplan chain status --spec PATH`**: prints current chain progress without driving.
+- **Failure/escalate policies**: `stop_chain` (default), `skip_milestone`, `retry_milestone`.
+- **Seed handling**: if a seed plan is specified and not already in a terminal state, it is driven first under the same auto loop — fixing the gap where seed plans had no state-aware driver.
+- **Validation**: up front, the chain driver checks every idea file exists and the seed plan (if set) resolves under the project root. Structured `invalid_spec` / `missing_idea_file` / `missing_seed_plan` errors.
+- **`--no-git-refresh` flag**: suppresses the automatic `git checkout main && git pull` that runs before each milestone. Default: enabled (preserves existing CI/orchestrator behavior). Disable on developer checkouts where you do not want chain to stomp on the currently checked-out branch.
+- **PyYAML** added as a runtime dependency.
+
+### Tests
+
+- `tests/test_chain.py` covers spec parsing, `chain status`, idea-file validation, seed-plan validation, happy-path execution (with `auto.drive` mocked), resume-from-`chain_state.json`, on-failure `stop_chain`, and `--no-git-refresh` suppression.
+
 ## v0.14.5 — 2026-04-15
 
 ### Git-worktree isolation for subprocess workers

--- a/megaplan/chain.py
+++ b/megaplan/chain.py
@@ -285,8 +285,17 @@ def _plan_state(root: Path, plan: str, *, timeout: float) -> str:
         return "unknown"
 
 
-def _refresh_main(root: Path, *, writer) -> None:
-    """Best-effort `git fetch + checkout main + pull`. Never raises; logs only."""
+def _refresh_main(root: Path, *, writer, no_git_refresh: bool = False) -> None:
+    """Best-effort `git fetch + checkout main + pull`. Never raises; logs only.
+
+    When ``no_git_refresh`` is True, this is a no-op (still logs that it was
+    skipped). This guard exists so developer checkouts running ``megaplan
+    chain`` do not get their currently checked-out branch stomped by an
+    automatic ``git checkout main``.
+    """
+    if no_git_refresh:
+        writer("[chain] skipping git refresh (--no-git-refresh)\n")
+        return
     for cmd in (
         ["git", "fetch", "origin", "main"],
         ["git", "checkout", "main"],
@@ -397,6 +406,7 @@ def run_chain(
     root: Path,
     *,
     writer=sys.stdout.write,
+    no_git_refresh: bool = False,
 ) -> dict[str, Any]:
     """Drive the full chain. Returns a structured JSON-serializable result."""
     spec = load_spec(spec_path)
@@ -457,7 +467,7 @@ def run_chain(
             plan_name = state.current_plan_name
             log(f"resuming existing plan {plan_name} for {milestone.label}")
         else:
-            _refresh_main(root, writer=writer)
+            _refresh_main(root, writer=writer, no_git_refresh=no_git_refresh)
             plan_name = _init_plan(
                 root,
                 milestone.idea,
@@ -527,6 +537,17 @@ def build_chain_parser(subparsers: Any) -> None:
         required=False,
         help="Path to the chain spec YAML (required at top-level or on subcommands)",
     )
+    chain_parser.add_argument(
+        "--no-git-refresh",
+        action="store_true",
+        help=(
+            "Skip the automatic `git checkout main && git pull` that runs "
+            "before each milestone. Use this on developer checkouts where "
+            "you do not want chain to stomp on the currently checked-out "
+            "branch. Default: refresh enabled (preserves CI/orchestrator "
+            "behavior)."
+        ),
+    )
 
     status_parser = chain_sub.add_parser(
         "status", help="Show persisted chain progress without driving"
@@ -559,8 +580,9 @@ def run_chain_cli(root: Path, args: argparse.Namespace) -> int:
         return 0
 
     # Default action: run.
+    no_git_refresh = bool(getattr(args, "no_git_refresh", False))
     try:
-        result = run_chain(spec_path, root)
+        result = run_chain(spec_path, root, no_git_refresh=no_git_refresh)
     except CliError as exc:
         return _emit_error(exc)
     sys.stdout.write(json.dumps(result, indent=2) + "\n")

--- a/megaplan/chain.py
+++ b/megaplan/chain.py
@@ -1,0 +1,575 @@
+"""Chain driver — run a pipeline of milestone plans with state kept in megaplan.
+
+This replaces ad-hoc bash orchestration (`chain.sh`). A YAML spec declares an
+optional seed plan and an ordered list of milestones; each milestone is
+initialized from an idea file, then driven to `done` via the same auto-loop
+entry point used by `megaplan auto`.
+
+Plan state stays in megaplan. Bash is no longer responsible for polling or
+deciding the next step — only for process/container liveness.
+
+Spec format (YAML)::
+
+    seed:
+      plan: milestone-m0-from-docs-state-20260415-0217
+    milestones:
+      - label: m1
+        idea: /workspace/ideas/M1-foundation-store.txt
+        branch: megaplan/m1-foundation-store   # optional, currently informational
+      - label: m1a
+        idea: /workspace/ideas/M1a-settings-store.txt
+    on_failure:
+      abort: stop_chain          # stop_chain | skip_milestone | retry_milestone
+    on_escalate:
+      abort: stop_chain          # stop_chain | skip_milestone | retry_milestone
+
+Progress is persisted to ``chain_state.json`` beside the spec so a relaunched
+process can resume where the previous run left off.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError as exc:  # pragma: no cover - import guard
+    raise RuntimeError(
+        "megaplan chain requires PyYAML. Install with `pip install pyyaml`."
+    ) from exc
+
+from megaplan.auto import (
+    DEFAULT_MAX_ITERATIONS,
+    DEFAULT_PHASE_TIMEOUT_SECONDS,
+    DEFAULT_POLL_SLEEP_SECONDS,
+    DEFAULT_STALL_THRESHOLD,
+    DEFAULT_STATUS_TIMEOUT_SECONDS,
+    DriverOutcome,
+    ESCALATE_ACTIONS,
+    drive as auto_drive,
+)
+from megaplan._core import resolve_plan_dir
+from megaplan.types import CliError
+
+
+VALID_FAILURE_ACTIONS = ("stop_chain", "skip_milestone", "retry_milestone")
+TERMINAL_SKIP_STATES = ("done", "aborted", "failed")
+
+
+@dataclass
+class MilestoneSpec:
+    label: str
+    idea: str
+    branch: str | None = None
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any], index: int) -> "MilestoneSpec":
+        if not isinstance(raw, dict):
+            raise CliError("invalid_spec", f"milestones[{index}] must be a mapping")
+        label = raw.get("label")
+        idea = raw.get("idea")
+        if not isinstance(label, str) or not label.strip():
+            raise CliError("invalid_spec", f"milestones[{index}].label is required")
+        if not isinstance(idea, str) or not idea.strip():
+            raise CliError("invalid_spec", f"milestones[{index}].idea is required")
+        branch = raw.get("branch")
+        if branch is not None and not isinstance(branch, str):
+            raise CliError("invalid_spec", f"milestones[{index}].branch must be a string")
+        return cls(label=label, idea=idea, branch=branch)
+
+
+@dataclass
+class ChainSpec:
+    milestones: list[MilestoneSpec]
+    seed_plan: str | None = None
+    on_failure: str = "stop_chain"
+    on_escalate: str = "stop_chain"
+    # Driver knobs propagated into auto.drive for each plan.
+    stall_threshold: int = DEFAULT_STALL_THRESHOLD
+    max_iterations: int = DEFAULT_MAX_ITERATIONS
+    poll_sleep: float = DEFAULT_POLL_SLEEP_SECONDS
+    phase_timeout: float = DEFAULT_PHASE_TIMEOUT_SECONDS
+    status_timeout: float = DEFAULT_STATUS_TIMEOUT_SECONDS
+    escalate_action: str = "force-proceed"  # passed to auto.drive on_escalate
+    robustness: str = "standard"
+    auto_approve: bool = True
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "ChainSpec":
+        if not isinstance(raw, dict):
+            raise CliError("invalid_spec", "chain spec must be a YAML mapping")
+        milestones_raw = raw.get("milestones") or []
+        if not isinstance(milestones_raw, list):
+            raise CliError("invalid_spec", "`milestones` must be a list")
+        milestones = [MilestoneSpec.from_dict(m, i) for i, m in enumerate(milestones_raw)]
+        seed_raw = raw.get("seed") or {}
+        seed_plan: str | None = None
+        if seed_raw:
+            if not isinstance(seed_raw, dict):
+                raise CliError("invalid_spec", "`seed` must be a mapping")
+            seed_plan = seed_raw.get("plan")
+            if seed_plan is not None and not isinstance(seed_plan, str):
+                raise CliError("invalid_spec", "`seed.plan` must be a string")
+            if isinstance(seed_plan, str) and not seed_plan.strip():
+                seed_plan = None
+
+        def _action(section: str, default: str) -> str:
+            block = raw.get(section) or {}
+            if not isinstance(block, dict):
+                raise CliError("invalid_spec", f"`{section}` must be a mapping")
+            value = block.get("abort", default)
+            if value not in VALID_FAILURE_ACTIONS:
+                raise CliError(
+                    "invalid_spec",
+                    f"{section}.abort must be one of {VALID_FAILURE_ACTIONS}; got {value!r}",
+                )
+            return value
+
+        on_failure = _action("on_failure", "stop_chain")
+        on_escalate = _action("on_escalate", "stop_chain")
+
+        driver_raw = raw.get("driver") or {}
+        if not isinstance(driver_raw, dict):
+            raise CliError("invalid_spec", "`driver` must be a mapping")
+        stall = int(driver_raw.get("stall_threshold", DEFAULT_STALL_THRESHOLD))
+        max_iter = int(driver_raw.get("max_iterations", DEFAULT_MAX_ITERATIONS))
+        poll = float(driver_raw.get("poll_sleep", DEFAULT_POLL_SLEEP_SECONDS))
+        phase_to = float(driver_raw.get("phase_timeout", DEFAULT_PHASE_TIMEOUT_SECONDS))
+        status_to = float(driver_raw.get("status_timeout", DEFAULT_STATUS_TIMEOUT_SECONDS))
+        esc = driver_raw.get("on_escalate", "force-proceed")
+        if esc not in ESCALATE_ACTIONS:
+            raise CliError(
+                "invalid_spec",
+                f"driver.on_escalate must be one of {ESCALATE_ACTIONS}; got {esc!r}",
+            )
+        robustness = driver_raw.get("robustness", "standard")
+        if not isinstance(robustness, str):
+            raise CliError("invalid_spec", "driver.robustness must be a string")
+        auto_approve = bool(driver_raw.get("auto_approve", True))
+
+        return cls(
+            milestones=milestones,
+            seed_plan=seed_plan,
+            on_failure=on_failure,
+            on_escalate=on_escalate,
+            stall_threshold=stall,
+            max_iterations=max_iter,
+            poll_sleep=poll,
+            phase_timeout=phase_to,
+            status_timeout=status_to,
+            escalate_action=esc,
+            robustness=robustness,
+            auto_approve=auto_approve,
+        )
+
+
+@dataclass
+class ChainState:
+    """Persisted progress for a chain run.
+
+    ``current_milestone_index`` is -1 before any milestone starts (seed phase),
+    0 for the first milestone, etc. ``current_plan_name`` is the plan currently
+    being driven. ``last_state`` is the terminal driver status string from the
+    most recently completed plan.
+    """
+
+    current_milestone_index: int = -1
+    current_plan_name: str | None = None
+    last_state: str | None = None
+    completed: list[dict[str, Any]] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "current_milestone_index": self.current_milestone_index,
+            "current_plan_name": self.current_plan_name,
+            "last_state": self.last_state,
+            "completed": list(self.completed),
+        }
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "ChainState":
+        return cls(
+            current_milestone_index=int(raw.get("current_milestone_index", -1)),
+            current_plan_name=raw.get("current_plan_name"),
+            last_state=raw.get("last_state"),
+            completed=list(raw.get("completed") or []),
+        )
+
+
+def _state_path_for(spec_path: Path) -> Path:
+    return spec_path.with_name("chain_state.json")
+
+
+def load_spec(spec_path: Path) -> ChainSpec:
+    if not spec_path.exists():
+        raise CliError("invalid_spec", f"spec file not found: {spec_path}")
+    try:
+        raw = yaml.safe_load(spec_path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise CliError("invalid_spec", f"YAML parse error: {exc}") from exc
+    return ChainSpec.from_dict(raw or {})
+
+
+def load_chain_state(spec_path: Path) -> ChainState:
+    state_path = _state_path_for(spec_path)
+    if not state_path.exists():
+        return ChainState()
+    try:
+        raw = json.loads(state_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise CliError("invalid_chain_state", f"chain_state.json is invalid JSON: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise CliError("invalid_chain_state", "chain_state.json must be an object")
+    return ChainState.from_dict(raw)
+
+
+def save_chain_state(spec_path: Path, state: ChainState) -> None:
+    state_path = _state_path_for(spec_path)
+    tmp = state_path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(state.to_dict(), indent=2) + "\n", encoding="utf-8")
+    tmp.replace(state_path)
+
+
+def validate_paths(spec: ChainSpec, root: Path) -> None:
+    """Check that all idea files exist and the seed plan (if any) is on disk."""
+    for m in spec.milestones:
+        idea_path = Path(m.idea)
+        if not idea_path.exists():
+            raise CliError(
+                "missing_idea_file",
+                f"milestone {m.label!r} idea file not found: {m.idea}",
+            )
+    if spec.seed_plan:
+        try:
+            resolve_plan_dir(root, spec.seed_plan)
+        except CliError as exc:
+            raise CliError(
+                "missing_seed_plan",
+                f"seed plan {spec.seed_plan!r} not found under {root}: {exc.message}",
+            ) from exc
+
+
+# ---------------------------------------------------------------------------
+# Driving
+# ---------------------------------------------------------------------------
+
+
+def _plan_state(root: Path, plan: str, *, timeout: float) -> str:
+    """Read just the `state` field of a plan via `megaplan status`.
+
+    Returns "missing" if the plan is not found. Used to decide whether to skip
+    driving (plan already terminal) vs. run the full auto loop.
+    """
+    try:
+        proc = subprocess.run(
+            ["megaplan", "status", "--plan", plan],
+            cwd=str(root),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return "unknown"
+    if proc.returncode != 0:
+        return "missing"
+    try:
+        return json.loads(proc.stdout).get("state", "unknown")
+    except json.JSONDecodeError:
+        return "unknown"
+
+
+def _refresh_main(root: Path, *, writer) -> None:
+    """Best-effort `git fetch + checkout main + pull`. Never raises; logs only."""
+    for cmd in (
+        ["git", "fetch", "origin", "main"],
+        ["git", "checkout", "main"],
+        ["git", "pull", "--ff-only", "origin", "main"],
+    ):
+        try:
+            proc = subprocess.run(
+                cmd, cwd=str(root), capture_output=True, text=True, check=False, timeout=120
+            )
+            writer(f"[chain] {' '.join(cmd)} -> rc={proc.returncode}\n")
+        except (subprocess.TimeoutExpired, FileNotFoundError) as exc:
+            writer(f"[chain] {' '.join(cmd)} failed: {exc}\n")
+
+
+def _init_plan(
+    root: Path,
+    idea_path: str,
+    *,
+    robustness: str,
+    auto_approve: bool,
+    writer,
+) -> str:
+    """Run `megaplan init` with the idea file's contents, return the plan name."""
+    idea_text = Path(idea_path).read_text(encoding="utf-8")
+    args = ["megaplan", "init", "--project-dir", str(root)]
+    if auto_approve:
+        args.append("--auto-approve")
+    args.extend(["--robustness", robustness, idea_text])
+    writer(f"[chain] initializing plan from {idea_path}\n")
+    proc = subprocess.run(
+        args, cwd=str(root), capture_output=True, text=True, check=False, timeout=300
+    )
+    if proc.returncode != 0:
+        raise CliError(
+            "init_failed",
+            f"megaplan init failed (rc={proc.returncode}): "
+            f"{proc.stderr.strip() or proc.stdout.strip()[-400:]}",
+        )
+    try:
+        payload = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise CliError("init_failed", f"megaplan init produced non-JSON output: {exc}") from exc
+    plan = payload.get("plan")
+    if not isinstance(plan, str) or not plan:
+        raise CliError("init_failed", "megaplan init did not return a plan name")
+    writer(f"[chain] launched plan={plan}\n")
+    return plan
+
+
+def _drive_plan(
+    root: Path,
+    plan: str,
+    spec: ChainSpec,
+    *,
+    writer,
+) -> DriverOutcome:
+    """Run the auto driver for a single plan."""
+    return auto_drive(
+        plan,
+        cwd=root,
+        stall_threshold=spec.stall_threshold,
+        max_iterations=spec.max_iterations,
+        on_escalate=spec.escalate_action,
+        poll_sleep=spec.poll_sleep,
+        phase_timeout=spec.phase_timeout,
+        status_timeout=spec.status_timeout,
+        writer=writer,
+    )
+
+
+def _handle_outcome(
+    outcome: DriverOutcome,
+    *,
+    spec: ChainSpec,
+    writer,
+) -> str:
+    """Decide the next action given a DriverOutcome.
+
+    Returns one of: "advance" (move to next milestone), "stop" (chain halts),
+    "retry" (re-run the same milestone), "skip" (advance without waiting).
+    """
+    status = outcome.status
+    if status == "done":
+        return "advance"
+    if status == "aborted":
+        # auto.drive returns aborted both for user aborts and on-escalate=abort.
+        # Treat according to on_escalate policy so the chain can skip if asked.
+        writer(f"[chain] plan {outcome.plan} ended aborted\n")
+        policy = spec.on_escalate
+    elif status == "escalated":
+        writer(f"[chain] plan {outcome.plan} escalated — applying on_escalate policy\n")
+        policy = spec.on_escalate
+    else:
+        # failed, stalled, cap → treat as failure
+        writer(f"[chain] plan {outcome.plan} ended {status}: {outcome.reason}\n")
+        policy = spec.on_failure
+    if policy == "stop_chain":
+        return "stop"
+    if policy == "skip_milestone":
+        return "skip"
+    if policy == "retry_milestone":
+        return "retry"
+    return "stop"
+
+
+def run_chain(
+    spec_path: Path,
+    root: Path,
+    *,
+    writer=sys.stdout.write,
+) -> dict[str, Any]:
+    """Drive the full chain. Returns a structured JSON-serializable result."""
+    spec = load_spec(spec_path)
+    validate_paths(spec, root)
+    state = load_chain_state(spec_path)
+
+    events: list[dict[str, Any]] = []
+
+    def log(msg: str, **fields: Any) -> None:
+        events.append({"msg": msg, **fields})
+        writer(f"[chain] {msg}\n")
+
+    # ---- Seed phase ----
+    if spec.seed_plan and state.current_milestone_index < 0:
+        seed_state = _plan_state(root, spec.seed_plan, timeout=spec.status_timeout)
+        log(f"seed plan {spec.seed_plan} state={seed_state}")
+        if seed_state not in TERMINAL_SKIP_STATES:
+            state.current_plan_name = spec.seed_plan
+            save_chain_state(spec_path, state)
+            outcome = _drive_plan(root, spec.seed_plan, spec, writer=writer)
+            state.last_state = outcome.status
+            save_chain_state(spec_path, state)
+            decision = _handle_outcome(outcome, spec=spec, writer=writer)
+            if decision == "stop":
+                return _result("stopped", state, events, reason=f"seed plan {outcome.status}")
+            if decision == "retry":
+                # Recursive retry kept simple: re-drive seed once.
+                outcome = _drive_plan(root, spec.seed_plan, spec, writer=writer)
+                state.last_state = outcome.status
+                save_chain_state(spec_path, state)
+                if outcome.status != "done":
+                    return _result("stopped", state, events, reason="seed retry failed")
+            # skip / advance both proceed to milestones
+        state.completed.append(
+            {"label": "seed", "plan": spec.seed_plan, "status": state.last_state or seed_state}
+        )
+        state.current_milestone_index = 0
+        state.current_plan_name = None
+        save_chain_state(spec_path, state)
+
+    elif state.current_milestone_index < 0:
+        state.current_milestone_index = 0
+        save_chain_state(spec_path, state)
+
+    # ---- Milestones ----
+    idx = max(state.current_milestone_index, 0)
+    while idx < len(spec.milestones):
+        milestone = spec.milestones[idx]
+        log(f"milestone {milestone.label} starting")
+
+        # Resume mid-milestone if we already have a plan name recorded.
+        if (
+            state.current_plan_name
+            and state.current_milestone_index == idx
+            and _plan_state(root, state.current_plan_name, timeout=spec.status_timeout)
+            not in ("missing",)
+        ):
+            plan_name = state.current_plan_name
+            log(f"resuming existing plan {plan_name} for {milestone.label}")
+        else:
+            _refresh_main(root, writer=writer)
+            plan_name = _init_plan(
+                root,
+                milestone.idea,
+                robustness=spec.robustness,
+                auto_approve=spec.auto_approve,
+                writer=writer,
+            )
+            state.current_milestone_index = idx
+            state.current_plan_name = plan_name
+            save_chain_state(spec_path, state)
+
+        outcome = _drive_plan(root, plan_name, spec, writer=writer)
+        state.last_state = outcome.status
+        save_chain_state(spec_path, state)
+        decision = _handle_outcome(outcome, spec=spec, writer=writer)
+
+        if decision == "stop":
+            return _result(
+                "stopped",
+                state,
+                events,
+                reason=f"milestone {milestone.label} ended {outcome.status}",
+            )
+        if decision == "retry":
+            log(f"retrying milestone {milestone.label}")
+            state.current_plan_name = None  # force re-init next loop
+            save_chain_state(spec_path, state)
+            continue
+        # advance or skip
+        state.completed.append(
+            {"label": milestone.label, "plan": plan_name, "status": outcome.status}
+        )
+        idx += 1
+        state.current_milestone_index = idx
+        state.current_plan_name = None
+        save_chain_state(spec_path, state)
+
+    log("all milestones complete")
+    return _result("done", state, events)
+
+
+def _result(
+    status: str, state: ChainState, events: list[dict[str, Any]], *, reason: str = ""
+) -> dict[str, Any]:
+    return {
+        "status": status,
+        "reason": reason,
+        "chain_state": state.to_dict(),
+        "events": events,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI plumbing
+# ---------------------------------------------------------------------------
+
+
+def build_chain_parser(subparsers: Any) -> None:
+    chain_parser = subparsers.add_parser(
+        "chain",
+        help="Drive a pipeline of milestone plans described by a YAML spec",
+    )
+    chain_sub = chain_parser.add_subparsers(dest="chain_action")
+    # No action == run. `status` is the explicit subcommand.
+    chain_parser.add_argument(
+        "--spec",
+        required=False,
+        help="Path to the chain spec YAML (required at top-level or on subcommands)",
+    )
+
+    status_parser = chain_sub.add_parser(
+        "status", help="Show persisted chain progress without driving"
+    )
+    status_parser.add_argument("--spec", required=True, help="Path to the chain spec YAML")
+
+
+def run_chain_cli(root: Path, args: argparse.Namespace) -> int:
+    action = getattr(args, "chain_action", None)
+    spec_arg = getattr(args, "spec", None)
+    if not spec_arg:
+        sys.stderr.write("megaplan chain: --spec is required\n")
+        return 64
+    spec_path = Path(spec_arg).expanduser().resolve()
+
+    if action == "status":
+        try:
+            spec = load_spec(spec_path)
+        except CliError as exc:
+            return _emit_error(exc)
+        chain_state = load_chain_state(spec_path)
+        payload = {
+            "success": True,
+            "spec": str(spec_path),
+            "milestone_count": len(spec.milestones),
+            "seed_plan": spec.seed_plan,
+            "chain_state": chain_state.to_dict(),
+        }
+        sys.stdout.write(json.dumps(payload, indent=2) + "\n")
+        return 0
+
+    # Default action: run.
+    try:
+        result = run_chain(spec_path, root)
+    except CliError as exc:
+        return _emit_error(exc)
+    sys.stdout.write(json.dumps(result, indent=2) + "\n")
+    if result["status"] == "done":
+        return 0
+    return 1
+
+
+def _emit_error(error: CliError) -> int:
+    payload = {"success": False, "error": error.code, "message": error.message}
+    sys.stdout.write(json.dumps(payload, indent=2) + "\n")
+    return error.exit_code or 1

--- a/megaplan/cli.py
+++ b/megaplan/cli.py
@@ -957,6 +957,9 @@ def build_parser() -> argparse.ArgumentParser:
     from megaplan.auto import build_auto_parser
     build_auto_parser(subparsers)
 
+    from megaplan.chain import build_chain_parser
+    build_chain_parser(subparsers)
+
     return parser
 
 
@@ -1054,6 +1057,13 @@ def main(argv: list[str] | None = None) -> int:
         from megaplan.auto import run_auto
         try:
             return run_auto(root, args)
+        except CliError as error:
+            return error_response(error, root=root)
+
+    if args.command == "chain":
+        from megaplan.chain import run_chain_cli
+        try:
+            return run_chain_cli(root, args)
         except CliError as error:
             return error_response(error, root=root)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "megaplan-harness"
-version = "0.14.6"
+version = "0.16.0"
 description = "AI agent harness for coordinating Claude and GPT to make and execute extremely robust plans"
 requires-python = ">=3.11"
 license = { text = "OSNL-0.2" }
@@ -17,6 +17,9 @@ classifiers = [
     "Environment :: Console",
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Quality Assurance",
+]
+dependencies = [
+    "PyYAML>=6.0",
 ]
 
 [project.scripts]

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -1,0 +1,285 @@
+"""Tests for megaplan.chain — the chain driver subcommand."""
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from megaplan.auto import DriverOutcome
+from megaplan.chain import (
+    ChainSpec,
+    ChainState,
+    MilestoneSpec,
+    load_chain_state,
+    load_spec,
+    run_chain,
+    save_chain_state,
+)
+from megaplan.types import CliError
+
+
+def _write_spec(tmp_path: Path, spec_dict: dict, *, name: str = "chain.yaml") -> Path:
+    spec_path = tmp_path / name
+    spec_path.write_text(yaml.safe_dump(spec_dict), encoding="utf-8")
+    return spec_path
+
+
+def _touch_idea(tmp_path: Path, name: str, body: str = "an idea") -> Path:
+    ideas_dir = tmp_path / "ideas"
+    ideas_dir.mkdir(exist_ok=True)
+    path = ideas_dir / name
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def _fake_outcome(plan: str, status: str = "done") -> DriverOutcome:
+    return DriverOutcome(
+        status=status, plan=plan, final_state=status, iterations=1, reason=""
+    )
+
+
+# ---------------------------------------------------------------------------
+# Spec parsing
+# ---------------------------------------------------------------------------
+
+
+def test_load_spec_parses_milestones_and_seed(tmp_path: Path) -> None:
+    idea = _touch_idea(tmp_path, "m1.txt")
+    spec_path = _write_spec(
+        tmp_path,
+        {
+            "seed": {"plan": "seed-plan-20260415"},
+            "milestones": [
+                {"label": "m1", "idea": str(idea), "branch": "mp/m1"},
+            ],
+            "on_failure": {"abort": "stop_chain"},
+            "on_escalate": {"abort": "skip_milestone"},
+        },
+    )
+    spec = load_spec(spec_path)
+    assert spec.seed_plan == "seed-plan-20260415"
+    assert len(spec.milestones) == 1
+    assert spec.milestones[0] == MilestoneSpec(label="m1", idea=str(idea), branch="mp/m1")
+    assert spec.on_failure == "stop_chain"
+    assert spec.on_escalate == "skip_milestone"
+
+
+def test_load_spec_rejects_missing_label(tmp_path: Path) -> None:
+    spec_path = _write_spec(tmp_path, {"milestones": [{"idea": "/tmp/x.txt"}]})
+    with pytest.raises(CliError) as excinfo:
+        load_spec(spec_path)
+    assert excinfo.value.code == "invalid_spec"
+
+
+def test_load_spec_rejects_bad_failure_action(tmp_path: Path) -> None:
+    spec_path = _write_spec(
+        tmp_path,
+        {"milestones": [], "on_failure": {"abort": "nonsense"}},
+    )
+    with pytest.raises(CliError) as excinfo:
+        load_spec(spec_path)
+    assert "on_failure.abort" in excinfo.value.message
+
+
+# ---------------------------------------------------------------------------
+# Path validation
+# ---------------------------------------------------------------------------
+
+
+def test_run_chain_errors_when_idea_missing(tmp_path: Path) -> None:
+    spec_path = _write_spec(
+        tmp_path,
+        {"milestones": [{"label": "m1", "idea": str(tmp_path / "missing.txt")}]},
+    )
+    with pytest.raises(CliError) as excinfo:
+        run_chain(spec_path, tmp_path, writer=lambda _msg: None)
+    assert excinfo.value.code == "missing_idea_file"
+
+
+def test_run_chain_errors_when_seed_plan_missing(tmp_path: Path) -> None:
+    idea = _touch_idea(tmp_path, "m1.txt")
+    spec_path = _write_spec(
+        tmp_path,
+        {
+            "seed": {"plan": "no-such-plan"},
+            "milestones": [{"label": "m1", "idea": str(idea)}],
+        },
+    )
+    # Set up a megaplan root without the seed plan.
+    (tmp_path / ".megaplan" / "plans").mkdir(parents=True)
+    with pytest.raises(CliError) as excinfo:
+        run_chain(spec_path, tmp_path, writer=lambda _msg: None)
+    assert excinfo.value.code == "missing_seed_plan"
+
+
+# ---------------------------------------------------------------------------
+# Chain state persistence
+# ---------------------------------------------------------------------------
+
+
+def test_save_and_load_chain_state_roundtrip(tmp_path: Path) -> None:
+    spec_path = tmp_path / "chain.yaml"
+    spec_path.write_text("milestones: []\n", encoding="utf-8")
+    state = ChainState(
+        current_milestone_index=2,
+        current_plan_name="foo-20260415",
+        last_state="done",
+        completed=[{"label": "m1", "plan": "m1-x", "status": "done"}],
+    )
+    save_chain_state(spec_path, state)
+    loaded = load_chain_state(spec_path)
+    assert loaded.current_milestone_index == 2
+    assert loaded.current_plan_name == "foo-20260415"
+    assert loaded.last_state == "done"
+    assert loaded.completed == [{"label": "m1", "plan": "m1-x", "status": "done"}]
+
+
+# ---------------------------------------------------------------------------
+# Driver orchestration (auto.drive is mocked)
+# ---------------------------------------------------------------------------
+
+
+def _setup_two_milestones(tmp_path: Path) -> Path:
+    i1 = _touch_idea(tmp_path, "m1.txt", "idea one")
+    i2 = _touch_idea(tmp_path, "m1a.txt", "idea two")
+    return _write_spec(
+        tmp_path,
+        {
+            "milestones": [
+                {"label": "m1", "idea": str(i1)},
+                {"label": "m1a", "idea": str(i2)},
+            ]
+        },
+    )
+
+
+def test_run_chain_executes_milestones_in_order(tmp_path: Path) -> None:
+    spec_path = _setup_two_milestones(tmp_path)
+    (tmp_path / ".megaplan" / "plans").mkdir(parents=True)
+
+    init_calls: list[str] = []
+    drive_calls: list[str] = []
+
+    def fake_init(root, idea_path, *, robustness, auto_approve, writer):
+        plan = f"plan-for-{Path(idea_path).stem}"
+        init_calls.append(idea_path)
+        return plan
+
+    def fake_drive(plan, **_kwargs):
+        drive_calls.append(plan)
+        return _fake_outcome(plan, "done")
+
+    with patch("megaplan.chain._init_plan", side_effect=fake_init), \
+         patch("megaplan.chain.auto_drive", side_effect=fake_drive), \
+         patch("megaplan.chain._refresh_main", lambda *a, **k: None):
+        result = run_chain(spec_path, tmp_path, writer=lambda _m: None)
+
+    assert result["status"] == "done"
+    assert len(init_calls) == 2
+    assert drive_calls == ["plan-for-m1", "plan-for-m1a"]
+    saved = load_chain_state(spec_path)
+    assert saved.current_milestone_index == 2
+    assert [c["label"] for c in saved.completed] == ["m1", "m1a"]
+
+
+def test_run_chain_stops_on_failure(tmp_path: Path) -> None:
+    spec_path = _setup_two_milestones(tmp_path)
+    (tmp_path / ".megaplan" / "plans").mkdir(parents=True)
+
+    drive_calls: list[str] = []
+
+    def fake_drive(plan, **_kwargs):
+        drive_calls.append(plan)
+        return _fake_outcome(plan, "failed")
+
+    with patch("megaplan.chain._init_plan", side_effect=lambda root, idea_path, **_k: f"plan-{Path(idea_path).stem}"), \
+         patch("megaplan.chain.auto_drive", side_effect=fake_drive), \
+         patch("megaplan.chain._refresh_main", lambda *a, **k: None):
+        result = run_chain(spec_path, tmp_path, writer=lambda _m: None)
+
+    assert result["status"] == "stopped"
+    assert len(drive_calls) == 1  # did not proceed to second milestone
+    saved = load_chain_state(spec_path)
+    assert saved.last_state == "failed"
+
+
+def test_run_chain_resumes_from_chain_state(tmp_path: Path) -> None:
+    spec_path = _setup_two_milestones(tmp_path)
+    (tmp_path / ".megaplan" / "plans").mkdir(parents=True)
+
+    # Pretend milestone m1 already completed.
+    pre = ChainState(
+        current_milestone_index=1,
+        current_plan_name=None,
+        last_state="done",
+        completed=[{"label": "m1", "plan": "plan-m1", "status": "done"}],
+    )
+    save_chain_state(spec_path, pre)
+
+    init_calls: list[str] = []
+
+    def fake_init(root, idea_path, *, robustness, auto_approve, writer):
+        init_calls.append(idea_path)
+        return f"plan-{Path(idea_path).stem}"
+
+    def fake_drive(plan, **_kwargs):
+        return _fake_outcome(plan, "done")
+
+    with patch("megaplan.chain._init_plan", side_effect=fake_init), \
+         patch("megaplan.chain.auto_drive", side_effect=fake_drive), \
+         patch("megaplan.chain._refresh_main", lambda *a, **k: None):
+        result = run_chain(spec_path, tmp_path, writer=lambda _m: None)
+
+    # Only the second idea (m1a) should have been init'd; m1 is skipped.
+    assert result["status"] == "done"
+    assert len(init_calls) == 1
+    assert "m1a" in init_calls[0]
+
+
+def test_run_chain_with_seed_drives_seed_first(tmp_path: Path) -> None:
+    """When seed plan isn't terminal, drive it before milestones."""
+    i1 = _touch_idea(tmp_path, "m1.txt")
+    seed_name = "seed-plan-20260415"
+    # Fake-create the seed plan dir so resolve_plan_dir accepts it.
+    seed_dir = tmp_path / ".megaplan" / "plans" / seed_name
+    seed_dir.mkdir(parents=True)
+    (seed_dir / "state.json").write_text(
+        json.dumps({"name": seed_name, "current_state": "planned", "iteration": 1}),
+        encoding="utf-8",
+    )
+    spec_path = _write_spec(
+        tmp_path,
+        {
+            "seed": {"plan": seed_name},
+            "milestones": [{"label": "m1", "idea": str(i1)}],
+        },
+    )
+
+    plan_state_calls: list[str] = []
+    drive_calls: list[str] = []
+
+    def fake_plan_state(root, plan, *, timeout):
+        plan_state_calls.append(plan)
+        # Seed is mid-flight; milestone plans always "missing" until init.
+        if plan == seed_name:
+            return "planned"
+        return "missing"
+
+    def fake_drive(plan, **_kwargs):
+        drive_calls.append(plan)
+        return _fake_outcome(plan, "done")
+
+    with patch("megaplan.chain._plan_state", side_effect=fake_plan_state), \
+         patch("megaplan.chain._init_plan", side_effect=lambda root, idea_path, **_k: f"plan-{Path(idea_path).stem}"), \
+         patch("megaplan.chain.auto_drive", side_effect=fake_drive), \
+         patch("megaplan.chain._refresh_main", lambda *a, **k: None):
+        result = run_chain(spec_path, tmp_path, writer=lambda _m: None)
+
+    assert result["status"] == "done"
+    # Seed must be driven first, then the milestone plan.
+    assert drive_calls[0] == seed_name
+    assert drive_calls[1].startswith("plan-m1")

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -283,3 +283,59 @@ def test_run_chain_with_seed_drives_seed_first(tmp_path: Path) -> None:
     # Seed must be driven first, then the milestone plan.
     assert drive_calls[0] == seed_name
     assert drive_calls[1].startswith("plan-m1")
+
+
+# ---------------------------------------------------------------------------
+# --no-git-refresh flag
+# ---------------------------------------------------------------------------
+
+
+def test_no_git_refresh_suppresses_subprocess_calls(tmp_path: Path) -> None:
+    """With no_git_refresh=True, _refresh_main must not invoke any subprocess."""
+    from megaplan.chain import _refresh_main
+
+    msgs: list[str] = []
+    with patch("megaplan.chain.subprocess.run") as mock_run:
+        _refresh_main(tmp_path, writer=msgs.append, no_git_refresh=True)
+    assert mock_run.call_count == 0
+    assert any("skipping git refresh" in m for m in msgs)
+
+
+def test_refresh_main_default_invokes_git(tmp_path: Path) -> None:
+    """Default behavior (no_git_refresh=False) still issues the git commands."""
+    from megaplan.chain import _refresh_main
+
+    class _Proc:
+        returncode = 0
+
+    with patch("megaplan.chain.subprocess.run", return_value=_Proc()) as mock_run:
+        _refresh_main(tmp_path, writer=lambda _m: None)
+    # fetch + checkout + pull
+    assert mock_run.call_count == 3
+    cmds = [call.args[0] for call in mock_run.call_args_list]
+    assert cmds[0][:2] == ["git", "fetch"]
+    assert cmds[1] == ["git", "checkout", "main"]
+    assert cmds[2][:2] == ["git", "pull"]
+
+
+def test_run_chain_no_git_refresh_skips_refresh(tmp_path: Path) -> None:
+    """End-to-end: run_chain(..., no_git_refresh=True) propagates the flag."""
+    spec_path = _setup_two_milestones(tmp_path)
+    (tmp_path / ".megaplan" / "plans").mkdir(parents=True)
+
+    refresh_calls: list[bool] = []
+
+    def fake_refresh(root, *, writer, no_git_refresh=False):
+        refresh_calls.append(no_git_refresh)
+
+    def fake_drive(plan, **_kwargs):
+        return _fake_outcome(plan, "done")
+
+    with patch("megaplan.chain._init_plan", side_effect=lambda root, idea_path, **_k: f"plan-{Path(idea_path).stem}"), \
+         patch("megaplan.chain.auto_drive", side_effect=fake_drive), \
+         patch("megaplan.chain._refresh_main", side_effect=fake_refresh):
+        result = run_chain(spec_path, tmp_path, writer=lambda _m: None, no_git_refresh=True)
+
+    assert result["status"] == "done"
+    assert len(refresh_calls) == 2
+    assert all(call is True for call in refresh_calls)


### PR DESCRIPTION
## Summary

Replaces the ad-hoc bash chain orchestrator (`chain.sh`) with a first-class `megaplan chain` subcommand. Plan-state decisions (next phase, valid transitions, stall detection, escalation) now live in megaplan instead of fragile shell polling.

## What changed

- **`megaplan chain --spec PATH`**: drives a YAML-described pipeline of milestone plans.
- **YAML spec**: seed plan, ordered milestones (label + idea path + optional branch), `on_failure` / `on_escalate` policies (`stop_chain`, `skip_milestone`, `retry_milestone`).
- **Atomic `chain_state.json`**: persisted next to the spec — `current_milestone_index`, `current_plan_name`, `last_state`, `completed[]`. Resumable across restarts.
- **State-aware seed handling**: a non-terminal seed plan is driven through `megaplan.auto.drive` like any milestone (closes the gap where `chain.sh` had no driver for the seed).
- **Up-front validation**: every idea file must exist; seed plan (if set) must resolve under the project root. Structured errors: `invalid_spec`, `missing_idea_file`, `missing_seed_plan`.
- **`megaplan chain status --spec PATH`**: inspect persisted progress without driving.
- **PyYAML** added as a runtime dependency.

## Review-driven addition: `--no-git-refresh`

Per review concern: `_refresh_main` previously did an unconditional `git fetch + git checkout main + git pull` before each milestone. On a developer checkout that would silently switch off whatever branch the operator was on. New `--no-git-refresh` CLI flag short-circuits the refresh:

- Default: refresh enabled (preserves existing CI/orchestrator behavior).
- Disable on developer checkouts to keep chain from stomping the current branch.
- When disabled, `_refresh_main` logs a skip line and issues zero subprocess calls.

## Tests

13 chain tests pass:
- spec parsing + rejection of invalid spec / failure action
- idea-file + seed-plan path validation
- chain-state persistence roundtrip
- milestone execution in order (auto.drive mocked)
- stop_chain on failure
- resume from existing chain_state.json
- seed-first drive when seed is non-terminal
- `--no-git-refresh` suppresses subprocess calls
- default `_refresh_main` still issues git fetch/checkout/pull
- end-to-end `run_chain(..., no_git_refresh=True)` plumbing

Full suite: 552 pass, 12 pre-existing failures (parallel_critique / parallel_review / schemas — unrelated to this branch; the same failures exist on `main`).

## Test plan

- [ ] CI green (chain tests + full suite minus pre-existing failures)
- [ ] Smoke run of `megaplan chain --spec example.yaml --no-git-refresh` from a feature branch confirms the operator's branch is preserved
- [ ] Smoke run with the flag absent confirms backward-compat behavior (still does the git checkout main + pull)

🤖 Generated with [Claude Code](https://claude.com/claude-code)