### PR TITLE
fix(v0.14.6): recover from poisoned worker sessions; accept status=blocked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ Fix: when megaplan invoked its `claude` / `codex` subprocess workers, it was pas
 - **Divergence warning**: emits a one-time warning at startup when CWD differs from the plan's stored `project_dir`, so operators notice when a plan created in checkout A is being executed from worktree B.
 - **`--work-dir PATH` flag**: every worker-invoking subcommand (`plan`, `prep`, `critique`, `revise`, `gate`, `finalize`, `execute`, `review`, `auto`, `loop-init`, `loop-run`) accepts `--work-dir` to explicitly override the detected CWD.
 
+## v0.14.6 — 2026-04-15
+
+### Poisoned-session recovery
+
+Fixes a class of infinite-loop failure where a persistent Codex/Claude session retained an obsolete "sandbox is broken" belief (e.g. an old `bwrap: Creating new namespace failed: Permission denied` line from before `MEGAPLAN_TRUSTED_CONTAINER=1` was wired up). On subsequent runs the model would read the stale history, refuse to execute, and return `status=blocked` — which megaplan then silently dropped as malformed, preventing any state progress and triggering supervisor restart loops.
+
+- **Accept `status=blocked`**: `execution.py`, `execution_timeout.py`, and the execute/finalize JSON schemas now accept `blocked` as a valid task status. Blocked updates are merged and recorded instead of being silently discarded as malformed `task_updates`.
+- **Detect poisoned sessions**: new `_is_poisoned_environmental_failure(raw)` helper matches known-stale sandbox error signatures. When it fires in `run_codex_step`/`run_claude_step` on a *resumed* session in *trusted-container* mode, megaplan drops the session id and recursively retries with `fresh=True`, mirroring the existing rollout-missing recovery from v0.14.3.
+- **Surface blocked tasks**: the execute summary now lists blocked task IDs and emits a warning (`"N task(s) reported status=blocked by the worker — investigate executor_notes before continuing"`) so supervisors and humans see the real reason a batch did not advance instead of just `state=finalized`.
+- **Status reports `tasks_blocked`**: CLI `status` output exposes `tasks_blocked` alongside `tasks_done` / `tasks_skipped` / `tasks_pending`.
+- **Auto driver exits rc=5 on all-blocked stalls**: when `megaplan auto` detects a state-stall and every remaining task is `blocked` (no pending), it exits with status `blocked` / exit code 5 and a specific reason, distinct from generic `stalled=2` and `escalated=3`. Supervisors can treat this as a poisoned-worker signal and retry with `--fresh`.
+
 ## v0.14.0 — 2026-04-15
 
 ### Strict gate flag resolution

--- a/megaplan/auto.py
+++ b/megaplan/auto.py
@@ -40,7 +40,7 @@ PHASE_TIMEOUT_EXIT_CODE = 124  # conventional; matches GNU `timeout`
 class DriverOutcome:
     """Terminal outcome reported when the loop exits."""
 
-    status: str  # "done" | "stalled" | "escalated" | "failed" | "aborted" | "cap"
+    status: str  # "done" | "stalled" | "escalated" | "failed" | "aborted" | "cap" | "blocked"
     plan: str
     final_state: str
     iterations: int
