### PR TITLE
fix(v0.14.5): use CWD for subprocess worker --add-dir / -C (worktree isolation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.14.5 — 2026-04-15
+
+### Git-worktree isolation for subprocess workers
+
+Fix: when megaplan invoked its `claude` / `codex` subprocess workers, it was passing the plan's stored `project_dir` as the `--add-dir` / `-C` target. Runs started from a git worktree would silently write source-code changes back into the main checkout, colliding with other concurrent runs.
+
+- **CWD drives `--add-dir`**: `run_claude_step` now passes the CWD (or an explicit override) as `--add-dir` and subprocess cwd, instead of the plan's stored `project_dir`.
+- **CWD drives Codex `-C`**: `run_codex_step` now passes the CWD as Codex's `-C` and as the `sandbox_workspace_write.writable_roots` entry. The `--add-dir` for Codex still points at the plan's artifacts directory (`plan_dir`), which is unchanged.
+- **Plan state still lives at `project_dir`**: `.megaplan/plans/<name>/` artifacts remain co-located with the plan as before. Only the source-code working tree the worker sees has changed.
+- **Divergence warning**: emits a one-time warning at startup when CWD differs from the plan's stored `project_dir`, so operators notice when a plan created in checkout A is being executed from worktree B.
+- **`--work-dir PATH` flag**: every worker-invoking subcommand (`plan`, `prep`, `critique`, `revise`, `gate`, `finalize`, `execute`, `review`, `auto`, `loop-init`, `loop-run`) accepts `--work-dir` to explicitly override the detected CWD.
+
 ## v0.14.0 — 2026-04-15
 
 ### Strict gate flag resolution

--- a/megaplan/auto.py
+++ b/megaplan/auto.py
@@ -359,6 +359,14 @@ def build_auto_parser(subparsers: Any) -> None:
         ),
     )
     auto_parser.add_argument(
+        "--work-dir",
+        default=None,
+        help=(
+            "Override the source-code working directory for subprocess workers "
+            "(--add-dir / -C). Defaults to the current working directory."
+        ),
+    )
+    auto_parser.add_argument(
         "--status-timeout",
         type=float,
         default=DEFAULT_STATUS_TIMEOUT_SECONDS,

--- a/megaplan/cli.py
+++ b/megaplan/cli.py
@@ -846,6 +846,10 @@ def build_parser() -> argparse.ArgumentParser:
         step_parser.add_argument("--fresh", action="store_true")
         step_parser.add_argument("--persist", action="store_true")
         step_parser.add_argument("--ephemeral", action="store_true")
+        step_parser.add_argument("--work-dir", default=None,
+                                 help="Override the source-code working directory passed to subprocess workers "
+                                      "(--add-dir / -C). Defaults to the current working directory. Use this to "
+                                      "force a specific path (e.g. a git worktree) regardless of where the plan was created.")
         if name == "execute":
             step_parser.add_argument("--confirm-destructive", action="store_true")
             step_parser.add_argument("--user-approved", action="store_true")
@@ -918,6 +922,8 @@ def build_parser() -> argparse.ArgumentParser:
     loop_init_parser.add_argument("--fresh", action="store_true")
     loop_init_parser.add_argument("--persist", action="store_true")
     loop_init_parser.add_argument("--ephemeral", action="store_true")
+    loop_init_parser.add_argument("--work-dir", default=None,
+                                  help="Override the source-code working directory for subprocess workers (default: CWD)")
     loop_init_parser.add_argument("goal", nargs="?")
 
     loop_run_parser = subparsers.add_parser("loop-run", help="Run an existing MegaLoop workflow")
@@ -933,6 +939,8 @@ def build_parser() -> argparse.ArgumentParser:
     loop_run_parser.add_argument("--fresh", action="store_true")
     loop_run_parser.add_argument("--persist", action="store_true")
     loop_run_parser.add_argument("--ephemeral", action="store_true")
+    loop_run_parser.add_argument("--work-dir", default=None,
+                                 help="Override the source-code working directory for subprocess workers (default: CWD)")
 
     loop_status_parser = subparsers.add_parser("loop-status", help="Show MegaLoop state")
     loop_status_parser.add_argument("name")
@@ -1027,6 +1035,14 @@ def main(argv: list[str] | None = None) -> int:
             return render_response(handle_config(args))
     except CliError as error:
         return error_response(error)
+
+    # Capture the working directory for subprocess workers (--add-dir / -C).
+    # This preserves git-worktree isolation: workers edit source code under
+    # the CWD (or an explicit --work-dir override), not the plan's stored
+    # project_dir (which may be a sibling checkout).
+    from megaplan.workers import set_work_dir_override
+    work_dir_override = getattr(args, "work_dir", None)
+    set_work_dir_override(work_dir_override if work_dir_override else Path.cwd())
 
     root = _find_megaplan_root(Path.cwd())
     ensure_runtime_layout(root)

--- a/megaplan/workers.py
+++ b/megaplan/workers.py
@@ -91,6 +91,72 @@ class WorkerResult:
     total_tokens: int = 0
 
 
+# ---------------------------------------------------------------------------
+# Worker working directory resolution (git-worktree isolation)
+#
+# When megaplan is invoked from a git worktree, the plan's stored project_dir
+# may point at a *different* checkout (usually the main repo). To avoid
+# subprocess workers writing source code into the wrong working tree, resolve
+# the "working directory" at CLI entry (CWD, or an explicit --work-dir
+# override) and pass *that* through to the worker's --add-dir / -C flags.
+#
+# Plan state files (.megaplan/plans/...) still live under project_dir; only
+# the source-code working tree tracked by the subprocess changes.
+# ---------------------------------------------------------------------------
+
+_WORK_DIR_OVERRIDE: Path | None = None
+_WORK_DIR_WARNED: bool = False
+
+
+def set_work_dir_override(path: Path | str | None) -> None:
+    """Set an explicit working directory for subprocess workers.
+
+    Typically called once from the CLI entry point with either an explicit
+    --work-dir value or ``Path.cwd()``. Pass ``None`` to clear the override
+    (primarily useful in tests).
+    """
+    global _WORK_DIR_OVERRIDE, _WORK_DIR_WARNED
+    _WORK_DIR_OVERRIDE = Path(path) if path is not None else None
+    _WORK_DIR_WARNED = False
+
+
+def resolve_work_dir(state: PlanState) -> Path:
+    """Return the source-code working directory for worker subprocesses.
+
+    Precedence:
+    1. Explicit override set via :func:`set_work_dir_override`.
+    2. Current working directory (``Path.cwd()``).
+
+    If the resolved path differs from the plan's stored ``project_dir``, a
+    one-time warning is printed so operators notice worktree divergence.
+    """
+    global _WORK_DIR_WARNED
+    if _WORK_DIR_OVERRIDE is not None:
+        work_dir = _WORK_DIR_OVERRIDE
+    else:
+        work_dir = Path.cwd()
+    try:
+        project_dir = Path(state["config"]["project_dir"]).resolve()
+    except Exception:
+        project_dir = None
+    try:
+        resolved_work = work_dir.resolve()
+    except Exception:
+        resolved_work = work_dir
+    if (
+        not _WORK_DIR_WARNED
+        and project_dir is not None
+        and resolved_work != project_dir
+    ):
+        print(
+            f"[megaplan] Plan was created in {project_dir}; current run is in "
+            f"{resolved_work}. Using current CWD for subprocess --add-dir.",
+            flush=True,
+        )
+        _WORK_DIR_WARNED = True
+    return work_dir
+
+
 def run_command(
     command: list[str],
     *,
@@ -1098,12 +1164,13 @@ def run_claude_step(
     if os.getenv(MOCK_ENV_VAR) == "1":
         return mock_worker_output(step, state, plan_dir, prompt_override=prompt_override, prompt_kwargs=prompt_kwargs)
     project_dir = Path(state["config"]["project_dir"])
+    work_dir = resolve_work_dir(state)
     schema_name = STEP_SCHEMA_FILENAMES[step]
     schema_text = json.dumps(read_json(schemas_root(root) / schema_name))
     session_key = session_key_for(step, "claude")
     session = state["sessions"].get(session_key, {})
     session_id = session.get("id")
-    command = ["claude", "-p", "--output-format", "json", "--json-schema", schema_text, "--add-dir", str(project_dir)]
+    command = ["claude", "-p", "--output-format", "json", "--json-schema", schema_text, "--add-dir", str(work_dir)]
     if step in _EXECUTE_STEPS:
         command.extend(["--permission-mode", "bypassPermissions"])
     if session_id and not fresh:
@@ -1119,7 +1186,7 @@ def run_claude_step(
         **(prompt_kwargs or {}),
     )
     try:
-        result = run_command(command, cwd=project_dir, stdin_text=prompt)
+        result = run_command(command, cwd=work_dir, stdin_text=prompt)
     except CliError as error:
         if error.code == "worker_timeout":
             error.extra["session_id"] = session_id
@@ -1154,6 +1221,7 @@ def run_codex_step(
     if os.getenv(MOCK_ENV_VAR) == "1":
         return mock_worker_output(step, state, plan_dir, prompt_override=prompt_override, prompt_kwargs=prompt_kwargs)
     project_dir = Path(state["config"]["project_dir"])
+    work_dir = resolve_work_dir(state)
     schema_file = schemas_root(root) / STEP_SCHEMA_FILENAMES[step]
     session_key = session_key_for(step, "codex")
     session = state["sessions"].get(session_key, {})
@@ -1189,7 +1257,7 @@ def run_codex_step(
             "exec",
             "--skip-git-repo-check",
             "-C",
-            str(project_dir),
+            str(work_dir),
             "--add-dir",
             str(plan_dir),
         ]
@@ -1202,7 +1270,7 @@ def run_codex_step(
         else:
             command.extend([
                 "-c",
-                f"sandbox_workspace_write.writable_roots=[\"{project_dir}\"]",
+                f"sandbox_workspace_write.writable_roots=[\"{work_dir}\"]",
             ])
         command.extend([
             "-o",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "megaplan-harness"
-version = "0.14.4"
+version = "0.14.5"
 description = "AI agent harness for coordinating Claude and GPT to make and execute extremely robust plans"
 requires-python = ">=3.11"
 license = { text = "OSNL-0.2" }

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -938,10 +938,14 @@ def test_run_codex_step_uses_full_auto_for_critique_template_writes(tmp_path: Pa
 
 def test_run_codex_step_grants_plan_dir_when_project_dir_differs(tmp_path: Path) -> None:
     from megaplan._core import ensure_runtime_layout
-    from megaplan.workers import CommandResult, run_codex_step
+    from megaplan.workers import CommandResult, run_codex_step, set_work_dir_override
 
     ensure_runtime_layout(tmp_path)
     plan_dir, state = _mock_state(tmp_path)
+    # Pin the work dir to the plan's project_dir so this test continues to
+    # exercise the "grant plan_dir via --add-dir" path without also triggering
+    # the worktree warning.
+    set_work_dir_override(Path(state["config"]["project_dir"]))
     plan_payload = {
         "plan": "# Plan\nDo it.",
         "questions": [],
@@ -966,8 +970,11 @@ def test_run_codex_step_grants_plan_dir_when_project_dir_differs(tmp_path: Path)
             duration_ms=1,
         )
 
-    with patch("megaplan.workers.run_command", side_effect=fake_run_command):
-        result = run_codex_step("plan", state, plan_dir, root=tmp_path, persistent=False, fresh=True)
+    try:
+        with patch("megaplan.workers.run_command", side_effect=fake_run_command):
+            result = run_codex_step("plan", state, plan_dir, root=tmp_path, persistent=False, fresh=True)
+    finally:
+        set_work_dir_override(None)
 
     assert result.payload == plan_payload
 
@@ -1738,3 +1745,166 @@ def test_run_codex_step_sanitizes_codex_child_env(tmp_path: Path, monkeypatch: p
         result = run_codex_step("plan", state, plan_dir, root=tmp_path, persistent=False, fresh=True)
 
     assert result.payload == plan_payload
+
+
+# ---------------------------------------------------------------------------
+# Worktree isolation: subprocess workers should receive the CWD (or an
+# explicit --work-dir override) for --add-dir / -C, not the plan's stored
+# project_dir. This preserves git-worktree isolation across parallel runs.
+# ---------------------------------------------------------------------------
+
+
+def test_run_claude_step_uses_cwd_for_add_dir_when_worktree_differs(
+    tmp_path: Path,
+) -> None:
+    from megaplan._core import ensure_runtime_layout
+    from megaplan.workers import (
+        CommandResult,
+        run_claude_step,
+        set_work_dir_override,
+    )
+
+    ensure_runtime_layout(tmp_path)
+    plan_dir, state = _mock_state(tmp_path)
+    # Simulate a worktree: project_dir is /tmp/.../project but the current
+    # "checkout" is /tmp/.../worktree.
+    worktree_dir = tmp_path / "worktree"
+    worktree_dir.mkdir()
+    set_work_dir_override(worktree_dir)
+
+    plan_payload = {
+        "plan": "# Plan\nDo it.",
+        "questions": [],
+        "success_criteria": [{"criterion": "criterion", "priority": "must"}],
+        "assumptions": [],
+    }
+
+    captured: dict[str, Any] = {}
+
+    def fake_run_command(command: list[str], **kwargs: object) -> CommandResult:
+        captured["command"] = command
+        captured["cwd"] = kwargs.get("cwd")
+        return CommandResult(
+            command=command,
+            cwd=tmp_path,
+            returncode=0,
+            stdout=json.dumps({"result": json.dumps(plan_payload), "total_cost_usd": 0.0}),
+            stderr="",
+            duration_ms=1,
+        )
+
+    try:
+        with patch("megaplan.workers.run_command", side_effect=fake_run_command):
+            run_claude_step("plan", state, plan_dir, root=tmp_path, fresh=True)
+    finally:
+        set_work_dir_override(None)
+
+    command = captured["command"]
+    add_dir_idx = command.index("--add-dir") + 1
+    assert Path(command[add_dir_idx]) == worktree_dir
+    assert Path(command[add_dir_idx]) != Path(state["config"]["project_dir"])
+    assert Path(captured["cwd"]) == worktree_dir
+
+
+def test_run_claude_step_honors_explicit_work_dir_override(
+    tmp_path: Path,
+) -> None:
+    from megaplan._core import ensure_runtime_layout
+    from megaplan.workers import (
+        CommandResult,
+        run_claude_step,
+        set_work_dir_override,
+    )
+
+    ensure_runtime_layout(tmp_path)
+    plan_dir, state = _mock_state(tmp_path)
+    # project_dir lives at tmp_path/project; --work-dir explicitly forces a
+    # different path (simulating the operator passing --work-dir on the CLI).
+    forced_dir = tmp_path / "forced"
+    forced_dir.mkdir()
+    set_work_dir_override(forced_dir)
+
+    plan_payload = {
+        "plan": "# Plan\nDo it.",
+        "questions": [],
+        "success_criteria": [{"criterion": "criterion", "priority": "must"}],
+        "assumptions": [],
+    }
+
+    captured: dict[str, Any] = {}
+
+    def fake_run_command(command: list[str], **kwargs: object) -> CommandResult:
+        captured["command"] = command
+        return CommandResult(
+            command=command,
+            cwd=tmp_path,
+            returncode=0,
+            stdout=json.dumps({"result": json.dumps(plan_payload), "total_cost_usd": 0.0}),
+            stderr="",
+            duration_ms=1,
+        )
+
+    try:
+        with patch("megaplan.workers.run_command", side_effect=fake_run_command):
+            run_claude_step("plan", state, plan_dir, root=tmp_path, fresh=True)
+    finally:
+        set_work_dir_override(None)
+
+    command = captured["command"]
+    add_dir_idx = command.index("--add-dir") + 1
+    assert Path(command[add_dir_idx]) == forced_dir
+
+
+def test_run_codex_step_uses_work_dir_for_dash_c_not_project_dir(
+    tmp_path: Path,
+) -> None:
+    from megaplan._core import ensure_runtime_layout
+    from megaplan.workers import (
+        CommandResult,
+        run_codex_step,
+        set_work_dir_override,
+    )
+
+    ensure_runtime_layout(tmp_path)
+    plan_dir, state = _mock_state(tmp_path)
+    worktree_dir = tmp_path / "worktree"
+    worktree_dir.mkdir()
+    set_work_dir_override(worktree_dir)
+
+    plan_payload = {
+        "plan": "# Plan\nDo it.",
+        "questions": [],
+        "success_criteria": [{"criterion": "criterion", "priority": "must"}],
+        "assumptions": [],
+    }
+
+    captured: dict[str, Any] = {}
+
+    def fake_run_command(command: list[str], **kwargs: object) -> CommandResult:
+        captured["command"] = command
+        output_idx = command.index("-o") + 1
+        Path(command[output_idx]).write_text(json.dumps(plan_payload), encoding="utf-8")
+        return CommandResult(
+            command=command,
+            cwd=tmp_path,
+            returncode=0,
+            stdout="",
+            stderr="",
+            duration_ms=1,
+        )
+
+    try:
+        with patch("megaplan.workers.run_command", side_effect=fake_run_command):
+            run_codex_step("plan", state, plan_dir, root=tmp_path, persistent=False, fresh=True)
+    finally:
+        set_work_dir_override(None)
+
+    command = captured["command"]
+    cd_idx = command.index("-C") + 1
+    add_dir_idx = command.index("--add-dir") + 1
+    # -C (source-code cwd) should follow the worktree, NOT project_dir.
+    assert Path(command[cd_idx]) == worktree_dir
+    assert Path(command[cd_idx]) != Path(state["config"]["project_dir"])
+    # --add-dir still grants access to the plan's artifacts directory
+    # (unchanged by the worktree fix).
+    assert Path(command[add_dir_idx]) == plan_dir


### PR DESCRIPTION
## Summary

Megaplan was passing the plan's stored `project_dir` as `--add-dir` to `claude` and `-C` to `codex`. Runs started from a git worktree silently wrote source changes back into the main checkout, colliding with concurrent runs.

- `run_claude_step` / `run_codex_step` now resolve a work_dir (CWD by default, overridable via `--work-dir`) and use that for the subprocess source-code target (`--add-dir` for claude, `-C` + `writable_roots` for codex).
- Plan state files still live under `project_dir`; only the source-code working tree the worker sees has moved.
- Codex's `--add-dir` (which grants access to the plan artifacts dir) is unchanged, per its original intent.
- One-time warning on startup when CWD differs from the plan's stored `project_dir`.
- `--work-dir PATH` flag added to every worker-invoking subcommand (`plan`/`prep`/`critique`/`revise`/`gate`/`finalize`/`execute`/`review`/`auto`/`loop-init`/`loop-run`) for explicit override.

## Test plan

- [x] Baseline: 548 passing on main (6e58a3f).
- [x] After change: 551 passing (3 new tests).
- [x] New: claude `--add-dir` follows CWD when project_dir differs.
- [x] New: explicit `--work-dir` override honored.
- [x] New: codex `-C` follows CWD; codex `--add-dir` unchanged (still plan_dir).
- [x] Existing: `test_run_codex_step_grants_plan_dir_when_project_dir_differs` updated to pin work_dir for continuity; still passes.

## Version

`0.14.5` (patch bump). 0.17+ is reserved for concurrent verifiability / tiebreaker work — untouched here.