### PR TITLE
v0.15.0 — doc mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,17 +20,16 @@ New first-class subcommand that drives an ordered pipeline of milestone plans de
 
 - `tests/test_chain.py` covers spec parsing, `chain status`, idea-file validation, seed-plan validation, happy-path execution (with `auto.drive` mocked), resume-from-`chain_state.json`, on-failure `stop_chain`, and `--no-git-refresh` suppression.
 
-## v0.14.5 — 2026-04-15
+## v0.15.0 — 2026-04-15
 
-### Git-worktree isolation for subprocess workers
+### Doc mode
 
-Fix: when megaplan invoked its `claude` / `codex` subprocess workers, it was passing the plan's stored `project_dir` as the `--add-dir` / `-C` target. Runs started from a git worktree would silently write source-code changes back into the main checkout, colliding with other concurrent runs.
+Megaplan can now run in `--mode doc`, letting execution produce a single document artifact instead of a code diff.
 
-- **CWD drives `--add-dir`**: `run_claude_step` now passes the CWD (or an explicit override) as `--add-dir` and subprocess cwd, instead of the plan's stored `project_dir`.
-- **CWD drives Codex `-C`**: `run_codex_step` now passes the CWD as Codex's `-C` and as the `sandbox_workspace_write.writable_roots` entry. The `--add-dir` for Codex still points at the plan's artifacts directory (`plan_dir`), which is unchanged.
-- **Plan state still lives at `project_dir`**: `.megaplan/plans/<name>/` artifacts remain co-located with the plan as before. Only the source-code working tree the worker sees has changed.
-- **Divergence warning**: emits a one-time warning at startup when CWD differs from the plan's stored `project_dir`, so operators notice when a plan created in checkout A is being executed from worktree B.
-- **`--work-dir PATH` flag**: every worker-invoking subcommand (`plan`, `prep`, `critique`, `revise`, `gate`, `finalize`, `execute`, `review`, `auto`, `loop-init`, `loop-run`) accepts `--work-dir` to explicitly override the detected CWD.
+- `megaplan init` adds `--mode doc` and `--output <relative/path>` for document-targeted plans.
+- Execute workers now support a doc-mode schema with `sections_written` instead of per-task file changes.
+- Doc-mode prompt tracks reframe prep, execute, and review around authoring and document quality.
+- Execution auditing can now reason about section-based delivery instead of only file-based changes.
 
 ## v0.14.6 — 2026-04-15
 
@@ -43,6 +42,18 @@ Fixes a class of infinite-loop failure where a persistent Codex/Claude session r
 - **Surface blocked tasks**: the execute summary now lists blocked task IDs and emits a warning (`"N task(s) reported status=blocked by the worker — investigate executor_notes before continuing"`) so supervisors and humans see the real reason a batch did not advance instead of just `state=finalized`.
 - **Status reports `tasks_blocked`**: CLI `status` output exposes `tasks_blocked` alongside `tasks_done` / `tasks_skipped` / `tasks_pending`.
 - **Auto driver exits rc=5 on all-blocked stalls**: when `megaplan auto` detects a state-stall and every remaining task is `blocked` (no pending), it exits with status `blocked` / exit code 5 and a specific reason, distinct from generic `stalled=2` and `escalated=3`. Supervisors can treat this as a poisoned-worker signal and retry with `--fresh`.
+
+## v0.14.5 — 2026-04-15
+
+### Git-worktree isolation for subprocess workers
+
+Fix: when megaplan invoked its `claude` / `codex` subprocess workers, it was passing the plan's stored `project_dir` as the `--add-dir` / `-C` target. Runs started from a git worktree would silently write source-code changes back into the main checkout, colliding with other concurrent runs.
+
+- **CWD drives `--add-dir`**: `run_claude_step` now passes the CWD (or an explicit override) as `--add-dir` and subprocess cwd, instead of the plan's stored `project_dir`.
+- **CWD drives Codex `-C`**: `run_codex_step` now passes the CWD as Codex's `-C` and as the `sandbox_workspace_write.writable_roots` entry. The `--add-dir` for Codex still points at the plan's artifacts directory (`plan_dir`), which is unchanged.
+- **Plan state still lives at `project_dir`**: `.megaplan/plans/<name>/` artifacts remain co-located with the plan as before. Only the source-code working tree the worker sees has changed.
+- **Divergence warning**: emits a one-time warning at startup when CWD differs from the plan's stored `project_dir`, so operators notice when a plan created in checkout A is being executed from worktree B.
+- **`--work-dir PATH` flag**: every worker-invoking subcommand (`plan`, `prep`, `critique`, `revise`, `gate`, `finalize`, `execute`, `review`, `auto`, `loop-init`, `loop-run`) accepts `--work-dir` to explicitly override the detected CWD.
 
 ## v0.14.0 — 2026-04-15
 

--- a/megaplan/cli.py
+++ b/megaplan/cli.py
@@ -290,7 +290,11 @@ def _build_status_payload(plan_dir: Path, state: dict[str, Any]) -> StepResponse
     lock_held = plan_lock_is_held(plan_dir)
     active_step = _build_active_step(state.get("active_step"), plan_dir=plan_dir)
     last_step = _build_last_step(state)
+    plan_mode = state.get("config", {}).get("mode", "code")
+    plan_output_path = state.get("config", {}).get("output_path")
     summary = f"Plan '{state['name']}' is currently in state '{state['current_state']}'."