@@ -199,6 +199,31 @@ def drive(
         if state == last_state:
             stall_count += 1
             if stall_count >= stall_threshold:
+                # Distinguish an all-blocked outcome from a generic stall.
+                # When execute reports every pending task as `blocked`, the
+                # problem is a poisoned session or genuinely broken env —
+                # supervisors should react differently (e.g. retry with a
+                # fresh session) rather than just restart and loop.
+                progress = status.get("progress") or {}
+                tasks_blocked = int(progress.get("tasks_blocked", 0) or 0)
+                tasks_pending = int(progress.get("tasks_pending", 0) or 0)
+                if tasks_blocked > 0 and tasks_pending == 0:
+                    log(
+                        f"all pending tasks reported status=blocked "
+                        f"({tasks_blocked} blocked) — treating as poisoned outcome"
+                    )
+                    return DriverOutcome(
+                        status="blocked",
+                        plan=plan,
+                        final_state=state,
+                        iterations=iteration,
+                        reason=(
+                            "all tasks reported blocked — workers may be poisoned "
+                            "or the environment may genuinely be broken"
+                        ),
+                        last_phase=last_phase,
+                        events=events,
+                    )
                 log(f"stalled at state={state} for {stall_count} iterations")
                 return DriverOutcome(
                     status="stalled",
@@ -401,4 +426,9 @@ def run_auto(root: Path, args: argparse.Namespace) -> int:
         return 3
     if outcome.status == "cap":
         return 4
+    # rc=3 is already claimed by 'escalated'; use rc=5 for all-blocked so the
+    # supervisor can distinguish "workers said every task is blocked" from a
+    # generic stall or escalation.
+    if outcome.status == "blocked":
+        return 5
     return 1

--- a/megaplan/cli.py
+++ b/megaplan/cli.py
@@ -147,6 +147,7 @@ def _build_progress_payload(plan_dir: Path, state: dict[str, Any]) -> dict[str, 
             "tasks_done": 0,
             "tasks_skipped": 0,
             "tasks_pending": 0,
+            "tasks_blocked": 0,
             "batches_total": 0,
             "batches_completed": 0,
             "tasks": [],
@@ -161,6 +162,7 @@ def _build_progress_payload(plan_dir: Path, state: dict[str, Any]) -> dict[str, 
     tasks_done = sum(1 for t in tasks if t.get("status") == "done")
     tasks_skipped = sum(1 for t in tasks if t.get("status") == "skipped")
     tasks_pending = sum(1 for t in tasks if t.get("status") == "pending")
+    tasks_blocked = sum(1 for t in tasks if t.get("status") == "blocked")
     tasks_total = len(tasks)
     completed_ids = {
         t["id"] for t in tasks if t.get("status") in {"done", "skipped"} and isinstance(t.get("id"), str)
@@ -188,6 +190,7 @@ def _build_progress_payload(plan_dir: Path, state: dict[str, Any]) -> dict[str, 
         "tasks_done": tasks_done,
         "tasks_skipped": tasks_skipped,
         "tasks_pending": tasks_pending,
+        "tasks_blocked": tasks_blocked,
         "batches_total": len(global_batches),
         "batches_completed": batches_completed,
         "tasks": task_status_list,

--- a/megaplan/execution.py
+++ b/megaplan/execution.py
@@ -295,7 +295,7 @@ def _merge_batch_results(
         merge_label="task_update",
         # Don't flag incomplete based on all tasks — check batch coverage below
         incomplete_message=None,
-        enum_fields={"status": {"done", "skipped", "completed"}},
+        enum_fields={"status": {"done", "skipped", "completed", "blocked"}},
         nonempty_fields={"executor_notes"},
         array_fields=("files_changed", "commands_run"),
     )
@@ -648,6 +648,25 @@ def handle_execute_one_batch(
         next_step = "execute"
         response_state = STATE_FINALIZED
 
+    # Surface worker-reported `status=blocked` tasks prominently. Merged
+    # task_updates have already been written into finalize_data; count tasks
+    # in this batch that ended in 'blocked' so supervisors see the real
+    # reason a batch did not advance instead of just "state=finalized".
+    batch_blocked_ids = [
+        task.get("id")
+        for task in finalize_data.get("tasks", [])
+        if task.get("id") in set(batch_task_ids)
+        and task.get("status") == "blocked"
+    ]
+    warnings: list[str] = []
+    if blocked:
+        warnings.append(summary)
+    if batch_blocked_ids:
+        warnings.append(
+            f"{len(batch_blocked_ids)} task(s) reported status=blocked by the worker "
+            "— investigate executor_notes before continuing"
+        )
+
     response: StepResponse = {
         "success": not blocked,
         "step": "execute",
@@ -661,9 +680,10 @@ def handle_execute_one_batch(
         "batches_remaining": batches_remaining,
         "files_changed": result.payload.get("files_changed", []),
         "deviations": result.payload.get("deviations", []),
-        "warnings": [summary] if blocked else [],
+        "warnings": warnings,
         "auto_approve": auto_approve,
         "user_approved_gate": user_approved_gate,
+        "blocked_task_ids": batch_blocked_ids,
     }
     if next_step == "execute" and not blocked:
         response["guidance"] = f"Run --batch {batch_number + 1}"

--- a/megaplan/execution_timeout.py
+++ b/megaplan/execution_timeout.py
@@ -134,7 +134,7 @@ def _merge_timeout_checkpoint(
         issues=issues,
         validation_label=f"{checkpoint_name}.task_updates",
         merge_label="checkpoint task_update",
-        enum_fields={"status": {"done", "skipped", "completed"}},
+        enum_fields={"status": {"done", "skipped", "completed", "blocked"}},
         nonempty_fields={"executor_notes"},
         array_fields=("files_changed", "commands_run"),
     )

--- a/megaplan/schemas.py
+++ b/megaplan/schemas.py
@@ -236,7 +236,7 @@ SCHEMAS: dict[str, dict[str, Any]] = {
                         "id": {"type": "string"},
                         "description": {"type": "string"},
                         "depends_on": {"type": "array", "items": {"type": "string"}},
-                        "status": {"type": "string", "enum": ["pending", "done", "skipped"]},
+                        "status": {"type": "string", "enum": ["pending", "done", "skipped", "blocked"]},
                         "executor_notes": {"type": "string"},
                         "files_changed": {"type": "array", "items": {"type": "string"}},
                         "commands_run": {"type": "array", "items": {"type": "string"}},
@@ -325,7 +325,7 @@ SCHEMAS: dict[str, dict[str, Any]] = {
                     "type": "object",
                     "properties": {
                         "task_id": {"type": "string"},
-                        "status": {"type": "string", "enum": ["done", "skipped"]},
+                        "status": {"type": "string", "enum": ["done", "skipped", "blocked"]},
                         "executor_notes": {"type": "string"},
                         "files_changed": {"type": "array", "items": {"type": "string"}},
                         "commands_run": {"type": "array", "items": {"type": "string"}},

--- a/megaplan/workers.py
+++ b/megaplan/workers.py
@@ -290,6 +290,22 @@ _ROLLOUT_MISSING_PATTERNS = (
 )
 
 
+# Patterns that indicate the worker's *session history* has absorbed an
+# obsolete environmental failure (e.g. from an earlier invocation before the
+# container was configured for trusted-mode). On a later invocation the model
+# reads this history, believes the environment is still broken, and returns
+# "blocked" without attempting commands — causing infinite retry loops.
+# Detecting these in the raw output and invalidating the session forces a
+# fresh start so the belief can't survive.
+_POISONED_SESSION_PATTERNS: tuple[tuple[str, ...], ...] = (
+    # Single-substring match (any one of these is enough).
+    ("bwrap: creating new namespace failed",),
+    # Multi-substring match (all substrings must be present).
+    ("permission denied", "cannot start sandbox"),
+    ("repository command execution", "unavailable", "sandbox"),
+)
+
+
 def _is_rollout_missing(raw: str) -> bool:
     """Detect Codex's signal that a session/thread id has no rollout.
 
@@ -306,6 +322,28 @@ def _is_rollout_missing(raw: str) -> bool:
         return False
     lowered = raw.lower()
     return any(pat in lowered for pat in _ROLLOUT_MISSING_PATTERNS)
+
+
+def _is_poisoned_environmental_failure(raw: str) -> bool:
+    """Detect obsolete sandbox/environment failure beliefs in worker output.
+
+    Returns True when the raw output contains known-stale environment errors
+    that a persistent session may have absorbed from a prior invocation
+    (before trusted-container mode was enabled). See the comment on
+    ``_POISONED_SESSION_PATTERNS`` above for motivation.
+
+    The check is intentionally conservative: every pattern is a conjunction
+    of substrings all of which must be present (case-insensitive). A single
+    sandbox error combined with a generic "Permission denied" elsewhere in a
+    long trace should not trigger unless the full phrase appears.
+    """
+    if not raw:
+        return False
+    lowered = raw.lower()
+    for group in _POISONED_SESSION_PATTERNS:
+        if all(sub in lowered for sub in group):
+            return True
+    return False
 
 
 def _trusted_container() -> bool:
@@ -1190,8 +1228,55 @@ def run_claude_step(
     except CliError as error:
         if error.code == "worker_timeout":
             error.extra["session_id"] = session_id
+        # Mirror run_codex_step's poisoned-session recovery for Claude.
+        resumed = bool(session.get("id")) and not fresh
+        if (
+            resumed
+            and _trusted_container()
+            and _is_poisoned_environmental_failure(
+                str(error.extra.get("raw_output", ""))
+            )
+        ):
+            print(
+                "[megaplan] Detected poisoned session (obsolete sandbox failure belief); "
+                "invalidating session and retrying with --fresh",
+                flush=True,
+            )
+            state["sessions"].pop(session_key, None)
+            return run_claude_step(
+                step,
+                state,
+                plan_dir,
+                root=root,
+                fresh=True,
+                prompt_override=prompt_override,
+                prompt_kwargs=prompt_kwargs,
+            )
         raise
     raw = result.stdout or result.stderr
+    # Non-exception poisoned-session recovery. Only trigger when we resumed
+    # (fresh sessions can't carry stale history).
+    if (
+        session.get("id")
+        and not fresh
+        and _trusted_container()
+        and _is_poisoned_environmental_failure(raw)
+    ):
+        print(
+            "[megaplan] Detected poisoned session (obsolete sandbox failure belief); "
+            "invalidating session and retrying with --fresh",
+            flush=True,
+        )
+        state["sessions"].pop(session_key, None)
+        return run_claude_step(
+            step,
+            state,
+            plan_dir,
+            root=root,
+            fresh=True,
+            prompt_override=prompt_override,
+            prompt_kwargs=prompt_kwargs,
+        )
     envelope, payload = parse_claude_envelope(raw)
     try:
         validate_payload(step, payload)
@@ -1320,6 +1405,37 @@ def run_codex_step(
                 prompt_override=prompt_override,
                 prompt_kwargs=prompt_kwargs,
             )
+        # Recover from a poisoned session: the history carries an obsolete
+        # "sandbox is broken" belief from a pre-trusted-container run. Only
+        # act when we're in trusted-container mode (so we know the belief is
+        # stale) and we were resuming a session (fresh sessions can't carry
+        # the poisoned history). See _is_poisoned_environmental_failure.
+        if (
+            not fresh
+            and persistent
+            and session.get("id")
+            and _trusted_container()
+            and _is_poisoned_environmental_failure(
+                str(error.extra.get("raw_output", ""))
+            )
+        ):
+            print(
+                "[megaplan] Detected poisoned session (obsolete sandbox failure belief); "
+                "invalidating session and retrying with --fresh",
+                flush=True,
+            )
+            state["sessions"].pop(session_key, None)
+            return run_codex_step(
+                step,
+                state,
+                plan_dir,
+                root=root,
+                persistent=persistent,
+                fresh=True,
+                json_trace=json_trace,
+                prompt_override=prompt_override,
+                prompt_kwargs=prompt_kwargs,
+            )
         if error.code == "worker_timeout":
             recovered_payload = _recover_codex_payload(
                 step,
@@ -1380,6 +1496,33 @@ def run_codex_step(
         print(
             f"[megaplan] Codex session {session['id']} has no rollout "
             f"(container restart or session wipe); retrying {step} with a fresh session",
+            flush=True,
+        )
+        state["sessions"].pop(session_key, None)
+        return run_codex_step(
+            step,
+            state,
+            plan_dir,
+            root=root,
+            persistent=persistent,
+            fresh=True,
+            json_trace=json_trace,
+            prompt_override=prompt_override,
+            prompt_kwargs=prompt_kwargs,
+        )
+    # Poisoned-session recovery on non-exception path: the worker exited 0 or
+    # non-zero but produced output that still echoes an obsolete sandbox
+    # failure belief. Same guard conditions as the CliError branch above.
+    if (
+        not fresh
+        and persistent
+        and session.get("id")
+        and _trusted_container()
+        and _is_poisoned_environmental_failure(raw)
+    ):
+        print(
+            "[megaplan] Detected poisoned session (obsolete sandbox failure belief); "
+            "invalidating session and retrying with --fresh",
             flush=True,
         )
         state["sessions"].pop(session_key, None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "megaplan-harness"
-version = "0.14.5"
+version = "0.14.6"
 description = "AI agent harness for coordinating Claude and GPT to make and execute extremely robust plans"
 requires-python = ">=3.11"
 license = { text = "OSNL-0.2" }

--- a/tests/test_megaplan.py
+++ b/tests/test_megaplan.py
@@ -3311,7 +3311,7 @@ def test_validate_merge_inputs_filters_malformed_entries() -> None:
             "bad-entry",
         ],
         required_fields=("task_id", "status", "executor_notes", "files_changed", "commands_run"),
-        enum_fields={"status": {"done", "skipped"}},
+        enum_fields={"status": {"done", "skipped", "blocked"}},
         array_fields=("files_changed", "commands_run"),
         label="task_updates",
     )
@@ -3342,7 +3342,7 @@ def test_validate_merge_inputs_rejects_empty_required_content() -> None:
             {"task_id": "T3", "status": "skipped", "executor_notes": "Investigated and skipped."},
         ],
         required_fields=("task_id", "status", "executor_notes"),
-        enum_fields={"status": {"done", "skipped"}},
+        enum_fields={"status": {"done", "skipped", "blocked"}},
         nonempty_fields={"executor_notes"},
         deviations=deviations,
         label="task_updates",
@@ -3375,7 +3375,7 @@ def test_validate_merge_inputs_accepts_array_fields() -> None:
             },
         ],
         required_fields=("task_id", "status", "executor_notes", "files_changed", "commands_run"),
-        enum_fields={"status": {"done", "skipped"}},
+        enum_fields={"status": {"done", "skipped", "blocked"}},
         nonempty_fields={"executor_notes"},
         array_fields=("files_changed", "commands_run"),
         deviations=deviations,
@@ -3726,7 +3726,7 @@ def test_validate_merge_inputs_tracks_deviations() -> None:
             {"task_id": "T2", "status": "invalid_enum", "executor_notes": "x"},  # bad enum
         ],
         required_fields=("task_id", "status", "executor_notes"),
-        enum_fields={"status": {"done", "skipped"}},
+        enum_fields={"status": {"done", "skipped", "blocked"}},
         deviations=deviations,
         label="task_updates",
     )
@@ -5228,3 +5228,47 @@ def test_review_works_after_batch_by_batch_execution(
         make_args(plan=plan_fixture.plan_name),
     )
     assert review["state"] == megaplan.STATE_DONE
+
+
+# ---------------------------------------------------------------------------
+# Task-update status=blocked acceptance (v0.14.6)
+# ---------------------------------------------------------------------------
+
+
+def test_validate_merge_inputs_accepts_blocked_status() -> None:
+    """`status=blocked` must be accepted (not silently discarded) so workers
+    can signal a poisoned/broken environment without megaplan dropping it."""
+    deviations: list[str] = []
+    valid = megaplan.merge._validate_merge_inputs(
+        [
+            {
+                "task_id": "T1",
+                "status": "blocked",
+                "executor_notes": "bwrap: Creating new namespace failed — env broken.",
+                "files_changed": [],
+                "commands_run": [],
+            }
+        ],
+        required_fields=("task_id", "status", "executor_notes", "files_changed", "commands_run"),
+        enum_fields={"status": {"done", "skipped", "completed", "blocked"}},
+        nonempty_fields={"executor_notes"},
+        array_fields=("files_changed", "commands_run"),
+        deviations=deviations,
+        label="task_updates",
+    )
+    assert len(valid) == 1
+    assert valid[0]["status"] == "blocked"
+    assert deviations == []
+
+
+def test_execution_merge_config_includes_blocked_status() -> None:
+    """The enum_fields passed to the execute merge path must include blocked."""
+    # Import source to sanity-check the constant survives future edits.
+    import inspect
+    import megaplan.execution as execution_module
+
+    source = inspect.getsource(execution_module._merge_batch_results)
+    assert '"blocked"' in source, (
+        "execution._merge_batch_results must include 'blocked' in the task_updates "
+        "status enum so workers can report poisoned-environment outcomes."
+    )

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -195,7 +195,7 @@ def test_finalize_schema_tracks_structured_execution_fields() -> None:
         "evidence_files",
         "reviewer_verdict",
     }
-    assert task_schema["properties"]["status"]["enum"] == ["pending", "done", "skipped"]
+    assert task_schema["properties"]["status"]["enum"] == ["pending", "done", "skipped", "blocked"]
     assert "executor_note" in finalize["properties"]["sense_checks"]["items"]["properties"]
     # Validation sub-schema
     validation_schema = finalize["properties"]["validation"]
@@ -216,7 +216,7 @@ def test_execution_schema_requires_task_updates() -> None:
     assert "sense_check_acknowledgments" in execution["properties"]
     assert "sense_check_acknowledgments" in execution["required"]
     item_schema = execution["properties"]["task_updates"]["items"]
-    assert item_schema["properties"]["status"]["enum"] == ["done", "skipped"]
+    assert item_schema["properties"]["status"]["enum"] == ["done", "skipped", "blocked"]
     assert "files_changed" in item_schema["properties"]
     assert "commands_run" in item_schema["properties"]
 

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -1908,3 +1908,156 @@ def test_run_codex_step_uses_work_dir_for_dash_c_not_project_dir(
     # --add-dir still grants access to the plan's artifacts directory
     # (unchanged by the worktree fix).
     assert Path(command[add_dir_idx]) == plan_dir
+
+
+# ---------------------------------------------------------------------------
+# Poisoned-session detection + recovery (v0.14.6)
+# ---------------------------------------------------------------------------
+
+
+def test_is_poisoned_environmental_failure_matches_bwrap_namespace_error() -> None:
+    from megaplan.workers import _is_poisoned_environmental_failure
+
+    raw = "something happened\nbwrap: Creating new namespace failed: Permission denied\nmore"
+    assert _is_poisoned_environmental_failure(raw) is True
+
+
+def test_is_poisoned_environmental_failure_matches_permission_denied_sandbox() -> None:
+    from megaplan.workers import _is_poisoned_environmental_failure
+
+    raw = "error: Permission denied while trying to start the sandbox. cannot start sandbox."
+    assert _is_poisoned_environmental_failure(raw) is True
+
+
+def test_is_poisoned_environmental_failure_matches_repo_cmd_unavailable_sandbox() -> None:
+    from megaplan.workers import _is_poisoned_environmental_failure
+
+    raw = (
+        "Repository command execution is currently unavailable because the sandbox "
+        "could not be initialized."
+    )
+    assert _is_poisoned_environmental_failure(raw) is True
+
+
+def test_is_poisoned_environmental_failure_ignores_unrelated_errors() -> None:
+    from megaplan.workers import _is_poisoned_environmental_failure
+
+    assert _is_poisoned_environmental_failure("") is False
+    assert _is_poisoned_environmental_failure("TypeError: foo is not callable") is False
+    # A lone "Permission denied" without sandbox context must not trip patterns.
+    assert _is_poisoned_environmental_failure("Permission denied: /root/.cache") is False
+
+
+def test_run_codex_step_resumed_session_retries_fresh_on_poisoned_output(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Resumed Codex session whose output contains a stale bwrap failure line
+    should cause run_codex_step to drop the session id and recursively
+    re-invoke itself with fresh=True."""
+    from megaplan._core import ensure_runtime_layout
+    from megaplan.workers import CommandResult, run_codex_step
+
+    ensure_runtime_layout(tmp_path)
+    plan_dir, state = _mock_state(tmp_path)
+    state["sessions"] = {
+        "codex_executor": {
+            "id": "sess-poisoned",
+            "mode": "persistent",
+            "created_at": "2026-04-15T00:00:00Z",
+            "last_used_at": "2026-04-15T00:00:00Z",
+            "refreshed": False,
+        }
+    }
+    monkeypatch.setenv("MEGAPLAN_TRUSTED_CONTAINER", "1")
+
+    poisoned_raw = (
+        "bwrap: Creating new namespace failed: Permission denied\n"
+        "cannot continue\n"
+    )
+    call_counter = {"n": 0}
+
+    def fake_run_command(command, **kwargs):
+        call_counter["n"] += 1
+        if call_counter["n"] == 1:
+            return CommandResult(
+                command=command,
+                cwd=tmp_path,
+                returncode=1,
+                stdout="",
+                stderr=poisoned_raw,
+                duration_ms=5,
+            )
+        out_idx = command.index("-o") + 1
+        output_path = Path(command[out_idx])
+        payload = {
+            "output": "done",
+            "files_changed": [],
+            "commands_run": [],
+            "deviations": [],
+            "task_updates": [],
+            "sense_check_acknowledgments": [],
+        }
+        output_path.write_text(json.dumps(payload), encoding="utf-8")
+        return CommandResult(
+            command=command,
+            cwd=tmp_path,
+            returncode=0,
+            stdout=json.dumps({"type": "thread.started", "thread_id": "sess-fresh"}) + "\n",
+            stderr="",
+            duration_ms=5,
+        )
+
+    with patch("megaplan.workers.create_codex_prompt", return_value="prompt"):
+        with patch("megaplan.workers.run_command", side_effect=fake_run_command):
+            result = run_codex_step(
+                "execute",
+                state,
+                plan_dir,
+                root=tmp_path,
+                persistent=True,
+                fresh=False,
+            )
+
+    assert call_counter["n"] == 2
+    assert result.payload.get("output") == "done"
+    assert result.session_id == "sess-fresh"
+    # Stale session id must have been dropped from state before the recursive
+    # call; the new session id is installed by the caller (apply_session_update).
+    assert state["sessions"].get("codex_executor", {}).get("id") != "sess-poisoned"
+
+
+def test_run_codex_step_skips_poison_retry_when_fresh_already(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With fresh=True the poisoned-session branch must not engage."""
+    from megaplan._core import ensure_runtime_layout
+    from megaplan.workers import CommandResult, run_codex_step
+
+    ensure_runtime_layout(tmp_path)
+    plan_dir, state = _mock_state(tmp_path)
+    monkeypatch.setenv("MEGAPLAN_TRUSTED_CONTAINER", "1")
+
+    poisoned_raw = "bwrap: Creating new namespace failed: Permission denied\n"
+
+    def fake_run_command(command, **kwargs):
+        return CommandResult(
+            command=command,
+            cwd=tmp_path,
+            returncode=1,
+            stdout="",
+            stderr=poisoned_raw,
+            duration_ms=1,
+        )
+
+    with patch("megaplan.workers.create_codex_prompt", return_value="prompt"):
+        with patch("megaplan.workers.run_command", side_effect=fake_run_command):
+            with pytest.raises(CliError):
+                run_codex_step(
+                    "execute",
+                    state,
+                    plan_dir,
+                    root=tmp_path,
+                    persistent=False,
+                    fresh=True,
+                )
+


### PR DESCRIPTION
## Summary
- Stops the infinite-loop failure where a persistent Codex/Claude session retains an obsolete "sandbox is broken" belief (e.g. a stale `bwrap: Creating new namespace failed: Permission denied` line from before `MEGAPLAN_TRUSTED_CONTAINER=1` was wired up), causing the model to return `status=blocked` every run — which megaplan then silently dropped, leaving state unchanged and triggering supervisor restart loops.
- Adds `_is_poisoned_environmental_failure(raw)` to `megaplan/workers.py` and mirrors the v0.14.3 rollout-missing recovery: when a *resumed* session in *trusted-container* mode produces known-stale sandbox error text, megaplan drops the session and recursively retries with `fresh=True`.
- Accepts `status=blocked` as a valid task update in `execution.py`, `execution_timeout.py`, and the `execution.json` / `finalize.json` JSON schemas. Blocked updates are now recorded instead of silently discarded as malformed.
- Surfaces blocked tasks in the execute summary warnings (`"N task(s) reported status=blocked by the worker — investigate executor_notes before continuing"`), exposes `tasks_blocked` in CLI `status` progress, and makes `megaplan auto` exit with a new `blocked` status + rc=5 when every pending task is reported blocked — distinct from generic stall (rc=2) and gate escalation (rc=3).

## Bug chain (for reviewers)
1. Persistent session retains chat history across invocations.
2. A transient failure (e.g. old `bwrap` error) lands in the history.
3. On a later run, even after the env is fixed, the model sees the stale history and refuses to execute → returns `status: "blocked"`.
4. Prior to this PR: `"blocked"` was not in the `enum_fields` whitelist, so `merge._validate_merge_inputs` silently dropped the update.
5. No state change → `megaplan auto` stall-detects → supervisor restarts → same poisoned session resumes → loop.

Mitigation order: (1) accept `blocked` so the signal survives, (2) detect + auto-recover, (3) surface it, (4) let `auto` exit distinctly so supervisors can react.

## Notes
- Version bumped to **0.14.6**. `0.14.5` is reserved by the pending worktree-add-dir PR; this branched from `main@6e58a3f` (0.14.4) and jumped one patch.
- `auto` exit code `3` is already taken by `escalated`; this PR uses **rc=5** for the new `blocked` outcome.

## Test plan
- [x] `PYENV_VERSION=3.11.11 python -m pytest tests/ -q` — 544 passed / 12 failed (baseline 536 / 12). The 12 failures are pre-existing and unrelated (parallel_critique/parallel_review/review-schema tests already failing on `main`).
- [x] New unit tests: 4× `_is_poisoned_environmental_failure` pattern coverage, 1× resumed-session recursive `fresh=True` retry (with session-id dropped), 1× fresh=True skips poison-retry, 1× `_validate_merge_inputs` accepts `status=blocked`, 1× `_merge_batch_results` source contains the blocked enum.
- [ ] Manual smoke: run `megaplan auto --plan <live plan>` under `MEGAPLAN_TRUSTED_CONTAINER=1` with a session that once saw a bwrap failure; confirm the `[megaplan] Detected poisoned session` log line and a single fresh retry.