+    if plan_mode == "doc":
+        summary += f" Mode: doc. Output: {plan_output_path}."
     if active_step:
         summary = (
             summary
@@ -320,6 +324,8 @@ def _build_status_payload(plan_dir: Path, state: dict[str, Any]) -> StepResponse
         "active_step": active_step,
         "last_step": last_step,
         "total_cost_usd": state.get("meta", {}).get("total_cost_usd", 0.0),
+        "mode": plan_mode,
+        "output_path": plan_output_path,
         "notes_count": len(notes) if isinstance(notes, list) else 0,
         "notes": notes if isinstance(notes, list) else [],
         "session_summaries": [
@@ -816,6 +822,8 @@ def build_parser() -> argparse.ArgumentParser:
     init_parser.add_argument("--name")
     init_parser.add_argument("--auto-approve", action="store_true", default=None)
     init_parser.add_argument("--robustness", choices=list(ROBUSTNESS_LEVELS), default=None)
+    init_parser.add_argument("--mode", choices=["code", "doc"], default="code")
+    init_parser.add_argument("--output")
     init_parser.add_argument("--hermes", nargs="?", const="", default=None,
                              help="Use Hermes agent for all phases. Optional: specify default model")
     init_parser.add_argument("--phase-model", action="append", default=[],

--- a/megaplan/doc_assembly.py
+++ b/megaplan/doc_assembly.py
@@ -1,0 +1,117 @@
+"""Doc-mode section assembly — collects per-batch executor outputs into a single document."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from megaplan._core import read_json
+
+
+def extract_sections(batch_payloads: list[dict[str, Any]]) -> dict[str, str]:
+    """Map section_id to rendered text from executor output.
+
+    Scans task_updates across all batch payloads. Each task with status
+    'done' contributes its sections_written entries. The section content
+    is taken from the task's executor_notes (the authored text).
+    """
+    sections: dict[str, str] = {}
+    for payload in batch_payloads:
+        for task in payload.get("task_updates", []):
+            if not isinstance(task, dict):
+                continue
+            if task.get("status") != "done":
+                continue
+            notes = task.get("executor_notes", "")
+            for section_id in task.get("sections_written", []):
+                if isinstance(section_id, str) and section_id.strip():
+                    sections[section_id] = notes
+    return sections
+
+
+def _task_order_index(finalize_data: dict[str, Any]) -> dict[str, int]:
+    """Build a mapping from task_id to its position in the finalize task list."""
+    return {
+        task["id"]: index
+        for index, task in enumerate(finalize_data.get("tasks", []))
+        if isinstance(task, dict) and isinstance(task.get("id"), str)
+    }
+
+
+def _section_plan_order(
+    finalize_data: dict[str, Any],
+    batch_payloads: list[dict[str, Any]],
+) -> list[str]:
+    """Return section IDs ordered by their owning task's position in the plan."""
+    task_index = _task_order_index(finalize_data)
+    section_to_task: dict[str, str] = {}
+    for payload in batch_payloads:
+        for task in payload.get("task_updates", []):
+            if not isinstance(task, dict):
+                continue
+            task_id = task.get("task_id", "")
+            for section_id in task.get("sections_written", []):
+                if isinstance(section_id, str) and section_id.strip():
+                    section_to_task.setdefault(section_id, task_id)
+    ordered = sorted(
+        section_to_task.keys(),
+        key=lambda sid: task_index.get(section_to_task.get(sid, ""), 999),
+    )
+    return ordered
+
+
+def assemble_doc(
+    plan_dir: Path,
+    output_path: Path,
+    finalize_data: dict[str, Any],
+) -> Path:
+    """Read per-batch executor outputs and assemble the final document.
+
+    Sections are ordered by their owning task's position in finalize_data.
+    The file is written atomically (temp file + rename). Running twice
+    replaces the file completely (idempotent).
+    """
+    batch_payloads: list[dict[str, Any]] = []
+    batch_index = 1
+    while True:
+        batch_path = plan_dir / f"execution_batch_{batch_index}.json"
+        if not batch_path.exists():
+            break
+        try:
+            batch_payloads.append(read_json(batch_path))
+        except (OSError, ValueError):
+            pass
+        batch_index += 1
+
+    sections = extract_sections(batch_payloads)
+    ordered_ids = _section_plan_order(finalize_data, batch_payloads)
+
+    lines: list[str] = []
+    for section_id in ordered_ids:
+        content = sections.get(section_id, "")
+        if content:
+            lines.append(content)
+
+    assembled_text = "\n\n".join(lines) if lines else ""
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(output_path.parent),
+        suffix=".tmp",
+    )
+    closed = False
+    try:
+        os.write(fd, assembled_text.encode("utf-8"))
+        os.close(fd)
+        closed = True
+        os.replace(tmp_path, str(output_path))
+    except BaseException:
+        if not closed:
+            os.close(fd)
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+        raise
+
+    return output_path

--- a/megaplan/evaluation.py
+++ b/megaplan/evaluation.py
@@ -120,7 +120,86 @@ def _is_perfunctory_ack(note: str) -> bool:
     return is_rubber_stamp(note, strict=False)
 
 
-def validate_execution_evidence(finalize_data: dict[str, Any], project_dir: Path) -> dict[str, Any]:
+def validate_execution_evidence(finalize_data: dict[str, Any], project_dir: Path, *, mode: str = "code") -> dict[str, Any]:
+    if mode == "doc":
+        return _validate_execution_evidence_doc(finalize_data, project_dir)
+    return _validate_execution_evidence_code(finalize_data, project_dir)
+
+
+def _validate_execution_evidence_doc(finalize_data: dict[str, Any], project_dir: Path) -> dict[str, Any]:
+    findings: list[str] = []
+    tasks = finalize_data.get("tasks", [])
+
+    planned_sections: set[str] = set()
+    claimed_sections: set[str] = set()
+    for task in tasks:
+        if task.get("status") != "done":
+            continue
+        for section_id in task.get("sections_written", []):
+            if isinstance(section_id, str) and section_id.strip():
+                claimed_sections.add(section_id)
+
+    for task in tasks:
+        for section_id in task.get("sections_written", []):
+            if isinstance(section_id, str) and section_id.strip():
+                planned_sections.add(section_id)
+
+    missing_sections = sorted(planned_sections - claimed_sections)
+    if missing_sections:
+        findings.append(
+            "Planned sections not claimed by any done task: "
+            + ", ".join(missing_sections)
+        )
+
+    unclaimed = sorted(claimed_sections - planned_sections)
+    if unclaimed:
+        findings.append(
+            "Sections claimed by done tasks but not in any task plan: "
+            + ", ".join(unclaimed)
+        )
+
+    output_path_str = ""
+    config = finalize_data.get("config", {})
+    if isinstance(config, dict):
+        output_path_str = config.get("output_path", "")
+    if not output_path_str:
+        for task in tasks:
+            if task.get("sections_written"):
+                break
+
+    for sense_check in finalize_data.get("sense_checks", []):
+        sense_check_id = sense_check.get("id", "?")
+        note = sense_check.get("executor_note", "")
+        if not isinstance(note, str) or not note.strip():
+            findings.append(f"Sense check {sense_check_id} is missing an executor acknowledgment.")
+            continue
+        if _is_perfunctory_ack(note):
+            findings.append(
+                f"Sense check {sense_check_id} acknowledgment is perfunctory: {note.strip()!r}."
+            )
+
+    for task in tasks:
+        if task.get("status") != "done":
+            continue
+        task_id = task.get("id", "?")
+        notes = task.get("executor_notes", "")
+        if not isinstance(notes, str) or not notes.strip():
+            continue
+        if is_rubber_stamp(notes, strict=True):
+            findings.append(
+                f"Task {task_id} executor_notes are perfunctory: {notes.strip()!r}."
+            )
+
+    return {
+        "findings": findings,
+        "files_in_diff": [],
+        "files_claimed": [],
+        "skipped": False,
+        "reason": "",
+    }
+
+
+def _validate_execution_evidence_code(finalize_data: dict[str, Any], project_dir: Path) -> dict[str, Any]:
     findings: list[str] = []
     files_claimed = sorted(
         {

--- a/megaplan/execution.py
+++ b/megaplan/execution.py
@@ -138,20 +138,29 @@ def _build_aggregate_execution_payload(
     *,
     completed_batches: int,
     total_batches: int,
+    mode: str = "code",
 ) -> dict[str, Any]:
     outputs = [
         f"Batch {index + 1}: {payload.get('output', '')}".strip()
         for index, payload in enumerate(batch_payloads)
     ]
-    files_changed: list[str] = []
-    commands_run: list[str] = []
     deviations: list[str] = []
     task_updates: list[dict[str, Any]] = []
     sense_check_acknowledgments: list[dict[str, Any]] = []
+    if mode == "doc":
+        sections_written: list[str] = []
+    else:
+        files_changed: list[str] = []
+    commands_run: list[str] = []
     for payload in batch_payloads:
-        files_changed.extend(
-            [path for path in payload.get("files_changed", []) if isinstance(path, str)]
-        )
+        if mode == "doc":
+            sections_written.extend(
+                [s for s in payload.get("sections_written", []) if isinstance(s, str)]
+            )
+        else:
+            files_changed.extend(
+                [path for path in payload.get("files_changed", []) if isinstance(path, str)]
+            )
         commands_run.extend(
             [
                 command
@@ -177,14 +186,18 @@ def _build_aggregate_execution_payload(
     )
     if outputs:
         output = output + "\n" + "\n".join(outputs)
-    return {
+    result: dict[str, Any] = {
         "output": output,
-        "files_changed": _stable_unique_strings(files_changed),
         "commands_run": _stable_unique_strings(commands_run),
         "deviations": deviations,
         "task_updates": task_updates,
         "sense_check_acknowledgments": sense_check_acknowledgments,
     }
+    if mode == "doc":
+        result["sections_written"] = _stable_unique_strings(sections_written)
+    else:
+        result["files_changed"] = _stable_unique_strings(files_changed)
+    return result
 
 
 def _active_sense_check_ids(
@@ -260,6 +273,7 @@ def _merge_batch_results(
     batch_task_ids: list[str],
     batch_sense_check_ids: list[str],
     issues: list[str],
+    mode: str = "code",
 ) -> tuple[int, int, int, int]:
     batch_task_id_set = set(batch_task_ids)
     batch_sense_check_id_set = set(batch_sense_check_ids)
@@ -278,18 +292,20 @@ def _merge_batch_results(
         for task in finalize_data.get("tasks", [])
         if isinstance(task, dict) and isinstance(task.get("id"), str)
     }
+    if mode == "doc":
+        required_fields = ("task_id", "status", "executor_notes", "sections_written")
+        merge_fields = ("status", "executor_notes", "sections_written")
+        array_fields = ("sections_written",)
+    else:
+        required_fields = ("task_id", "status", "executor_notes", "files_changed", "commands_run")
+        merge_fields = ("status", "executor_notes", "files_changed", "commands_run")
+        array_fields = ("files_changed", "commands_run")
     merged_count, _ = _validate_and_merge_batch(
         payload.get("task_updates"),
-        required_fields=(
-            "task_id",
-            "status",
-            "executor_notes",
-            "files_changed",
-            "commands_run",
-        ),
+        required_fields=required_fields,
         targets_by_id=all_tasks_by_id,
         id_field="task_id",
-        merge_fields=("status", "executor_notes", "files_changed", "commands_run"),
+        merge_fields=merge_fields,
         issues=issues,
         validation_label="task_updates",
         merge_label="task_update",
@@ -297,7 +313,7 @@ def _merge_batch_results(
         incomplete_message=None,
         enum_fields={"status": {"done", "skipped", "completed", "blocked"}},
         nonempty_fields={"executor_notes"},
-        array_fields=("files_changed", "commands_run"),
+        array_fields=array_fields,
     )
     # Check batch-specific coverage: how many of THIS batch's tasks got updates?
     total_batch_tasks = len(batch_task_id_set)
@@ -368,8 +384,14 @@ def _run_and_merge_batch(
     ] = _capture_git_status_snapshot,
 ) -> BatchResult:
     project_dir = Path(state["config"]["project_dir"])
-    before_snapshot, before_error = capture_git_status_snapshot_fn(project_dir)
-    before_line_counts = capture_before_line_counts(project_dir, before_snapshot.keys())
+    plan_mode = state["config"].get("mode", "code")
+    if plan_mode == "doc":
+        before_snapshot: dict[str, str] = {}
+        before_error: str | None = None
+        before_line_counts: dict[str, int] = {}
+    else:
+        before_snapshot, before_error = capture_git_status_snapshot_fn(project_dir)
+        before_line_counts = capture_before_line_counts(project_dir, before_snapshot.keys())
     worker, agent, mode, refreshed = worker_module.run_step_with_worker(
         "execute",
         state,
@@ -382,26 +404,27 @@ def _run_and_merge_batch(
     payload = dict(worker.payload)
     deviations = list(payload.get("deviations", []))
     batch_task_id_set = set(batch_task_ids)
-    deviations.extend(
-        _observe_git_changes(
-            project_dir=project_dir,
-            payload=payload,
-            before_snapshot=before_snapshot,
-            before_error=before_error,
-            batch_number=batch_number,
-            batches_total=batches_total,
-            capture_git_status_snapshot_fn=capture_git_status_snapshot_fn,
+    if plan_mode != "doc":
+        deviations.extend(
+            _observe_git_changes(
+                project_dir=project_dir,
+                payload=payload,
+                before_snapshot=before_snapshot,
+                before_error=before_error,
+                batch_number=batch_number,
+                batches_total=batches_total,
+                capture_git_status_snapshot_fn=capture_git_status_snapshot_fn,
+            )
         )
-    )
-    deviations.extend(
-        _collect_quality_deviations(
-            project_dir=project_dir,
-            before_snapshot=before_snapshot,
-            before_line_counts=before_line_counts,
-            quality_config=quality_config,
-            capture_git_status_snapshot_fn=capture_git_status_snapshot_fn,
+        deviations.extend(
+            _collect_quality_deviations(
+                project_dir=project_dir,
+                before_snapshot=before_snapshot,
+                before_line_counts=before_line_counts,
+                quality_config=quality_config,
+                capture_git_status_snapshot_fn=capture_git_status_snapshot_fn,
+            )
         )
-    )
     merged_count, total_batch_tasks, acknowledged_count, total_batch_checks = (
         _merge_batch_results(
             finalize_data=finalize_data,
@@ -409,18 +432,30 @@ def _run_and_merge_batch(
             batch_task_ids=batch_task_ids,
             batch_sense_check_ids=batch_sense_check_ids,
             issues=deviations,
+            mode=plan_mode,
         )
     )
-    missing_task_evidence = _check_done_task_evidence(
-        finalize_data.get("tasks", []),
-        issues=deviations,
-        should_classify=lambda task: task.get("id") in batch_task_id_set,
-        has_evidence=lambda task: bool(task.get("files_changed")),
-        has_advisory_evidence=lambda task: bool(task.get("commands_run")),
-        missing_message="Done tasks missing both files_changed and commands_run: ",
-        advisory_message="Advisory: done tasks rely on commands_run without files_changed (FLAG-006 softening): ",
-    )
-    execution_audit = validate_execution_evidence(finalize_data, project_dir)
+    if plan_mode == "doc":
+        missing_task_evidence = _check_done_task_evidence(
+            finalize_data.get("tasks", []),
+            issues=deviations,
+            should_classify=lambda task: task.get("id") in batch_task_id_set,
+            has_evidence=lambda task: bool(task.get("sections_written")),
+            has_advisory_evidence=lambda task: True,
+            missing_message="Done tasks missing sections_written: ",
+            advisory_message="",
+        )
+    else:
+        missing_task_evidence = _check_done_task_evidence(
+            finalize_data.get("tasks", []),
+            issues=deviations,
+            should_classify=lambda task: task.get("id") in batch_task_id_set,
+            has_evidence=lambda task: bool(task.get("files_changed")),
+            has_advisory_evidence=lambda task: bool(task.get("commands_run")),
+            missing_message="Done tasks missing both files_changed and commands_run: ",
+            advisory_message="Advisory: done tasks rely on commands_run without files_changed (FLAG-006 softening): ",
+        )
+    execution_audit = validate_execution_evidence(finalize_data, project_dir, mode=plan_mode)
     if execution_audit["skipped"]:
         deviations.append(f"Advisory audit skip: {execution_audit['reason']}")
     for finding in execution_audit["findings"]:
@@ -574,11 +609,13 @@ def handle_execute_one_batch(
     )
 
     if is_final_batch and all_tracked and not blocked:
+        plan_mode = state["config"].get("mode", "code")
         batch_payloads = [read_json(path) for path in list_batch_artifacts(plan_dir)]
         aggregate_payload = _build_aggregate_execution_payload(
             batch_payloads,
             completed_batches=len(batch_payloads),
             total_batches=batches_total,
+            mode=plan_mode,
         )
         atomic_write_json(plan_dir / "execution.json", aggregate_payload)
         state["current_state"] = STATE_EXECUTED
@@ -872,10 +909,12 @@ def handle_execute_auto_loop(
         mode = result.mode
         refreshed = result.refreshed
 
+    plan_mode = state["config"].get("mode", "code")
     aggregate_payload = _build_aggregate_execution_payload(
         batch_payloads,
         completed_batches=len(batch_payloads),
         total_batches=total_batches,
+        mode=plan_mode,
     )
     if timeout_error is not None:
         aggregate_payload["deviations"] = list(aggregate_payload.get("deviations", []))
@@ -886,7 +925,7 @@ def handle_execute_auto_loop(
         atomic_write_text(plan_dir / "execution_trace.jsonl", "".join(trace_chunks))
 
     finalize_data = read_json(plan_dir / "finalize.json")
-    execution_audit = validate_execution_evidence(finalize_data, project_dir)
+    execution_audit = validate_execution_evidence(finalize_data, project_dir, mode=state["config"].get("mode", "code"))
     deviations = list(aggregate_payload.get("deviations", []))
     if timeout_recovery is not None:
         deviations.extend(
@@ -914,15 +953,26 @@ def handle_execute_auto_loop(
             active_sense_check_ids=active_sense_check_ids,
         )
     )
-    missing_task_evidence = _check_done_task_evidence(
-        finalize_data.get("tasks", []),
-        issues=deviations,
-        should_classify=lambda task: task.get("id") in active_task_ids,
-        has_evidence=lambda task: bool(task.get("files_changed")),
-        has_advisory_evidence=lambda task: bool(task.get("commands_run")),
-        missing_message="Done tasks missing both files_changed and commands_run: ",
-        advisory_message="Advisory: done tasks rely on commands_run without files_changed (FLAG-006 softening): ",
-    )
+    if plan_mode == "doc":
+        missing_task_evidence = _check_done_task_evidence(
+            finalize_data.get("tasks", []),
+            issues=deviations,
+            should_classify=lambda task: task.get("id") in active_task_ids,
+            has_evidence=lambda task: bool(task.get("sections_written")),
+            has_advisory_evidence=lambda task: True,
+            missing_message="Done tasks missing sections_written: ",
+            advisory_message="",
+        )
+    else:
+        missing_task_evidence = _check_done_task_evidence(
+            finalize_data.get("tasks", []),
+            issues=deviations,
+            should_classify=lambda task: task.get("id") in active_task_ids,
+            has_evidence=lambda task: bool(task.get("files_changed")),
+            has_advisory_evidence=lambda task: bool(task.get("commands_run")),
+            missing_message="Done tasks missing both files_changed and commands_run: ",
+            advisory_message="Advisory: done tasks rely on commands_run without files_changed (FLAG-006 softening): ",
+        )
     blocking_reasons = build_blocking_reasons(
         tracked_tasks=tracked_tasks,
         total_tasks=total_tasks,

--- a/megaplan/execution_timeout.py
+++ b/megaplan/execution_timeout.py
@@ -43,23 +43,38 @@ def _reset_timeout_invalid_tasks(
     *,
     execution_audit: dict[str, Any],
     issues: list[str],
+    mode: str = "code",
 ) -> list[str]:
     reset_reasons: dict[str, list[str]] = {}
-    missing_task_ids = _check_done_task_evidence(
-        finalize_data.get("tasks", []),
-        issues=issues,
-        should_classify=lambda task: True,
-        has_evidence=lambda task: bool(task.get("files_changed")),
-        has_advisory_evidence=lambda task: bool(task.get("commands_run")),
-        missing_message="Done tasks missing both files_changed and commands_run during timeout recovery: ",
-        advisory_message="Advisory: done tasks rely on commands_run without files_changed during timeout recovery: ",
-    )
-    for task_id in missing_task_ids:
-        reset_reasons.setdefault(task_id, []).append(
-            "missing both files_changed and commands_run"
+    if mode == "doc":
+        missing_task_ids = _check_done_task_evidence(
+            finalize_data.get("tasks", []),
+            issues=issues,
+            should_classify=lambda task: True,
+            has_evidence=lambda task: bool(task.get("sections_written")),
+            has_advisory_evidence=lambda task: True,
+            missing_message="Done tasks missing sections_written during timeout recovery: ",
+            advisory_message="",
         )
+    else:
+        missing_task_ids = _check_done_task_evidence(
+            finalize_data.get("tasks", []),
+            issues=issues,
+            should_classify=lambda task: True,
+            has_evidence=lambda task: bool(task.get("files_changed")),
+            has_advisory_evidence=lambda task: bool(task.get("commands_run")),
+            missing_message="Done tasks missing both files_changed and commands_run during timeout recovery: ",
+            advisory_message="Advisory: done tasks rely on commands_run without files_changed during timeout recovery: ",
+        )
+    for task_id in missing_task_ids:
+        if mode == "doc":
+            reset_reasons.setdefault(task_id, []).append("missing sections_written")
+        else:
+            reset_reasons.setdefault(task_id, []).append(
+                "missing both files_changed and commands_run"
+            )
 
-    if not execution_audit.get("skipped"):
+    if mode != "doc" and not execution_audit.get("skipped"):
         files_in_diff = {
             _normalize_execute_claimed_path(path)
             for path in execution_audit.get("files_in_diff", [])
@@ -113,30 +128,33 @@ def _merge_timeout_checkpoint(
     checkpoint_data: dict[str, Any],
     checkpoint_name: str,
     issues: list[str],
+    mode: str = "code",
 ) -> None:
     tasks_by_id = {
         task["id"]: task
         for task in finalize_data.get("tasks", [])
         if isinstance(task, dict) and isinstance(task.get("id"), str)
     }
+    if mode == "doc":
+        required_fields = ("task_id", "status", "executor_notes", "sections_written")
+        merge_fields = ("status", "executor_notes", "sections_written")
+        array_fields = ("sections_written",)
+    else:
+        required_fields = ("task_id", "status", "executor_notes", "files_changed", "commands_run")
+        merge_fields = ("status", "executor_notes", "files_changed", "commands_run")
+        array_fields = ("files_changed", "commands_run")
     merged_tasks, _ = _validate_and_merge_batch(
         checkpoint_data.get("task_updates"),
-        required_fields=(
-            "task_id",
-            "status",
-            "executor_notes",
-            "files_changed",
-            "commands_run",
-        ),
+        required_fields=required_fields,
         targets_by_id=tasks_by_id,
         id_field="task_id",
-        merge_fields=("status", "executor_notes", "files_changed", "commands_run"),
+        merge_fields=merge_fields,
         issues=issues,
         validation_label=f"{checkpoint_name}.task_updates",
         merge_label="checkpoint task_update",
         enum_fields={"status": {"done", "skipped", "completed", "blocked"}},
         nonempty_fields={"executor_notes"},
-        array_fields=("files_changed", "commands_run"),
+        array_fields=array_fields,
     )
     sense_checks_by_id = {
         sense_check["id"]: sense_check
@@ -175,6 +193,8 @@ def _recover_execute_timeout(
 ) -> StepResponse:
     deviations = [f"Execute timed out: {error.message}"]
     finalize_data = read_json(plan_dir / "finalize.json")
+    project_dir = Path(state["config"]["project_dir"])
+    plan_mode = state["config"].get("mode", "code")
     checkpoint_path = _timeout_checkpoint_path(plan_dir, batch_number=batch_number)
     try:
         checkpoint_data = read_json(checkpoint_path)
@@ -193,14 +213,15 @@ def _recover_execute_timeout(
                 checkpoint_data=checkpoint_data,
                 checkpoint_name=checkpoint_path.name,
                 issues=deviations,
+                mode=plan_mode,
             )
         else:
             deviations.append(
                 f"Advisory: timeout checkpoint {checkpoint_path.name} did not contain an object."
             )
 
-    project_dir = Path(state["config"]["project_dir"])
-    initial_audit = validate_execution_evidence(finalize_data, project_dir)
+    initial_audit = validate_execution_evidence(finalize_data, project_dir, mode=plan_mode)
+
     if initial_audit["skipped"]:
         deviations.append(
             f"Advisory audit skip during timeout recovery: {initial_audit['reason']}"
@@ -212,8 +233,9 @@ def _recover_execute_timeout(
         finalize_data,
         execution_audit=initial_audit,
         issues=deviations,
+        mode=plan_mode,
     )
-    execution_audit = validate_execution_evidence(finalize_data, project_dir)
+    execution_audit = validate_execution_evidence(finalize_data, project_dir, mode=plan_mode)
     atomic_write_json(plan_dir / "execution_audit.json", execution_audit)
     atomic_write_json(plan_dir / "finalize.json", finalize_data)
     atomic_write_text(
@@ -272,14 +294,24 @@ def _recover_execute_timeout(
     completed_tasks = [
         task for task in tasks if task.get("status") in {"done", "skipped"}
     ]
-    files_changed = sorted(
-        {
-            path
-            for task in completed_tasks
-            for path in task.get("files_changed", [])
-            if isinstance(path, str) and path.strip()
-        }
-    )
+    if plan_mode == "doc":
+        files_changed = sorted(
+            {
+                section
+                for task in completed_tasks
+                for section in task.get("sections_written", [])
+                if isinstance(section, str) and section.strip()
+            }
+        )
+    else:
+        files_changed = sorted(
+            {
+                path
+                for task in completed_tasks
+                for path in task.get("files_changed", [])
+                if isinstance(path, str) and path.strip()
+            }
+        )
     summary = (
         "Execute timed out after partial progress. "
         f"{len(completed_tasks)}/{len(tasks)} tasks remain marked done or skipped on disk. "

--- a/megaplan/handlers.py
+++ b/megaplan/handlers.py
@@ -374,9 +374,14 @@ def _write_plan_version(
 
 
 def _write_finalize_artifacts(plan_dir: Path, payload: dict[str, Any], state: PlanState) -> str:
-    baseline = _capture_test_baseline(Path(state["config"]["project_dir"]), state.get("config", {}))
-    payload.update(baseline)
-    _ensure_verification_task(payload, state)
+    if state["config"].get("mode") == "doc":
+        payload["baseline_test_failures"] = None
+        payload["baseline_test_command"] = None
+        payload["baseline_test_note"] = "Test baseline not applicable in doc mode."
+    else:
+        baseline = _capture_test_baseline(Path(state["config"]["project_dir"]), state.get("config", {}))
+        payload.update(baseline)
+        _ensure_verification_task(payload, state)
     _reconcile_validation_after_mutation(payload)
     atomic_write_json(plan_dir / "finalize.json", payload)
     atomic_write_json(plan_dir / "finalize_snapshot.json", payload)
@@ -719,6 +724,22 @@ def handle_init(root: Path, args: argparse.Namespace) -> StepResponse:
     project_dir = Path(args.project_dir).expanduser().resolve()
     if not project_dir.exists() or not project_dir.is_dir():
         raise CliError("invalid_project_dir", f"Project directory does not exist: {project_dir}")
+    mode = getattr(args, "mode", "code") or "code"
+    raw_output_path = getattr(args, "output", None)
+    normalized_output_path: str | None = None
+    if mode == "doc" and not raw_output_path:
+        raise CliError("invalid_args", "--output is required when --mode doc is selected")
+    if raw_output_path:
+        output_candidate = Path(raw_output_path)
+        if output_candidate.is_absolute():
+            raise CliError("invalid_args", "--output must be a relative path inside the project directory")
+        if any(part == ".." for part in output_candidate.parts):
+            raise CliError("invalid_args", "--output must not contain '..' path traversal")
+        resolved_output_path = (project_dir / output_candidate).resolve()
+        try:
+            normalized_output_path = resolved_output_path.relative_to(project_dir).as_posix()
+        except ValueError as exc:
+            raise CliError("invalid_args", "--output must stay within the project directory") from exc
     robustness = getattr(args, "robustness", None)
     if robustness is None:
         robustness = get_effective("execution", "robustness")
@@ -745,6 +766,7 @@ def handle_init(root: Path, args: argparse.Namespace) -> StepResponse:
             "project_dir": str(project_dir),
             "auto_approve": auto_approve,
             "robustness": robustness,
+            "mode": mode,
             "agent": "hermes" if getattr(args, "hermes", None) is not None else "",
         },
         "sessions": {},
@@ -761,6 +783,8 @@ def handle_init(root: Path, args: argparse.Namespace) -> StepResponse:
         },
         "last_gate": {},
     }
+    if normalized_output_path is not None:
+        state["config"]["output_path"] = normalized_output_path
     append_history(
         state,
         make_history_entry(
@@ -1337,7 +1361,8 @@ def _is_rework_reexecution(state: PlanState) -> bool:
 def handle_execute(root: Path, args: argparse.Namespace) -> StepResponse:
     with load_plan_locked(root, args.plan, step="execute") as (plan_dir, state):
         require_state(state, "execute", {STATE_FINALIZED})
-        if not args.confirm_destructive:
+        plan_mode = state["config"].get("mode", "code")
+        if plan_mode != "doc" and not args.confirm_destructive:
             raise CliError("missing_confirmation", "Execute requires --confirm-destructive")
         auto_approve = bool(state["config"].get("auto_approve", False))
         if getattr(args, "user_approved", False):
@@ -1386,6 +1411,11 @@ def handle_execute(root: Path, args: argparse.Namespace) -> StepResponse:
             save_state(plan_dir, state)
             raise
         clear_active_step(state, run_id=run_id)
+        if plan_mode == "doc" and response.get("state") == STATE_EXECUTED:
+            from megaplan.doc_assembly import assemble_doc
+            output_path = Path(state["config"]["project_dir"]) / state["config"]["output_path"]
+            finalize_data = read_json(plan_dir / "finalize.json")
+            assemble_doc(plan_dir, output_path, finalize_data)
         robustness = configured_robustness(state)
         if not workflow_includes_step(robustness, "review") and response.get("state") == STATE_EXECUTED:
             # Preserve the data-parity invariant even when review is skipped by robustness.
@@ -1577,8 +1607,9 @@ def handle_review(root: Path, args: argparse.Namespace) -> StepResponse:
     with load_plan_locked(root, args.plan, step="review") as (plan_dir, state):
         require_state(state, "review", {STATE_EXECUTED})
         robustness = configured_robustness(state)
+        plan_mode = state["config"].get("mode", "code")
         pre_check_flags: list[dict[str, Any]] = []
-        if robustness in {"standard", "robust", "superrobust"}:
+        if robustness in {"standard", "robust", "superrobust"} and plan_mode != "doc":
             pre_check_flags = run_pre_checks(plan_dir, state, Path(state["config"]["project_dir"]))
         if robustness in {"standard", "light", "robust"}:
             resolved = None

--- a/megaplan/hermes_worker.py
+++ b/megaplan/hermes_worker.py
@@ -191,7 +191,7 @@ def parse_agent_output(
 
     # Fallback: for execute phase, reconstruct from tool calls + git diff
     if payload is None and step == "execute":
-        payload = _reconstruct_execute_payload(messages, project_dir, plan_dir)
+        payload = _reconstruct_execute_payload(messages, project_dir, plan_dir, mode=plan_mode)
         if payload is not None:
             print(f"[hermes-worker] Reconstructed execute payload from tool calls", file=sys.stderr)
 
@@ -291,7 +291,9 @@ def run_hermes_step(
     from hermes_state import SessionDB
 
     project_dir = Path(state["config"]["project_dir"])
-    schema_name = STEP_SCHEMA_FILENAMES[step]
+    plan_mode = state["config"].get("mode", "code")
+    from megaplan.schemas import get_execution_schema_key
+    schema_name = get_execution_schema_key(plan_mode) if step == "execute" else STEP_SCHEMA_FILENAMES[step]
     schema = read_json(schemas_root(root) / schema_name)
     output_path: Path | None = None
 
@@ -481,7 +483,7 @@ def run_hermes_step(
         except CliError as error:
             # For execute, try reconstructed payload if validation fails
             if step == "execute":
-                reconstructed = _reconstruct_execute_payload(messages, project_dir, plan_dir)
+                reconstructed = _reconstruct_execute_payload(messages, project_dir, plan_dir, mode=plan_mode)
                 if reconstructed is not None:
                     try:
                         validate_payload(step, reconstructed)
@@ -621,6 +623,8 @@ def _reconstruct_execute_payload(
     messages: list,
     project_dir: Path,
     plan_dir: Path,
+    *,
+    mode: str = "code",
 ) -> dict | None:
     """Reconstruct an execute phase response from tool calls and git state.
 
@@ -655,7 +659,6 @@ def _reconstruct_execute_payload(
             if name in ("write_file", "patch", "edit_file", "apply_patch"):
                 path = args.get("path", "")
                 if isinstance(path, str) and path:
-                    # Make relative to project dir
                     try:
                         rel = str(Path(path).relative_to(project_dir))
                     except ValueError:
@@ -666,38 +669,37 @@ def _reconstruct_execute_payload(
                 if isinstance(cmd, str) and cmd:
                     commands_run.append(cmd)
 
-    # Also check git diff for files changed
-    try:
-        diff_result = subprocess.run(
-            ["git", "diff", "--name-only", "HEAD"],
-            cwd=project_dir,
-            capture_output=True, text=True, timeout=10, check=False,
-        )
-        if diff_result.returncode == 0:
-            for line in diff_result.stdout.splitlines():
-                if line.strip():
-                    files_changed.add(line.strip())
-    except Exception:
-        pass
+    if mode != "doc":
+        try:
+            diff_result = subprocess.run(
+                ["git", "diff", "--name-only", "HEAD"],
+                cwd=project_dir,
+                capture_output=True, text=True, timeout=10, check=False,
+            )
+            if diff_result.returncode == 0:
+                for line in diff_result.stdout.splitlines():
+                    if line.strip():
+                        files_changed.add(line.strip())
+        except Exception:
+            pass
 
-    # Check for untracked files too
-    try:
-        status_result = subprocess.run(
-            ["git", "status", "--porcelain"],
-            cwd=project_dir,
-            capture_output=True, text=True, timeout=10, check=False,
-        )
-        if status_result.returncode == 0:
-            for line in status_result.stdout.splitlines():
-                if line.startswith("?? ") or line.startswith("A  ") or line.startswith("M  "):
-                    fname = line[3:].strip()
-                    if fname and not fname.startswith(".megaplan/"):
-                        files_changed.add(fname)
-    except Exception:
-        pass
+        try:
+            status_result = subprocess.run(
+                ["git", "status", "--porcelain"],
+                cwd=project_dir,
+                capture_output=True, text=True, timeout=10, check=False,
+            )
+            if status_result.returncode == 0:
+                for line in status_result.stdout.splitlines():
+                    if line.startswith("?? ") or line.startswith("A  ") or line.startswith("M  "):
+                        fname = line[3:].strip()
+                        if fname and not fname.startswith(".megaplan/"):
+                            files_changed.add(fname)
+        except Exception:
+            pass
 
     if not tool_calls and not files_changed:
-        return None  # Nothing happened, can't reconstruct
+        return None
 
     # Try to read checkpoint file for task updates
     task_updates = []
@@ -710,6 +712,24 @@ def _reconstruct_execute_payload(
                 task_updates.extend(updates)
         except Exception:
             pass
+
+    if mode == "doc":
+        sections_written = sorted(
+            {
+                section
+                for tu in task_updates
+                for section in tu.get("sections_written", [])
+                if isinstance(section, str) and section.strip()
+            }
+        )
+        return {
+            "output": f"[Reconstructed from tool calls] Made {len(tool_calls)} tool calls, wrote {len(sections_written)} sections.",
+            "sections_written": sections_written,
+            "commands_run": [],
+            "deviations": ["Execute response reconstructed from tool calls — model failed to produce JSON report."],
+            "task_updates": task_updates,
+            "sense_check_acknowledgments": [],
+        }
 
     files_list = sorted(files_changed)
     return {

--- a/megaplan/prompts/__init__.py
+++ b/megaplan/prompts/__init__.py
@@ -33,13 +33,16 @@ from .execute import (
 )
 from .finalize import _finalize_prompt
 from .gate import _collect_critique_summaries, _flag_summary, _gate_prompt
+from .execute_doc import _execute_doc_batch_prompt, _execute_doc_prompt
 from .planning import PLAN_TEMPLATE, _plan_prompt, _prep_prompt
+from .prep_doc import _prep_doc_prompt
 from .review import (
     _review_prompt,
     _settled_decisions_block,
     _settled_decisions_instruction,
     _write_review_template,
 )
+from .review_doc import _review_doc_prompt
 
 _PromptBuilder = Callable[..., str]
 
@@ -107,12 +110,33 @@ def _prepend_harness_guard(prompt: str) -> str:
     return f"{_NESTED_HARNESS_GUARD}\n\n{prompt}"
 
 
+def _resolve_builder(
+    builders: dict[str, _PromptBuilder], step: str, state: PlanState, agent_label: str
+) -> _PromptBuilder:
+    mode = state.get("config", {}).get("mode", "code")
+    if mode == "doc":
+        if step == "prep":
+            return _prep_doc_prompt
+        if step == "execute":
+            return _execute_doc_prompt
+        if step == "review":
+            return partial(
+                _review_doc_prompt,
+                review_intro="Review the document critically against user intent and observable success criteria.",
+                criteria_guidance="Judge against the success criteria, not plan elegance.",
+                task_guidance="Review each task by cross-referencing the executor's per-task `sections_written` against the output document.",
+                sense_check_guidance="Review every sense check explicitly. Confirm concise executor acknowledgments when they are specific; dig deeper only when they are perfunctory or contradicted by the document.",
+            )
+    builder = builders.get(step)
+    if builder is None:
+        raise CliError("unsupported_step", f"Unsupported {agent_label} step '{step}'")
+    return builder
+
+
 def create_claude_prompt(
     step: str, state: PlanState, plan_dir: Path, root: Path | None = None, **prompt_kwargs: object
 ) -> str:
-    builder = _CLAUDE_PROMPT_BUILDERS.get(step)
-    if builder is None:
-        raise CliError("unsupported_step", f"Unsupported Claude step '{step}'")
+    builder = _resolve_builder(_CLAUDE_PROMPT_BUILDERS, step, state, "Claude")
     if step == "review":
         return _prepend_harness_guard(builder(state, plan_dir, **prompt_kwargs))
     if step in {"prep", "critique", "gate", "finalize", "execute"}:
@@ -123,9 +147,7 @@ def create_claude_prompt(
 def create_codex_prompt(
     step: str, state: PlanState, plan_dir: Path, root: Path | None = None, **prompt_kwargs: object
 ) -> str:
-    builder = _CODEX_PROMPT_BUILDERS.get(step)
-    if builder is None:
-        raise CliError("unsupported_step", f"Unsupported Codex step '{step}'")
+    builder = _resolve_builder(_CODEX_PROMPT_BUILDERS, step, state, "Codex")
     if step == "review":
         return _prepend_harness_guard(builder(state, plan_dir, **prompt_kwargs))
     if step in {"prep", "critique", "gate", "finalize", "execute"}:
@@ -136,9 +158,7 @@ def create_codex_prompt(
 def create_hermes_prompt(
     step: str, state: PlanState, plan_dir: Path, root: Path | None = None, **prompt_kwargs: object
 ) -> str:
-    builder = _HERMES_PROMPT_BUILDERS.get(step)
-    if builder is None:
-        raise CliError("unsupported_step", f"Unsupported Hermes step '{step}'")
+    builder = _resolve_builder(_HERMES_PROMPT_BUILDERS, step, state, "Hermes")
     if step == "review":
         return _prepend_harness_guard(builder(state, plan_dir, **prompt_kwargs))
     if step in {"prep", "critique", "gate", "finalize", "execute"}:
@@ -157,6 +177,8 @@ __all__ = [
     "_escalated_debt_for_prompt",
     "_execute_approval_note",
     "_execute_batch_prompt",
+    "_execute_doc_batch_prompt",
+    "_execute_doc_prompt",
     "_execute_nudges",
     "_execute_prompt",
     "_execute_rerun_guidance",
@@ -169,7 +191,9 @@ __all__ = [
     "_grouped_debt_for_prompt",
     "_plan_prompt",
     "_planning_debt_block",
+    "_prep_doc_prompt",
     "_prep_prompt",
+    "_review_doc_prompt",
     "_write_critique_template",
     "_render_prep_block",
     "_resolve_prompt_root",

--- a/megaplan/prompts/execute_doc.py
+++ b/megaplan/prompts/execute_doc.py
@@ -1,0 +1,270 @@
+"""Doc-mode execute prompt builders."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+from typing import Any
+
+from megaplan._core import (
+    batch_artifact_path,
+    compute_task_batches,
+    configured_robustness,
+    intent_and_notes_block,
+    json_dump,
+    latest_plan_meta_path,
+    read_json,
+)
+from megaplan.types import PlanState
+
+from ._shared import _debt_watch_lines, _render_prep_block
+from .execute import (
+    _execute_approval_note,
+    _execute_nudges,
+    _execute_rerun_guidance,
+    _execute_review_block,
+)
+
+_EXECUTE_DOC_OUTPUT_SHAPE_EXAMPLE = textwrap.dedent(
+    """
+    ```json
+    {
+      "output": "Authored the planned document sections.",
+      "files_changed": [],
+      "commands_run": [],
+      "deviations": [],
+      "task_updates": [
+        {
+          "task_id": "T1",
+          "status": "done",
+          "executor_notes": "Wrote the introduction section covering project motivation and scope.",
+          "sections_written": ["introduction"]
+        },
+        {
+          "task_id": "T2",
+          "status": "done",
+          "executor_notes": "Drafted the problem statement with three concrete examples from the codebase.",
+          "sections_written": ["problem-statement"]
+        },
+        {
+          "task_id": "T3",
+          "status": "skipped",
+          "executor_notes": "Skipped because the milestones depend on unresolved scope questions.",
+          "sections_written": []
+        }
+      ],
+      "sense_check_acknowledgments": [
+        {
+          "sense_check_id": "SC1",
+          "executor_note": "Confirmed the introduction names the target audience and links to prior art."
+        }
+      ]
+    }
+    ```
+    """
+).strip()
+
+_EXECUTE_DOC_REQUIREMENTS_TEMPLATE = textwrap.dedent(
+    """
+    Requirements:
+    - You are an author, not a coder. Your deliverable is document text, not code changes.
+    - Write each assigned section to the configured output path. This is the only file you should create or modify.
+    - Adapt if the document structure needs adjustment — report deviations explicitly.
+    - Do not over-engineer beyond what the plan prescribes.
+    - Output concrete sections written per task. `sections_written` means section IDs you authored — not sections you read or referenced.
+    - Use the tasks in `finalize.json` as the execution boundary.
+    - Best-effort progress checkpointing: if `{checkpoint_path}` is writable, then after each completed task read the full file, update that task's `status`, `executor_notes`, and `sections_written`, and write the full file back. Do NOT write to `finalize.json` directly — the harness owns that file.
+    - Best-effort sense-check checkpointing: if `{checkpoint_path}` is writable, then after each sense check acknowledgment read the full file again, update that sense check's `executor_note`, and write the full file back.
+    - Always use full read-modify-write updates for `{checkpoint_path}` instead of partial edits. If the sandbox blocks writes, continue execution and rely on the structured output below.
+    - Structured output remains the authoritative final summary for this step. Disk writes are progress checkpoints for timeout recovery only.
+    - Return `task_updates` with one object per completed or skipped task.
+    - `task_updates[].status` must be either `done` or `skipped`. Never return `pending` in execute output.
+    - Return `sense_check_acknowledgments` with one object per sense check.
+    - Keep `executor_notes` verification-focused: explain why the section content is correct and complete.
+    - Follow this JSON shape exactly:
+    {output_shape}
+    """
+).strip()
+
+
+def _execute_doc_prompt(state: PlanState, plan_dir: Path, root: Path | None = None) -> str:
+    project_dir = Path(state["config"]["project_dir"])
+    output_path = state["config"].get("output_path", "output.md")
+    prep_block, prep_instruction = _render_prep_block(plan_dir)
+    finalize_data = read_json(plan_dir / "finalize.json")
+    checkpoint_path = str(plan_dir / "execution_checkpoint.json")
+    latest_meta = read_json(latest_plan_meta_path(plan_dir, state))
+    gate = read_json(plan_dir / "gate.json")
+    robustness = configured_robustness(state)
+    prior_review_block = _execute_review_block(plan_dir)
+    rerun_guidance = _execute_rerun_guidance(plan_dir, finalize_data)
+    approval_note = _execute_approval_note(state)
+    execution_nudges = _execute_nudges(finalize_data, plan_dir, root)
+    requirements_block = _EXECUTE_DOC_REQUIREMENTS_TEMPLATE.format(
+        checkpoint_path=checkpoint_path,
+        output_shape=_EXECUTE_DOC_OUTPUT_SHAPE_EXAMPLE,
+    )
+    return textwrap.dedent(
+        f"""
+        Author the planned document sections.
+
+        Project directory:
+        {project_dir}
+
+        Output path (write all sections here):
+        {output_path}
+
+        {prep_block}
+
+        {prep_instruction}
+
+        {intent_and_notes_block(state)}
+
+        Execution tracking source of truth (`finalize.json`):
+        {json_dump(finalize_data).strip()}
+
+        Absolute checkpoint path for best-effort progress checkpoints (NOT `finalize.json`):
+        {checkpoint_path}
+
+        Plan metadata:
+        {json_dump(latest_meta).strip()}
+
+        Gate summary:
+        {json_dump(gate).strip()}
+
+        {prior_review_block}
+
+        {rerun_guidance}
+
+        {approval_note}
+        Robustness level: {robustness}.
+
+        {requirements_block}
+
+        {execution_nudges}
+        """
+    ).strip()
+
+
+def _execute_doc_batch_prompt(
+    state: PlanState,
+    plan_dir: Path,
+    batch_task_ids: list[str],
+    completed_task_ids: set[str] | None = None,
+    root: Path | None = None,
+) -> str:
+    completed = set(completed_task_ids or set())
+    output_path = state["config"].get("output_path", "output.md")
+    finalize_data = read_json(plan_dir / "finalize.json")
+    all_tasks = finalize_data.get("tasks", [])
+    tasks_by_id = {
+        task["id"]: task
+        for task in all_tasks
+        if isinstance(task, dict) and isinstance(task.get("id"), str)
+    }
+    batch_tasks = [
+        tasks_by_id[task_id] for task_id in batch_task_ids if task_id in tasks_by_id
+    ]
+    completed_tasks = [
+        task
+        for task_id, task in tasks_by_id.items()
+        if task_id in completed and task_id not in set(batch_task_ids)
+    ]
+    batch_sense_checks = [
+        sense_check
+        for sense_check in finalize_data.get("sense_checks", [])
+        if sense_check.get("task_id") in set(batch_task_ids)
+    ]
+    batch_sense_check_ids = [
+        sense_check["id"]
+        for sense_check in batch_sense_checks
+        if isinstance(sense_check.get("id"), str)
+    ]
+    global_batches = compute_task_batches(all_tasks)
+    batch_number = next(
+        (
+            index + 1
+            for index, batch in enumerate(global_batches)
+            if batch == batch_task_ids
+        ),
+        1,
+    )
+    batch_total = len(global_batches) or 1
+    checkpoint_path = str(batch_artifact_path(plan_dir, batch_number))
+    prior_batch_deviations = "None"
+    if batch_number > 1:
+        prior_batch_artifact = batch_artifact_path(plan_dir, batch_number - 1)
+        if prior_batch_artifact.exists():
+            try:
+                prior_batch_payload = read_json(prior_batch_artifact)
+            except (OSError, ValueError):
+                prior_batch_payload = {}
+            raw_deviations = prior_batch_payload.get("deviations", [])
+            if isinstance(raw_deviations, list):
+                deviations = [item for item in raw_deviations if isinstance(item, str)]
+                if deviations:
+                    prior_batch_deviations = json_dump(deviations).strip()
+    approval_note = _execute_approval_note(state)
+    debt_watch_items = _debt_watch_lines(plan_dir, root)
+    debt_watch_block = (
+        "\n".join(
+            [
+                "Debt watch items (do not make these worse):",
+                *[f"- {item}" for item in debt_watch_items],
+            ]
+        )
+        if debt_watch_items
+        else "Debt watch items (do not make these worse):\n- None."
+    )
+    return textwrap.dedent(
+        f"""
+        Author the planned document sections.
+
+        Project directory:
+        {Path(state["config"]["project_dir"])}
+
+        Output path (write all sections here):
+        {output_path}
+
+        {intent_and_notes_block(state)}
+
+        Batch framing:
+        - Execute batch {batch_number} of {batch_total}.
+        - Actionable task IDs for this batch: {batch_task_ids}
+        - Already completed task IDs available as dependency context: {sorted(completed)}
+
+        Actionable tasks for this batch:
+        {json_dump(batch_tasks).strip()}
+
+        Completed task context (already satisfied, do not re-execute unless directly required by current edits):
+        {json_dump(completed_tasks).strip()}
+
+        Prior batch deviations (address if applicable):
+        {prior_batch_deviations}
+
+        Batch-scoped sense checks:
+        {json_dump(batch_sense_checks).strip()}
+
+        Full execution tracking source of truth (`finalize.json`):
+        {json_dump(finalize_data).strip()}
+
+        {debt_watch_block}
+
+        {approval_note}
+        Robustness level: {configured_robustness(state)}.
+
+        Requirements:
+        - You are an author. Write document sections to the configured output path.
+        - Execute only the actionable tasks in this batch.
+        - Treat completed tasks as dependency context, not new work.
+        - Return structured JSON only.
+        - Only produce `task_updates` for these tasks: [{", ".join(batch_task_ids)}]
+        - Only produce `sense_check_acknowledgments` for these sense checks: [{", ".join(batch_sense_check_ids)}]
+        - Do not include updates for tasks or sense checks outside this batch.
+        - Keep `executor_notes` verification-focused.
+        - Best-effort progress checkpointing: if `{checkpoint_path}` is writable, checkpoint task and sense-check updates there (not `finalize.json`). The harness owns `finalize.json`.
+        - `sections_written` replaces `files_changed` in task_updates. List the section IDs you authored, not file paths.
+        - Follow this JSON shape:
+        {_EXECUTE_DOC_OUTPUT_SHAPE_EXAMPLE}
+        """
+    ).strip()

--- a/megaplan/prompts/finalize.py
+++ b/megaplan/prompts/finalize.py
@@ -28,6 +28,23 @@ def _finalize_prompt(state: PlanState, plan_dir: Path, root: Path | None = None)
     flag_registry = load_flag_registry(plan_dir)
     critique_history = _collect_critique_summaries(plan_dir, state["iteration"])
     debt_block = _finalize_debt_block(plan_dir, root)
+    plan_mode = state.get("config", {}).get("mode", "code")
+    if plan_mode == "doc":
+        task_field_guidance = textwrap.dedent(
+            """
+            - Each task represents a document section or group of sections to author.
+            - Task objects use `sections_written` (array of section IDs) instead of `files_changed`/`commands_run`.
+            - Do NOT include `files_changed` or `commands_run` in task descriptions — the executor writes to a single output file.
+            - Do NOT include `baseline_test_failures` or `baseline_test_command` — there are no tests for doc mode.
+            - The FINAL task should be a review/polish pass over the assembled document, not a test run.
+            """
+        ).strip()
+    else:
+        task_field_guidance = textwrap.dedent(
+            """
+            - The FINAL task MUST always be to run tests and verify the changes work. If specific test IDs or commands are mentioned in the original task, include them. Otherwise, the executor should find and run the tests most relevant to the files changed. If any test fails, read the error, fix the code, and re-run until they pass. Do NOT create new test files — run the project's existing test suite. Additionally, the executor should write a short throwaway script that reproduces the specific bug described in the task, run it to confirm the fix works, then delete the script.
+            """
+        ).strip()
     return textwrap.dedent(
         f"""
         You are preparing an execution-ready briefing document from the approved plan.
@@ -94,6 +111,6 @@ def _finalize_prompt(state: PlanState, plan_dir: Path, root: Path | None = None)
         - Preserve information that strong existing artifacts already capture well: execution ordering, watch-outs, reviewer checkpoints, and practical context.
         - The structured output should be self-contained: an executor reading only `finalize.json` should have everything needed to work.
         - Keep the task count proportional to the work. A simple 1-2 file fix should be 2 tasks: (1) apply the fix, (2) run tests. Do NOT create separate "inspect" or "read" tasks for simple changes — the executor can read and fix in one step. Only create more tasks when the work has genuinely independent stages.
-        - The FINAL task MUST always be to run tests and verify the changes work. If specific test IDs or commands are mentioned in the original task, include them. Otherwise, the executor should find and run the tests most relevant to the files changed. If any test fails, read the error, fix the code, and re-run until they pass. Do NOT create new test files — run the project's existing test suite. Additionally, the executor should write a short throwaway script that reproduces the specific bug described in the task, run it to confirm the fix works, then delete the script.
+        - {task_field_guidance}
         """
     ).strip()

--- a/megaplan/prompts/prep_doc.py
+++ b/megaplan/prompts/prep_doc.py
@@ -1,0 +1,57 @@
+"""Doc-mode prep prompt builder."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+from megaplan.types import PlanState
+
+
+def _prep_doc_prompt(state: PlanState, plan_dir: Path, root: Path | None = None) -> str:
+    del root
+    project_dir = Path(state["config"]["project_dir"])
+    output_path = plan_dir / "prep.json"
+    return textwrap.dedent(
+        f"""
+        Prepare a concise engineering brief for the document authoring task below. This brief will be the primary context for all subsequent planning and execution.
+
+        Task:
+        {state["idea"]}
+
+        Project: {project_dir}
+        Output file: {output_path}
+
+        First, assess: does this task need investigation?
+
+        Set "skip": true if ALL of these are true:
+        - The document's scope and audience are clearly specified
+        - No research or prior-art review is needed
+        - The sections and structure are obvious from the task description
+
+        Set "skip": false if ANY of these are true:
+        - The task references prior art, existing docs, or related work to review
+        - Multiple structural approaches seem possible
+        - The task involves concepts, terminology, or domain knowledge you'd need to look up
+        - The task references repository code that informs the document's content
+
+        If skipping, leave everything else empty. The original task description will be used directly.
+        If not skipping, fill in the brief:
+        1. Identify what sources, prior art, and related documents should inform this document.
+        2. If the project directory contains relevant code, docs, or config that the document should reference, search for them.
+        3. Extract evidence from the task description — audience, purpose, constraints, deliverable format.
+        4. Check whether similar documents already exist in the project that could serve as templates or that this document should reference.
+        5. If the task describes a problem or decision to document, trace the full context — what alternatives exist, what constraints apply, who the stakeholders are.
+        6. Identify the key questions the document must answer for its audience.
+
+        Brief fields:
+        - skip: true if no investigation needed, false if brief has useful content.
+        - task_summary: What the document should accomplish, in 2-3 sentences.
+        - key_evidence: Facts from the task description and project that inform the document's content.
+        - relevant_code: File paths and key structures in the project that the document should reference or describe. Use this to capture source material, not code to change.
+        - test_expectations: For doc mode, use this to list key claims or sections that reviewers should verify. Each entry's test_id is a section name, status is "expected", and what_it_checks describes what the section must cover.
+        - constraints: Audience, tone, length limits, format requirements, or content that must be included.
+        - suggested_approach: A concrete document outline or structural approach grounded in what you found.
+
+        """
+    ).strip()

--- a/megaplan/prompts/review.py
+++ b/megaplan/prompts/review.py
@@ -81,10 +81,21 @@ def _parallel_review_context(state: PlanState, plan_dir: Path) -> dict[str, Any]
     settled_decisions = gate.get("settled_decisions", [])
     if not isinstance(settled_decisions, list):
         settled_decisions = []
+    plan_mode = state["config"].get("mode", "code")
+    if plan_mode == "doc":
+        output_path = Path(state["config"]["output_path"])
+        if not output_path.is_absolute():
+            output_path = project_dir / output_path
+        try:
+            git_diff = output_path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            git_diff = ""
+    else:
+        git_diff = collect_git_diff_patch(project_dir)
     return {
         "project_dir": project_dir,
         "intent_block": intent_and_notes_block(state),
-        "git_diff": collect_git_diff_patch(project_dir),
+        "git_diff": git_diff,
         "finalize_data": read_json(plan_dir / "finalize.json"),
         "settled_decisions": settled_decisions,
     }

--- a/megaplan/prompts/review_doc.py
+++ b/megaplan/prompts/review_doc.py
@@ -1,0 +1,177 @@
+"""Doc-mode review prompt builder."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+from typing import Any
+
+from megaplan._core import (
+    intent_and_notes_block,
+    json_dump,
+    latest_plan_meta_path,
+    latest_plan_path,
+    load_flag_registry,
+    read_json,
+)
+from megaplan.types import PlanState
+
+from .review import (
+    _settled_decisions_block,
+    _settled_decisions_instruction,
+)
+
+
+def _review_doc_prompt(
+    state: PlanState,
+    plan_dir: Path,
+    *,
+    review_intro: str,
+    criteria_guidance: str,
+    task_guidance: str,
+    sense_check_guidance: str,
+    pre_check_flags: list[dict[str, Any]] | None = None,
+) -> str:
+    project_dir = Path(state["config"]["project_dir"])
+    output_path = state["config"].get("output_path", "output.md")
+    resolved_output = Path(project_dir) / output_path
+    output_content = ""
+    if resolved_output.exists():
+        try:
+            output_content = resolved_output.read_text(encoding="utf-8")
+        except OSError:
+            output_content = "(could not read output file)"
+    else:
+        output_content = "(output file does not exist yet)"
+
+    latest_plan = latest_plan_path(plan_dir, state).read_text(encoding="utf-8")
+    latest_meta = read_json(latest_plan_meta_path(plan_dir, state))
+    execution = read_json(plan_dir / "execution.json")
+    gate = read_json(plan_dir / "gate.json")
+    finalize_data = read_json(plan_dir / "finalize.json")
+    settled_decisions_block = _settled_decisions_block(gate)
+    settled_decisions_instruction = _settled_decisions_instruction(gate)
+
+    flag_reverify_items: list[dict[str, str]] = []
+    for flag in load_flag_registry(plan_dir).get("flags", []):
+        if not isinstance(flag, dict):
+            continue
+        status = str(flag.get("status", "open"))
+        if status not in {"open", "addressed", "verified", "disputed"}:
+            continue
+        flag_reverify_items.append(
+            {
+                "id": str(flag.get("id", "")),
+                "concern": str(flag.get("concern", "")),
+                "severity": str(flag.get("severity") or flag.get("severity_hint") or "uncertain"),
+                "status": status,
+            }
+        )
+    flag_reverify_block = ""
+    if flag_reverify_items:
+        flag_reverify_block = textwrap.dedent(
+            f"""
+            Critique flags to re-verify against the output document:
+            {json_dump(flag_reverify_items).strip()}
+
+            For each flag above, verify whether the final document actually addresses the concern.
+            A flag is resolved only if the document content directly addresses the concern.
+            Add resolved flag IDs to `verified_flag_ids`.
+            For any unresolved flag, add a `rework_items` entry with `task_id: "REVIEW"`, `issue`, `expected`, `actual`, `evidence_file`, `flag_id`, and `source: "review_flag_reverify"`.
+            """
+        ).strip()
+    pre_check_block = ""
+    if pre_check_flags:
+        pre_check_block = textwrap.dedent(
+            f"""
+            Advisory mechanical pre-check flags:
+            {json_dump(pre_check_flags).strip()}
+
+            Copy this list verbatim into the output `pre_check_flags` field.
+            """
+        ).strip()
+    extra_sections = ""
+    if flag_reverify_block:
+        extra_sections += f"\n\n{flag_reverify_block}"
+    if pre_check_block:
+        extra_sections += f"\n\n{pre_check_block}"
+    return textwrap.dedent(
+        f"""
+        {review_intro}
+
+        Project directory:
+        {project_dir}
+
+        Output file path:
+        {output_path}
+
+        {intent_and_notes_block(state)}
+
+        Approved plan:
+        {latest_plan}
+
+        Execution tracking state (`finalize.json`):
+        {json_dump(finalize_data).strip()}
+
+        Plan metadata:
+        {json_dump(latest_meta).strip()}
+
+        Gate summary:
+        {json_dump(gate).strip()}
+
+        {settled_decisions_block}{extra_sections}
+
+        Execution summary:
+        {json_dump(execution).strip()}
+
+        Output document content:
+        {output_content}
+
+        Requirements:
+        - Read the output file above and judge it against the success criteria.
+        - {criteria_guidance}
+        - Trust executor evidence by default. Dig deeper only where the document content or vague notes make a claim ambiguous.
+        - Each criterion has a `priority` (`must`, `should`, or `info`). Apply these rules:
+          - `must` criteria are hard gates. A `must` criterion that fails means `needs_rework`.
+          - `should` criteria are quality targets. If the spirit is met but the letter is not, mark `pass` with evidence explaining the gap. Only mark `fail` if the intent was clearly missed. A `should` failure alone does NOT require `needs_rework`.
+          - `info` criteria are for human reference. Mark them `waived` with a note — do not evaluate them.
+          - If a criterion (any priority) cannot be verified in this context, mark it `waived` with an explanation.
+        - Set `review_verdict` to `needs_rework` only when at least one `must` criterion fails or actual document work is incomplete. Use `approved` when all `must` criteria pass, even if some `should` criteria are flagged.
+        {settled_decisions_instruction}
+        - {task_guidance}
+        - {sense_check_guidance}
+        - Follow this JSON shape exactly:
+        ```json
+        {{
+          "review_verdict": "approved",
+          "criteria": [
+            {{
+              "name": "Document covers all planned sections",
+              "priority": "must",
+              "pass": "pass",
+              "evidence": "All 5 planned sections are present and non-empty."
+            }}
+          ],
+          "issues": [],
+          "rework_items": [],
+          "summary": "Approved. All must criteria pass.",
+          "task_verdicts": [
+            {{
+              "task_id": "T1",
+              "reviewer_verdict": "Pass. Introduction section covers scope and audience as planned.",
+              "evidence_files": []
+            }}
+          ],
+          "sense_check_verdicts": [
+            {{
+              "sense_check_id": "SC1",
+              "verdict": "Confirmed. The introduction references prior art as required."
+            }}
+          ]
+        }}
+        ```
+        - `rework_items` must be an array of structured rework directives. When `review_verdict` is `needs_rework`, populate one entry per issue.
+        - `issues` must still be populated as a flat one-line-per-item summary derived from `rework_items`.
+        - When approved, both `issues` and `rework_items` should be empty arrays.
+        """
+    ).strip()

--- a/megaplan/schemas.py
+++ b/megaplan/schemas.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import Any
 
 
@@ -208,6 +209,7 @@ SCHEMAS: dict[str, dict[str, Any]] = {
                                 "completeness",
                                 "performance",
                                 "maintainability",
+                                "doc-quality",
                                 "other",
                             ],
                         },
@@ -498,6 +500,31 @@ SCHEMAS: dict[str, dict[str, Any]] = {
         ],
     },
 }
+
+
+def _build_execution_doc_schema() -> dict[str, Any]:
+    schema = deepcopy(SCHEMAS["execution.json"])
+    schema["properties"]["sections_written"] = schema["properties"].pop("files_changed")
+    task_update_schema = schema["properties"]["task_updates"]["items"]
+    task_update_schema["properties"]["sections_written"] = task_update_schema["properties"].pop("files_changed")
+    task_update_schema["properties"].pop("commands_run", None)
+    task_update_schema["required"] = ["task_id", "status", "executor_notes", "sections_written"]
+    schema["required"] = [
+        "output",
+        "sections_written",
+        "commands_run",
+        "deviations",
+        "task_updates",
+        "sense_check_acknowledgments",
+    ]
+    return schema
+
+
+SCHEMAS["execution_doc.json"] = _build_execution_doc_schema()
+
+
+def get_execution_schema_key(mode: str) -> str:
+    return "execution_doc.json" if mode == "doc" else "execution.json"
 
 
 def _preserve_explicit_required(path: tuple[str, ...]) -> bool:

--- a/megaplan/types.py
+++ b/megaplan/types.py
@@ -29,6 +29,8 @@ class PlanConfig(TypedDict, total=False):
     project_dir: str
     auto_approve: bool
     robustness: str
+    mode: str
+    output_path: str
     agents: dict[str, str]
 
 

--- a/megaplan/workers.py
+++ b/megaplan/workers.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 from megaplan.checks import build_empty_template, checks_for_robustness
-from megaplan.schemas import SCHEMAS
+from megaplan.schemas import SCHEMAS, get_execution_schema_key
 from megaplan.types import (
     CliError,
     DEFAULT_AGENT_ROUTING,
@@ -1203,7 +1203,8 @@ def run_claude_step(
         return mock_worker_output(step, state, plan_dir, prompt_override=prompt_override, prompt_kwargs=prompt_kwargs)
     project_dir = Path(state["config"]["project_dir"])
     work_dir = resolve_work_dir(state)
-    schema_name = STEP_SCHEMA_FILENAMES[step]
+    plan_mode = state["config"].get("mode", "code")
+    schema_name = get_execution_schema_key(plan_mode) if step == "execute" else STEP_SCHEMA_FILENAMES[step]
     schema_text = json.dumps(read_json(schemas_root(root) / schema_name))
     session_key = session_key_for(step, "claude")
     session = state["sessions"].get(session_key, {})
@@ -1307,7 +1308,9 @@ def run_codex_step(
         return mock_worker_output(step, state, plan_dir, prompt_override=prompt_override, prompt_kwargs=prompt_kwargs)
     project_dir = Path(state["config"]["project_dir"])
     work_dir = resolve_work_dir(state)
-    schema_file = schemas_root(root) / STEP_SCHEMA_FILENAMES[step]
+    plan_mode = state["config"].get("mode", "code")
+    codex_schema_name = get_execution_schema_key(plan_mode) if step == "execute" else STEP_SCHEMA_FILENAMES[step]
+    schema_file = schemas_root(root) / codex_schema_name
     session_key = session_key_for(step, "codex")
     session = state["sessions"].get(session_key, {})
     out_handle = tempfile.NamedTemporaryFile("w+", encoding="utf-8", delete=False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "megaplan-harness"
-version = "0.16.0"
+version = "0.15.0"
 description = "AI agent harness for coordinating Claude and GPT to make and execute extremely robust plans"
 requires-python = ">=3.11"
 license = { text = "OSNL-0.2" }

--- a/tests/test_doc_assembly.py
+++ b/tests/test_doc_assembly.py
@@ -1,0 +1,133 @@
+"""Smoke tests for doc-mode section assembly (megaplan.doc_assembly)."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from megaplan.doc_assembly import assemble_doc, extract_sections
+
+
+def _write_batch(plan_dir: Path, index: int, payload: dict) -> None:
+    plan_dir.mkdir(parents=True, exist_ok=True)
+    (plan_dir / f"execution_batch_{index}.json").write_text(
+        json.dumps(payload), encoding="utf-8"
+    )
+
+
+def _finalize_with_tasks(*task_ids: str) -> dict:
+    return {"tasks": [{"id": tid} for tid in task_ids]}
+
+
+def test_extract_sections_collects_done_only() -> None:
+    payloads = [
+        {
+            "task_updates": [
+                {
+                    "task_id": "T1",
+                    "status": "done",
+                    "executor_notes": "Intro text",
+                    "sections_written": ["intro"],
+                },
+                {
+                    "task_id": "T2",
+                    "status": "in_progress",
+                    "executor_notes": "should not appear",
+                    "sections_written": ["body"],
+                },
+            ]
+        }
+    ]
+    sections = extract_sections(payloads)
+    assert sections == {"intro": "Intro text"}
+
+
+def test_assemble_doc_orders_sections_by_task_index(tmp_path: Path) -> None:
+    plan_dir = tmp_path / "plan"
+    output_path = tmp_path / "out.md"
+
+    # Batch 1 has T2's section, batch 2 has T1's section — written out of plan order.
+    _write_batch(plan_dir, 1, {
+        "task_updates": [
+            {"task_id": "T2", "status": "done",
+             "executor_notes": "Body content", "sections_written": ["body"]},
+        ]
+    })
+    _write_batch(plan_dir, 2, {
+        "task_updates": [
+            {"task_id": "T1", "status": "done",
+             "executor_notes": "Intro content", "sections_written": ["intro"]},
+        ]
+    })
+
+    finalize = _finalize_with_tasks("T1", "T2")
+    assemble_doc(plan_dir, output_path, finalize)
+    text = output_path.read_text(encoding="utf-8")
+    assert text == "Intro content\n\nBody content"
+
+
+def test_assemble_doc_is_idempotent(tmp_path: Path) -> None:
+    plan_dir = tmp_path / "plan"
+    output_path = tmp_path / "out.md"
+    _write_batch(plan_dir, 1, {
+        "task_updates": [
+            {"task_id": "T1", "status": "done",
+             "executor_notes": "Hello", "sections_written": ["s1"]},
+        ]
+    })
+    finalize = _finalize_with_tasks("T1")
+    assemble_doc(plan_dir, output_path, finalize)
+    first = output_path.read_text(encoding="utf-8")
+    assemble_doc(plan_dir, output_path, finalize)
+    second = output_path.read_text(encoding="utf-8")
+    assert first == second == "Hello"
+
+
+def test_assemble_doc_handles_no_batches(tmp_path: Path) -> None:
+    plan_dir = tmp_path / "plan"
+    plan_dir.mkdir()
+    output_path = tmp_path / "out.md"
+    assemble_doc(plan_dir, output_path, _finalize_with_tasks())
+    assert output_path.exists()
+    assert output_path.read_text(encoding="utf-8") == ""
+
+
+def test_assemble_doc_handles_empty_batch(tmp_path: Path) -> None:
+    plan_dir = tmp_path / "plan"
+    output_path = tmp_path / "out.md"
+    _write_batch(plan_dir, 1, {"task_updates": []})
+    assemble_doc(plan_dir, output_path, _finalize_with_tasks("T1"))
+    assert output_path.read_text(encoding="utf-8") == ""
+
+
+def test_assemble_doc_creates_parent_directory(tmp_path: Path) -> None:
+    plan_dir = tmp_path / "plan"
+    output_path = tmp_path / "nested" / "deep" / "out.md"
+    _write_batch(plan_dir, 1, {
+        "task_updates": [
+            {"task_id": "T1", "status": "done",
+             "executor_notes": "X", "sections_written": ["s1"]},
+        ]
+    })
+    assemble_doc(plan_dir, output_path, _finalize_with_tasks("T1"))
+    assert output_path.exists()
+    assert output_path.read_text(encoding="utf-8") == "X"
+
+
+def test_extract_sections_duplicate_section_id_last_wins(tmp_path: Path) -> None:
+    """Document current behavior: when two tasks claim the same section_id,
+    the later batch wins. This locks the contract so any future change is
+    deliberate."""
+    payloads = [
+        {"task_updates": [
+            {"task_id": "T1", "status": "done",
+             "executor_notes": "first", "sections_written": ["dup"]},
+        ]},
+        {"task_updates": [
+            {"task_id": "T2", "status": "done",
+             "executor_notes": "second", "sections_written": ["dup"]},
+        ]},
+    ]
+    sections = extract_sections(payloads)
+    assert sections == {"dup": "second"}

--- a/tests/test_handle_init_doc_mode.py
+++ b/tests/test_handle_init_doc_mode.py
@@ -1,0 +1,114 @@
+"""Smoke tests for handle_init's doc-mode arg validation (--mode/--output)."""
+from __future__ import annotations
+
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+import megaplan
+import megaplan._core
+import megaplan._core.io as io_module
+import megaplan.cli
+from megaplan.types import CliError
+
+
+def _bootstrap(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path]:
+    root = tmp_path / "root"
+    project_dir = tmp_path / "project"
+    config_path = tmp_path / "config"
+    root.mkdir()
+    project_dir.mkdir()
+    (project_dir / ".git").mkdir()
+
+    def _config_dir(home: Path | None = None) -> Path:
+        del home
+        return config_path
+
+    monkeypatch.setenv(megaplan.MOCK_ENV_VAR, "1")
+    monkeypatch.setattr(
+        megaplan._core.shutil,
+        "which",
+        lambda name: "/usr/bin/mock" if name in {"claude", "codex"} else None,
+    )
+    monkeypatch.setattr(io_module, "config_dir", _config_dir)
+    monkeypatch.setattr(megaplan.cli, "config_dir", _config_dir)
+    return root, project_dir
+
+
+def _args(project_dir: Path, **overrides: object) -> Namespace:
+    data: dict[str, object] = {
+        "plan": None,
+        "idea": "doc-mode test",
+        "name": None,
+        "project_dir": str(project_dir),
+        "auto_approve": None,
+        "robustness": "standard",
+        "agent": None,
+        "mode": "code",
+        "output": None,
+        "hermes": None,
+    }
+    data.update(overrides)
+    return Namespace(**data)
+
+
+def test_doc_mode_requires_output(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root, project_dir = _bootstrap(tmp_path, monkeypatch)
+    with pytest.raises(CliError) as info:
+        megaplan.handle_init(root, _args(project_dir, mode="doc", output=None))
+    assert info.value.code == "invalid_args"
+    assert "--output" in str(info.value)
+
+
+def test_output_rejects_absolute_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root, project_dir = _bootstrap(tmp_path, monkeypatch)
+    with pytest.raises(CliError) as info:
+        megaplan.handle_init(
+            root,
+            _args(project_dir, mode="doc", output="/etc/passwd"),
+        )
+    assert info.value.code == "invalid_args"
+    assert "relative" in str(info.value).lower() or "absolute" in str(info.value).lower()
+
+
+def test_output_rejects_parent_traversal(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root, project_dir = _bootstrap(tmp_path, monkeypatch)
+    with pytest.raises(CliError) as info:
+        megaplan.handle_init(
+            root,
+            _args(project_dir, mode="doc", output="../escape.md"),
+        )
+    assert info.value.code == "invalid_args"
+    assert ".." in str(info.value)
+
+
+def test_doc_mode_accepts_relative_output(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root, project_dir = _bootstrap(tmp_path, monkeypatch)
+    response = megaplan.handle_init(
+        root,
+        _args(project_dir, name="doc-plan", mode="doc", output="docs/result.md"),
+    )
+    plan_dir = megaplan.plans_root(root) / response["plan"]
+    import json as _json
+    state = _json.loads((plan_dir / "state.json").read_text(encoding="utf-8"))
+    assert state["config"]["mode"] == "doc"
+    assert state["config"]["output_path"] == "docs/result.md"
+
+
+def test_code_mode_with_output_normalizes_but_does_not_require(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """In code mode --output is optional. Providing it should not error;
+    the path validation rules still apply if given."""
+    root, project_dir = _bootstrap(tmp_path, monkeypatch)
+    # Code mode without --output: succeeds.
+    response = megaplan.handle_init(
+        root,
+        _args(project_dir, name="code-plan", mode="code", output=None),
+    )
+    plan_dir = megaplan.plans_root(root) / response["plan"]
+    import json as _json
+    state = _json.loads((plan_dir / "state.json").read_text(encoding="utf-8"))
+    assert state["config"]["mode"] == "code"
+    assert "output_path" not in state["config"]


### PR DESCRIPTION
## Summary
- Adds `--mode doc` to megaplan: execution authors a single document instead of producing a code diff. `megaplan init` gains `--mode {code,doc}` and `--output <relative/path>` (validated against absolute paths and `..` traversal).
- Mode-aware execute/review: `run_claude_step` and `run_codex_step` resolve the execute-step schema via `get_execution_schema_key(mode)` so doc-mode plans report `sections_written` instead of per-file changes. Doc-specific prep / execute / review prompts under `megaplan/prompts/`.
- New `megaplan/doc_assembly.py`: collects per-batch executor outputs, orders sections by their owning task's plan position, and writes the document atomically (temp file + `os.replace`).
- Smoke tests (added per review): `tests/test_doc_assembly.py` (7 tests) and `tests/test_handle_init_doc_mode.py` (5 tests).
- Rebased on `main@fcd44b4` (PR #5 worktree-isolation). Doc-mode schema selection coexists with PR #5's `resolve_work_dir(state)` routing in both Claude and Codex worker paths.

## Test plan
- [x] `PYENV_VERSION=3.11.11 python -m pytest tests/ -q` -> **563 passed** (551 prior + 12 new)
- [x] Conflict resolution verified (CHANGELOG keeps both v0.14.5 and v0.15.0; pyproject pinned to 0.15.0; workers.py keeps `work_dir = resolve_work_dir(state)` and mode-aware schema selection)