### PR TITLE
v0.17.0: verifiability contracts (PR-A of stacked 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v0.17.0 — 2026-04-15
+
+### Verifiability contracts
+
+Success criteria now declare which capabilities are needed to verify them, enabling pre-critique auditing and human-deferred verification.
+
+- **Capability registry**: closed set of 11 mechanism-shaped strings in `megaplan/capabilities.py` — 6 container (`run_shell`, `read_files`, `run_tests`, `parse_diff`, `read_build_output`, `run_linter`) and 5 human (`drive_browser`, `inspect_runtime_ui`, `observe_runtime_logs`, `subjective_judgment`, `verify_physical_device`).
+- **`requires` field on success criteria**: optional `requires: [cap1, cap2]` on each criterion in plan/revise schemas. Defaults to `[]` for backward compatibility.
+- **Pre-critique audit**: `megaplan/verifiability.py` validates that `requires` entries are known capabilities and that the union of worker capabilities can satisfy them. Synthetic `verifiability` flags are injected into the critique phase.
+- **`deferred_human` verdict**: review criteria that require human-only capabilities are marked `deferred_human` instead of `fail` or `waived`.
+- **`awaiting_human_verify` state**: plans with deferred human criteria enter this automation-terminal state instead of `done`.
+- **`megaplan verify-human`**: CLI command to record human verification evidence and transition from `awaiting_human_verify` to `done`.
+- **`megaplan audit-verifiability`**: CLI command to inspect capability coverage of a plan's criteria without changing state.
+- **`megaplan status --pending-human`**: lists plans in `awaiting_human_verify` state.
+- **Migration**: `requires` defaults to `[]` via schema default. Existing plans work unchanged.
+
 ## v0.16.0 — 2026-04-15
 
 ### Chain driver (`megaplan chain`)

--- a/megaplan/_core/workflow.py
+++ b/megaplan/_core/workflow.py
@@ -10,6 +10,7 @@ from megaplan.types import (
     PlanState,
     ROBUSTNESS_LEVELS,
     STATE_ABORTED,
+    STATE_AWAITING_HUMAN,
     STATE_CRITIQUED,
     STATE_DONE,
     STATE_EXECUTED,
@@ -63,6 +64,9 @@ WORKFLOW: dict[str, list[Transition]] = {
         # than gate_* conditions, so it lives in the handler instead of here
         # because `_transition_matches()` only understands gate-based branches.
         Transition("review", STATE_DONE),
+    ],
+    STATE_AWAITING_HUMAN: [
+        Transition("verify-human", STATE_DONE),
     ],
 }
 

--- a/megaplan/capabilities.py
+++ b/megaplan/capabilities.py
@@ -1,0 +1,66 @@
+"""Closed capability registry and worker discovery for verifiability contracts."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from megaplan.types import DEFAULT_AGENT_ROUTING
+
+CONTAINER_CAPABILITIES: frozenset[str] = frozenset({
+    "run_shell",
+    "read_files",
+    "run_tests",
+    "parse_diff",
+    "read_build_output",
+    "run_linter",
+})
+
+HUMAN_CAPABILITIES: frozenset[str] = frozenset({
+    "drive_browser",
+    "inspect_runtime_ui",
+    "observe_runtime_logs",
+    "subjective_judgment",
+    "verify_physical_device",
+})
+
+ALL_CAPABILITIES: frozenset[str] = CONTAINER_CAPABILITIES | HUMAN_CAPABILITIES
+
+DEFAULT_CONTAINER_CAPABILITIES: frozenset[str] = CONTAINER_CAPABILITIES
+DEFAULT_HUMAN_CAPABILITIES: frozenset[str] = HUMAN_CAPABILITIES
+
+
+def validate_capabilities(caps: list[str] | set[str]) -> list[str]:
+    """Return unknown capability strings not in the closed registry."""
+    return [c for c in caps if c not in ALL_CAPABILITIES]
+
+
+def get_worker_capabilities(state: dict[str, Any]) -> dict[str, set[str]]:
+    """Build worker-name → capabilities mapping from state config.
+
+    Falls back to DEFAULT_CONTAINER_CAPABILITIES for agents listed in
+    DEFAULT_AGENT_ROUTING that have no explicit config.
+    """
+    config = state.get("config", {})
+    workers_cfg: dict[str, Any] = config.get("workers", {})
+
+    result: dict[str, set[str]] = {}
+
+    if workers_cfg:
+        for name, wcfg in workers_cfg.items():
+            verifies = wcfg.get("verifies", [])
+            result[name] = set(verifies)
+    else:
+        seen_agents = set(DEFAULT_AGENT_ROUTING.values())
+        for agent in seen_agents:
+            result[agent] = set(DEFAULT_CONTAINER_CAPABILITIES)
+
+    return result
+
+
+def union_verifies(state: dict[str, Any]) -> set[str]:
+    """Return the union of all workers' verifies sets."""
+    caps = get_worker_capabilities(state)
+    result: set[str] = set()
+    for v in caps.values():
+        result |= v
+    return result

--- a/megaplan/cli.py
+++ b/megaplan/cli.py
@@ -49,6 +49,7 @@ from megaplan._core import (
 )
 from megaplan.execution import build_monitor_hint
 from megaplan.handlers import (
+    handle_audit_verifiability,
     handle_critique,
     handle_execute,
     handle_finalize,
@@ -59,6 +60,7 @@ from megaplan.handlers import (
     handle_prep,
     handle_review,
     handle_revise,
+    handle_verify_human,
 )
 from megaplan.loop.handlers import (
     handle_loop_init,
@@ -348,6 +350,18 @@ def _build_status_payload(plan_dir: Path, state: dict[str, Any]) -> StepResponse
 
 
 def handle_status(root: Path, args: argparse.Namespace) -> StepResponse:
+    if getattr(args, "pending_human", False):
+        items = []
+        for pd in active_plan_dirs(root):
+            st = read_json(pd / "state.json")
+            if st.get("current_state") == "awaiting_human_verify":
+                items.append({"name": st["name"], "state": st["current_state"]})
+        return {
+            "success": True,
+            "step": "status",
+            "summary": f"Found {len(items)} plan(s) awaiting human verification.",
+            "plans": items,
+        }
     plan_dir, state = load_plan(root, args.plan)
     return _build_status_payload(plan_dir, state)
 
@@ -845,6 +859,9 @@ def build_parser() -> argparse.ArgumentParser:
     for name in ["status", "audit", "progress", "watch"]:
         step_parser = subparsers.add_parser(name)
         step_parser.add_argument("--plan")
+        if name == "status":
+            step_parser.add_argument("--pending-human", action="store_true",
+                                     help="List plans awaiting human verification")
 
     for name in ["plan", "prep", "critique", "revise", "gate", "finalize", "execute", "review"]:
         step_parser = subparsers.add_parser(name)
@@ -899,6 +916,17 @@ def build_parser() -> argparse.ArgumentParser:
     override_parser.add_argument("--reason", default="")
     override_parser.add_argument("--note")
     override_parser.add_argument("--robustness", choices=list(ROBUSTNESS_LEVELS), default=None)
+
+    verify_human_parser = subparsers.add_parser("verify-human", help="Record human verification for a criterion")
+    verify_human_parser.add_argument("--plan")
+    verify_human_parser.add_argument("--criterion", required=True, help="Criterion name or index")
+    vh_group = verify_human_parser.add_mutually_exclusive_group(required=True)
+    vh_group.add_argument("--pass", dest="pass_flag", action="store_true")
+    vh_group.add_argument("--fail", dest="fail_flag", action="store_true")
+    verify_human_parser.add_argument("--evidence", required=True, help="Evidence supporting the verdict")
+
+    audit_verifiability_parser = subparsers.add_parser("audit-verifiability", help="Audit criteria verifiability")
+    audit_verifiability_parser.add_argument("--plan")
 
     debt_parser = subparsers.add_parser("debt", help="Inspect or manage persistent tech debt entries")
     debt_subparsers = debt_parser.add_subparsers(dest="debt_action", required=True)
@@ -993,6 +1021,8 @@ COMMAND_HANDLERS: dict[str, Callable[..., StepResponse]] = {
     "debt": handle_debt,
     "step": handle_step,
     "override": handle_override,
+    "verify-human": handle_verify_human,
+    "audit-verifiability": handle_audit_verifiability,
 }
 
 

--- a/megaplan/handlers.py
+++ b/megaplan/handlers.py
@@ -39,6 +39,7 @@ from megaplan.types import (
     CliError,
     PlanState,
     STATE_ABORTED,
+    STATE_AWAITING_HUMAN,
     STATE_CRITIQUED,
     STATE_DONE,
     STATE_EXECUTED,
@@ -61,6 +62,7 @@ from megaplan._core import (
     ensure_runtime_layout,
     extract_subsystem_tag,
     latest_plan_path,
+    latest_plan_meta_path,
     load_debt_registry,
     load_flag_registry,
     load_plan,
@@ -882,6 +884,47 @@ def handle_prep(root: Path, args: argparse.Namespace) -> StepResponse:
         )
 
 
+def _build_verifiability_flags(
+    success_criteria: list[dict[str, Any]],
+    worker_caps: dict[str, set[str]],
+) -> list[dict[str, Any]]:
+    from megaplan.capabilities import ALL_CAPABILITIES
+    from megaplan.verifiability import audit_criteria, validate_requires
+
+    flags: list[dict[str, Any]] = []
+    issues = validate_requires(success_criteria)
+    for issue_str in issues:
+        is_unknown_cap = "unknown capability" in issue_str
+        flags.append({
+            "id": f"verifiability-{len(flags)}",
+            "concern": issue_str,
+            "category": "verifiability",
+            "severity_hint": "likely-significant" if is_unknown_cap else "likely-minor",
+            "status": "open",
+        })
+
+    audits = audit_criteria(success_criteria, worker_caps)
+    for audit in audits:
+        if audit.verdict == "unverifiable_no_worker":
+            flags.append({
+                "id": f"verifiability-{len(flags)}",
+                "concern": f"Criterion {audit.criterion_idx}: {audit.rationale} Missing: {', '.join(audit.missing_caps)}",
+                "category": "verifiability",
+                "severity_hint": "likely-significant",
+                "status": "open",
+            })
+        elif audit.verdict == "human_only":
+            flags.append({
+                "id": f"verifiability-{len(flags)}",
+                "concern": f"Criterion {audit.criterion_idx}: requires human verification ({', '.join(audit.missing_caps)}).",
+                "category": "verifiability",
+                "severity_hint": "likely-minor",
+                "status": "open",
+            })
+
+    return flags
+
+
 def handle_critique(root: Path, args: argparse.Namespace) -> StepResponse:
     with load_plan_locked(root, args.plan, step="critique") as (plan_dir, state):
         require_state(state, "critique", {STATE_PLANNED})
@@ -890,15 +933,24 @@ def handle_critique(root: Path, args: argparse.Namespace) -> StepResponse:
         state["last_gate"] = {}
         critique_filename = f"critique_v{iteration}.json"
         if robustness == "tiny":
+            from megaplan.capabilities import get_worker_capabilities
+            from megaplan.verifiability import audit_criteria, validate_requires
+
+            plan_meta = read_json(latest_plan_meta_path(plan_dir, state))
+            success_criteria = plan_meta.get("success_criteria", [])
+            worker_caps = get_worker_capabilities(state)
+
+            verifiability_flags = _build_verifiability_flags(success_criteria, worker_caps)
+
             stub_critique = {
                 "checks": [],
-                "flags": [],
+                "flags": verifiability_flags,
                 "verified_flag_ids": [],
                 "disputed_flag_ids": [],
             }
             validate_payload("critique", stub_critique)
             atomic_write_json(plan_dir / critique_filename, stub_critique)
-            save_flag_registry(plan_dir, {"flags": []})
+            save_flag_registry(plan_dir, {"flags": verifiability_flags})
             minimal_gate: dict[str, Any] = {
                 "recommendation": "ITERATE",
                 "rationale": "Tiny robustness: critique stubbed; advancing directly to gated.",
@@ -920,6 +972,10 @@ def handle_critique(root: Path, args: argparse.Namespace) -> StepResponse:
                 total_tokens=0,
             )
             agent, _mode, _refreshed, _model = resolve_agent_mode("critique", args)
+            open_flags_detail = [
+                {"id": f["id"], "concern": f["concern"], "category": f["category"], "severity": f.get("severity", "unknown")}
+                for f in verifiability_flags
+            ]
             return _finish_step(
                 plan_dir, state, args,
                 step="critique",
@@ -927,7 +983,7 @@ def handle_critique(root: Path, args: argparse.Namespace) -> StepResponse:
                 agent=agent,
                 mode="stub",
                 refreshed=False,
-                summary="Tiny robustness: critique stubbed; advancing directly to gated.",
+                summary=f"Tiny robustness: critique stubbed with {len(verifiability_flags)} verifiability flag(s).",
                 artifacts=[critique_filename, "faults.json", "gate.json"],
                 output_file=critique_filename,
                 artifact_hash=sha256_file(plan_dir / critique_filename),
@@ -935,10 +991,10 @@ def handle_critique(root: Path, args: argparse.Namespace) -> StepResponse:
                     "iteration": iteration,
                     "checks": [],
                     "verified_flags": [],
-                    "open_flags": [],
+                    "open_flags": open_flags_detail,
                     "scope_creep_flags": [],
                 },
-                history_fields={"flags_count": 0},
+                history_fields={"flags_count": len(verifiability_flags)},
             )
         active_checks = checks_for_robustness(robustness)
         expected_ids = [check["id"] for check in active_checks]
@@ -969,6 +1025,17 @@ def handle_critique(root: Path, args: argparse.Namespace) -> StepResponse:
         invalid_checks = validate_critique_checks(worker.payload, expected_ids=expected_ids)
         if invalid_checks:
             _raise_step_validation_error(plan_dir=plan_dir, state=state, step="critique", iteration=iteration, worker=worker, code="invalid_critique", message="Critique output failed check validation: " + ", ".join(invalid_checks))
+
+        from megaplan.capabilities import get_worker_capabilities
+        from megaplan.verifiability import audit_criteria, validate_requires
+
+        plan_meta = read_json(latest_plan_meta_path(plan_dir, state))
+        success_criteria = plan_meta.get("success_criteria", [])
+        v_worker_caps = get_worker_capabilities(state)
+        v_flags = _build_verifiability_flags(success_criteria, v_worker_caps)
+        if v_flags:
+            worker.payload.setdefault("flags", []).extend(v_flags)
+
         atomic_write_json(plan_dir / critique_filename, worker.payload)
         registry = update_flags_after_critique(plan_dir, worker.payload, iteration=iteration)
         significant = len([flag for flag in registry["flags"] if flag.get("severity") == "significant" and flag["status"] in FLAG_BLOCKING_STATUSES])
@@ -1418,14 +1485,40 @@ def handle_execute(root: Path, args: argparse.Namespace) -> StepResponse:
             assemble_doc(plan_dir, output_path, finalize_data)
         robustness = configured_robustness(state)
         if not workflow_includes_step(robustness, "review") and response.get("state") == STATE_EXECUTED:
-            # Preserve the data-parity invariant even when review is skipped by robustness.
+            from megaplan.capabilities import get_worker_capabilities
+            from megaplan.verifiability import classify_criteria
+
+            plan_meta = read_json(latest_plan_meta_path(plan_dir, state))
+            success_criteria = plan_meta.get("success_criteria", [])
+            worker_caps = get_worker_capabilities(state)
+            _, human_deferred = classify_criteria(success_criteria, worker_caps)
+
+            stub_criteria = []
+            has_deferred_must = False
+            for sc in success_criteria:
+                entry: dict[str, Any] = {
+                    "name": sc.get("criterion", ""),
+                    "priority": sc.get("priority", "info"),
+                }
+                if sc in human_deferred:
+                    entry["pass"] = "deferred_human"
+                    entry["evidence"] = "Requires human verification capabilities."
+                    if sc.get("priority") == "must":
+                        has_deferred_must = True
+                else:
+                    entry["pass"] = "pass"
+                    entry["evidence"] = f"{robustness.title()} robustness: auto-approved."
+                stub_criteria.append(entry)
+
+            next_state = STATE_AWAITING_HUMAN if has_deferred_must else STATE_DONE
+
             stub_review = {
                 "review_verdict": "approved",
                 "checks": [],
                 "pre_check_flags": [],
                 "verified_flag_ids": [],
                 "disputed_flag_ids": [],
-                "criteria": [],
+                "criteria": stub_criteria,
                 "issues": [],
                 "rework_items": [],
                 "summary": f"{robustness.title()} robustness: review skipped; stub written for artifact parity.",
@@ -1437,9 +1530,9 @@ def handle_execute(root: Path, args: argparse.Namespace) -> StepResponse:
             artifacts = response.get("artifacts")
             if isinstance(artifacts, list) and "review.json" not in artifacts:
                 artifacts.append("review.json")
-            state["current_state"] = STATE_DONE
+            state["current_state"] = next_state
             save_state(plan_dir, state)
-            response["state"] = STATE_DONE
+            response["state"] = next_state
             response["next_step"] = None
             response.pop("next_step_runtime", None)
         else:
@@ -1506,6 +1599,7 @@ def _resolve_review_outcome(
     robustness: str,
     state: PlanState,
     issues: list[str],
+    criteria: list[dict[str, Any]] | None = None,
 ) -> tuple[str, str, str | None]:
     """Determine review result, next state, and next step.
 
@@ -1538,6 +1632,14 @@ def _resolve_review_outcome(
             )
         else:
             return "needs_rework", STATE_FINALIZED, "execute"
+
+    if criteria:
+        has_deferred_must = any(
+            c.get("pass") == "deferred_human" and c.get("priority") == "must"
+            for c in criteria
+        )
+        if has_deferred_must:
+            return "success", STATE_AWAITING_HUMAN, None
 
     return "success", STATE_DONE, None
 
@@ -1673,6 +1775,7 @@ def handle_review(root: Path, args: argparse.Namespace) -> StepResponse:
                     check_count, total_checks, missing_evidence,
                     robustness,
                     state, issues,
+                    criteria=worker.payload.get("criteria", []),
                 )
                 state["current_state"] = next_state
 
@@ -1802,6 +1905,7 @@ def handle_review(root: Path, args: argparse.Namespace) -> StepResponse:
             check_count, total_checks, missing_evidence,
             robustness,
             state, issues,
+            criteria=worker.payload.get("criteria", []),
         )
         state["current_state"] = next_state
 
@@ -2051,3 +2155,120 @@ def handle_override(root: Path, args: argparse.Namespace) -> StepResponse:
     if handler is None:
         raise CliError("invalid_override", f"Unknown override action: {action}")
     return handler(root, plan_dir, state, args)
+
+
+def handle_verify_human(root: Path, args: argparse.Namespace) -> StepResponse:
+    from megaplan._core import plans_root, resolve_plan_dir
+    plan_dir, state = load_plan(root, args.plan)
+
+    if state["current_state"] != STATE_AWAITING_HUMAN:
+        raise CliError(
+            "wrong_state",
+            f"verify-human requires state 'awaiting_human_verify', got '{state['current_state']}'.",
+        )
+
+    criterion_ref = args.criterion
+    passed = getattr(args, "pass_flag", False)
+    failed = getattr(args, "fail_flag", False)
+    evidence = args.evidence
+
+    plan_meta = read_json(latest_plan_meta_path(plan_dir, state))
+    success_criteria = plan_meta.get("success_criteria", [])
+
+    target_idx: int | None = None
+    try:
+        idx = int(criterion_ref)
+        if 0 <= idx < len(success_criteria):
+            target_idx = idx
+    except (ValueError, TypeError):
+        for i, sc in enumerate(success_criteria):
+            if sc.get("criterion", "") == criterion_ref:
+                target_idx = i
+                break
+
+    if target_idx is None:
+        raise CliError("invalid_criterion", f"Criterion not found: {criterion_ref!r}")
+
+    verifications_path = plan_dir / "human_verifications.json"
+    verifications: list[dict[str, Any]] = []
+    if verifications_path.exists():
+        verifications = read_json(verifications_path)
+        if not isinstance(verifications, list):
+            verifications = []
+
+    verifications.append({
+        "criterion_idx": target_idx,
+        "criterion": success_criteria[target_idx].get("criterion", ""),
+        "verdict": "pass" if passed else "fail",
+        "evidence": evidence,
+        "timestamp": now_utc(),
+    })
+    atomic_write_json(verifications_path, verifications)
+
+    verified_idxs = {
+        v["criterion_idx"] for v in verifications if v.get("verdict") == "pass"
+    }
+
+    from megaplan.capabilities import get_worker_capabilities
+    from megaplan.verifiability import classify_criteria
+
+    worker_caps = get_worker_capabilities(state)
+    _, human_deferred = classify_criteria(success_criteria, worker_caps)
+    deferred_must_idxs = {
+        i for i, sc in enumerate(success_criteria)
+        if sc in human_deferred and sc.get("priority") == "must"
+    }
+
+    all_verified = deferred_must_idxs <= verified_idxs
+    if all_verified:
+        state["current_state"] = STATE_DONE
+        save_state(plan_dir, state)
+        summary = "All deferred must criteria verified. Plan transitioned to done."
+    else:
+        remaining = deferred_must_idxs - verified_idxs
+        summary = f"Verification recorded. {len(remaining)} deferred must criteria remaining."
+
+    return {
+        "success": True,
+        "step": "verify-human",
+        "plan": state["name"],
+        "state": state["current_state"],
+        "summary": summary,
+        "criterion_idx": target_idx,
+        "verdict": "pass" if passed else "fail",
+    }
+
+
+def handle_audit_verifiability(root: Path, args: argparse.Namespace) -> StepResponse:
+    plan_dir, state = load_plan(root, args.plan)
+
+    plan_meta = read_json(latest_plan_meta_path(plan_dir, state))
+    success_criteria = plan_meta.get("success_criteria", [])
+
+    from megaplan.capabilities import get_worker_capabilities
+    from megaplan.verifiability import audit_criteria, validate_requires
+
+    worker_caps = get_worker_capabilities(state)
+    audits = audit_criteria(success_criteria, worker_caps)
+    issues = validate_requires(success_criteria)
+
+    audit_results = []
+    for audit in audits:
+        sc = success_criteria[audit.criterion_idx] if audit.criterion_idx < len(success_criteria) else {}
+        audit_results.append({
+            "criterion_idx": audit.criterion_idx,
+            "criterion": sc.get("criterion", ""),
+            "priority": sc.get("priority", ""),
+            "verdict": audit.verdict,
+            "rationale": audit.rationale,
+            "missing_caps": audit.missing_caps,
+        })
+
+    return {
+        "success": True,
+        "step": "audit-verifiability",
+        "plan": state["name"],
+        "summary": f"Audited {len(success_criteria)} criteria: {sum(1 for a in audits if a.verdict == 'machine_verifiable')} machine-verifiable, {sum(1 for a in audits if a.verdict == 'human_only')} human-only, {sum(1 for a in audits if a.verdict == 'unverifiable_no_worker')} unverifiable.",
+        "audits": audit_results,
+        "validation_issues": issues,
+    }

--- a/megaplan/prompts/planning.py
+++ b/megaplan/prompts/planning.py
@@ -121,6 +121,7 @@ def _plan_prompt(state: PlanState, plan_dir: Path) -> str:
           - `must` — hard gate. The reviewer will block on failure. Use for correctness, functional requirements, and verifiable outcomes (e.g., "all existing tests pass", "API returns 200 for valid input"). Every `must` criterion must have a clear yes/no answer.
           - `should` — quality target. The reviewer flags but does not block. Use for subjective goals, numeric guidelines, and best-effort improvements (e.g., "file under ~300 lines", "no deeply nested conditionals", "each function has a single responsibility").
           - `info` — documented for humans, reviewer skips. Use for criteria that cannot be verified in this pipeline (e.g., "13 manual smoke tests pass", "stakeholder sign-off obtained").
+        - Each success criterion should include a `requires` field listing the capabilities needed for verification. Valid capability strings: `run_shell`, `read_files`, `run_tests`, `parse_diff`, `read_build_output`, `run_linter` (container), `drive_browser`, `inspect_runtime_ui`, `observe_runtime_logs`, `subjective_judgment`, `verify_physical_device` (human). `must` criteria MUST have non-empty `requires`. Example: `{{"criterion": "All tests pass", "priority": "must", "requires": ["run_tests"]}}`.
         - Use the `questions` field for ambiguities that would materially change implementation.
         - Use the `assumptions` field for defaults you are making so planning can proceed now.
         - Prefer cheap validation steps early.

--- a/megaplan/prompts/review.py
+++ b/megaplan/prompts/review.py
@@ -511,6 +511,7 @@ def _review_prompt(
           - `must` criteria are hard gates. A `must` criterion that fails means `needs_rework`.
           - `should` criteria are quality targets. If the spirit is met but the letter is not, mark `pass` with evidence explaining the gap. Only mark `fail` if the intent was clearly missed. A `should` failure alone does NOT require `needs_rework`.
           - `info` criteria are for human reference. Mark them `waived` with a note — do not evaluate them.
+          - If a criterion has `requires` capabilities that are not satisfiable by container workers (e.g., `drive_browser`, `subjective_judgment`), mark it `deferred_human` — NOT `fail` or `waived`. Deferred-human criteria do NOT count toward `needs_rework`.
           - If a criterion (any priority) cannot be verified in this context (e.g., requires manual testing or runtime observation), mark it `waived` with an explanation.
         - Set `review_verdict` to `needs_rework` only when at least one `must` criterion fails or actual implementation work is incomplete. Use `approved` when all `must` criteria pass, even if some `should` criteria are flagged.
         {settled_decisions_instruction}

--- a/megaplan/schemas.py
+++ b/megaplan/schemas.py
@@ -19,6 +19,7 @@ SCHEMAS: dict[str, dict[str, Any]] = {
                     "properties": {
                         "criterion": {"type": "string"},
                         "priority": {"type": "string", "enum": ["must", "should", "info"]},
+                        "requires": {"type": "array", "items": {"type": "string"}, "default": []},
                     },
                     "required": ["criterion", "priority"],
                 },
@@ -95,6 +96,7 @@ SCHEMAS: dict[str, dict[str, Any]] = {
                     "properties": {
                         "criterion": {"type": "string"},
                         "priority": {"type": "string", "enum": ["must", "should", "info"]},
+                        "requires": {"type": "array", "items": {"type": "string"}, "default": []},
                     },
                     "required": ["criterion", "priority"],
                 },
@@ -211,6 +213,7 @@ SCHEMAS: dict[str, dict[str, Any]] = {
                                 "maintainability",
                                 "doc-quality",
                                 "other",
+                                "verifiability",
                             ],
                         },
                         "severity_hint": {
@@ -437,7 +440,7 @@ SCHEMAS: dict[str, dict[str, Any]] = {
                     "properties": {
                         "name": {"type": "string"},
                         "priority": {"type": "string", "enum": ["must", "should", "info"]},
-                        "pass": {"type": "string", "enum": ["pass", "fail", "waived"]},
+                        "pass": {"type": "string", "enum": ["pass", "fail", "waived", "deferred_human"]},
                         "evidence": {"type": "string"},
                     },
                     "required": ["name", "priority", "pass", "evidence"],

--- a/megaplan/types.py
+++ b/megaplan/types.py
@@ -18,7 +18,9 @@ STATE_FINALIZED = "finalized"
 STATE_EXECUTED = "executed"
 STATE_DONE = "done"
 STATE_ABORTED = "aborted"
+STATE_AWAITING_HUMAN = "awaiting_human_verify"
 TERMINAL_STATES = {STATE_DONE, STATE_ABORTED}
+AUTOMATION_TERMINAL_STATES = TERMINAL_STATES | {STATE_AWAITING_HUMAN}
 
 
 # ---------------------------------------------------------------------------

--- a/megaplan/verifiability.py
+++ b/megaplan/verifiability.py
@@ -1,0 +1,125 @@
+"""Verifiability audit — pure-Python capability matching for success criteria."""
+
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass, field
+from typing import Any
+
+from megaplan.capabilities import ALL_CAPABILITIES, HUMAN_CAPABILITIES
+
+
+@dataclass
+class CriterionAudit:
+    criterion_idx: int
+    verdict: str  # "machine_verifiable" | "human_only" | "unverifiable_no_worker"
+    rationale: str
+    missing_caps: list[str] = field(default_factory=list)
+
+
+def audit_criteria(
+    criteria: list[dict[str, Any]],
+    worker_caps: dict[str, set[str]],
+) -> list[CriterionAudit]:
+    """For each criterion, check requires ⊆ union of all worker verifies sets.
+
+    Returns a CriterionAudit per criterion with verdict:
+      - machine_verifiable: all required caps covered by at least one worker
+      - human_only: all required caps exist in registry but some need human workers
+      - unverifiable_no_worker: some required caps not satisfiable by any known worker
+    """
+    all_worker_caps = set()
+    for caps in worker_caps.values():
+        all_worker_caps |= caps
+
+    results: list[CriterionAudit] = []
+    for idx, criterion in enumerate(criteria):
+        requires = set(criterion.get("requires", []))
+        if not requires:
+            results.append(CriterionAudit(
+                criterion_idx=idx,
+                verdict="machine_verifiable",
+                rationale="No capabilities required (empty requires).",
+            ))
+            continue
+
+        missing_from_workers = requires - all_worker_caps
+        if not missing_from_workers:
+            results.append(CriterionAudit(
+                criterion_idx=idx,
+                verdict="machine_verifiable",
+                rationale="All required capabilities covered by configured workers.",
+            ))
+        elif missing_from_workers <= HUMAN_CAPABILITIES:
+            results.append(CriterionAudit(
+                criterion_idx=idx,
+                verdict="human_only",
+                rationale="Some required capabilities need human verification.",
+                missing_caps=sorted(missing_from_workers),
+            ))
+        else:
+            truly_unknown = missing_from_workers - HUMAN_CAPABILITIES
+            results.append(CriterionAudit(
+                criterion_idx=idx,
+                verdict="unverifiable_no_worker",
+                rationale="Required capabilities not satisfiable by any known worker.",
+                missing_caps=sorted(missing_from_workers),
+            ))
+
+    return results
+
+
+def classify_criteria(
+    criteria: list[dict[str, Any]],
+    worker_caps: dict[str, set[str]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Split criteria into (machine_verifiable, human_deferred).
+
+    machine_verifiable includes criteria with verdict machine_verifiable.
+    human_deferred includes human_only and unverifiable_no_worker.
+    """
+    audits = audit_criteria(criteria, worker_caps)
+    machine: list[dict[str, Any]] = []
+    human: list[dict[str, Any]] = []
+    for audit, criterion in zip(audits, criteria):
+        if audit.verdict == "machine_verifiable":
+            machine.append(criterion)
+        else:
+            human.append(criterion)
+    return machine, human
+
+
+def validate_requires(
+    criteria: list[dict[str, Any]],
+    registry: set[str] | frozenset[str] | None = None,
+) -> list[str]:
+    """Check all requires entries are known capability strings.
+
+    Returns list of issue strings. Flags must criteria with empty requires
+    as deprecation warnings.
+    """
+    if registry is None:
+        registry = ALL_CAPABILITIES
+
+    issues: list[str] = []
+    for idx, criterion in enumerate(criteria):
+        requires = criterion.get("requires", [])
+        priority = criterion.get("priority", "")
+
+        if priority == "must" and not requires:
+            msg = (
+                f"Criterion {idx} ({criterion.get('criterion', '?')}): "
+                f"must-priority criterion has empty requires — "
+                f"add requires to enable automated verification."
+            )
+            issues.append(msg)
+            warnings.warn(msg, DeprecationWarning, stacklevel=2)
+
+        for cap in requires:
+            if cap not in registry:
+                issues.append(
+                    f"Criterion {idx} ({criterion.get('criterion', '?')}): "
+                    f"unknown capability '{cap}' in requires."
+                )
+
+    return issues

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "megaplan-harness"
-version = "0.15.0"
+version = "0.17.0"
 description = "AI agent harness for coordinating Claude and GPT to make and execute extremely robust plans"
 requires-python = ">=3.11"
 license = { text = "OSNL-0.2" }

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -309,6 +309,7 @@ def _baseline_codex_review_prompt_snapshot(state: PlanState, plan_dir: Path) -> 
           - `must` criteria are hard gates. A `must` criterion that fails means `needs_rework`.
           - `should` criteria are quality targets. If the spirit is met but the letter is not, mark `pass` with evidence explaining the gap. Only mark `fail` if the intent was clearly missed. A `should` failure alone does NOT require `needs_rework`.
           - `info` criteria are for human reference. Mark them `waived` with a note — do not evaluate them.
+          - If a criterion has `requires` capabilities that are not satisfiable by container workers (e.g., `drive_browser`, `subjective_judgment`), mark it `deferred_human` — NOT `fail` or `waived`. Deferred-human criteria do NOT count toward `needs_rework`.
           - If a criterion (any priority) cannot be verified in this context (e.g., requires manual testing or runtime observation), mark it `waived` with an explanation.
         - Set `review_verdict` to `needs_rework` only when at least one `must` criterion fails or actual implementation work is incomplete. Use `approved` when all `must` criteria pass, even if some `should` criteria are flagged.
         {settled_decisions_instruction}

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -475,3 +475,46 @@ def test_strict_schema_new_tracking_objects_are_strict() -> None:
     }
     assert sense_check_schema["additionalProperties"] is False
     assert set(sense_check_schema["required"]) == {"id", "task_id", "question", "executor_note", "verdict"}
+
+
+def test_plan_schema_requires_field_round_trip() -> None:
+    from jsonschema import Draft7Validator
+
+    schema = SCHEMAS["plan.json"]
+    payload_with_requires = {
+        "plan": "Test plan",
+        "questions": [],
+        "success_criteria": [
+            {"criterion": "All tests pass", "priority": "must", "requires": ["run_tests"]},
+            {"criterion": "Code is clean", "priority": "should", "requires": ["run_linter", "read_files"]},
+            {"criterion": "Looks good", "priority": "info"},
+        ],
+        "assumptions": [],
+    }
+    assert list(Draft7Validator(schema).iter_errors(payload_with_requires)) == []
+
+    payload_without_requires = {
+        "plan": "Test plan",
+        "questions": [],
+        "success_criteria": [
+            {"criterion": "All tests pass", "priority": "must"},
+        ],
+        "assumptions": [],
+    }
+    assert list(Draft7Validator(schema).iter_errors(payload_without_requires)) == []
+
+
+def test_review_schema_accepts_deferred_human_verdict() -> None:
+    from jsonschema import Draft7Validator
+
+    payload = _minimal_review_payload()
+    payload["criteria"] = [
+        {"name": "UI check", "priority": "must", "pass": "deferred_human", "evidence": "Needs human."},
+    ]
+    assert list(Draft7Validator(SCHEMAS["review.json"]).iter_errors(payload)) == []
+
+
+def test_critique_schema_accepts_verifiability_category() -> None:
+    critique = SCHEMAS["critique.json"]
+    category_enum = critique["properties"]["flags"]["items"]["properties"]["category"]["enum"]
+    assert "verifiability" in category_enum

--- a/tests/test_tiny_robustness.py
+++ b/tests/test_tiny_robustness.py
@@ -69,16 +69,21 @@ def test_tiny_robustness_matches_light_artifacts_and_stub_payloads(
     validate_payload("critique", critique)
     validate_payload("review", review)
 
-    assert critique == {
-        "checks": [],
-        "flags": [],
-        "verified_flag_ids": [],
-        "disputed_flag_ids": [],
-    }
-    assert faults == {"flags": []}
+    assert critique["checks"] == []
+    assert critique["verified_flag_ids"] == []
+    assert critique["disputed_flag_ids"] == []
+    for flag in critique["flags"]:
+        assert flag["category"] == "verifiability"
+        assert flag["status"] == "open"
+    assert faults["flags"] == critique["flags"]
     assert gate["recommendation"] == "ITERATE"
     assert review["review_verdict"] == "approved"
-    assert review["criteria"] == []
+    assert isinstance(review["criteria"], list)
+    assert len(review["criteria"]) > 0
+    for c in review["criteria"]:
+        assert c["pass"] in ("pass", "deferred_human")
+        assert "name" in c
+        assert "priority" in c
     assert review["issues"] == []
     assert review["rework_items"] == []
     assert review["task_verdicts"] == []

--- a/tests/test_verifiability.py
+++ b/tests/test_verifiability.py
@@ -1,0 +1,239 @@
+"""Tests for megaplan.capabilities and megaplan.verifiability modules."""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from megaplan.capabilities import (
+    ALL_CAPABILITIES,
+    CONTAINER_CAPABILITIES,
+    DEFAULT_CONTAINER_CAPABILITIES,
+    DEFAULT_HUMAN_CAPABILITIES,
+    HUMAN_CAPABILITIES,
+    get_worker_capabilities,
+    union_verifies,
+    validate_capabilities,
+)
+from megaplan.verifiability import (
+    CriterionAudit,
+    audit_criteria,
+    classify_criteria,
+    validate_requires,
+)
+
+
+# ---------------------------------------------------------------------------
+# Capability registry tests
+# ---------------------------------------------------------------------------
+
+
+def test_validate_capabilities_known_accepted() -> None:
+    assert validate_capabilities(["run_tests"]) == []
+    assert validate_capabilities(["run_tests", "read_files", "drive_browser"]) == []
+    assert validate_capabilities(list(ALL_CAPABILITIES)) == []
+
+
+def test_validate_capabilities_unknown_rejected() -> None:
+    result = validate_capabilities(["made_up_cap"])
+    assert result == ["made_up_cap"]
+
+
+def test_validate_capabilities_mixed() -> None:
+    result = validate_capabilities(["run_tests", "teleport", "read_files", "quantum_compute"])
+    assert set(result) == {"teleport", "quantum_compute"}
+
+
+def test_registry_sets_no_overlap() -> None:
+    assert CONTAINER_CAPABILITIES & HUMAN_CAPABILITIES == frozenset()
+    assert ALL_CAPABILITIES == CONTAINER_CAPABILITIES | HUMAN_CAPABILITIES
+    assert len(ALL_CAPABILITIES) == 11
+
+
+def test_defaults_match_full_sets() -> None:
+    assert DEFAULT_CONTAINER_CAPABILITIES == CONTAINER_CAPABILITIES
+    assert DEFAULT_HUMAN_CAPABILITIES == HUMAN_CAPABILITIES
+
+
+# ---------------------------------------------------------------------------
+# audit_criteria tests
+# ---------------------------------------------------------------------------
+
+
+def _container_only_caps() -> dict[str, set[str]]:
+    return {"codex": set(CONTAINER_CAPABILITIES)}
+
+
+def _container_plus_human_caps() -> dict[str, set[str]]:
+    return {
+        "codex": set(CONTAINER_CAPABILITIES),
+        "human": set(HUMAN_CAPABILITIES),
+    }
+
+
+def _empty_worker_caps() -> dict[str, set[str]]:
+    return {"codex": set()}
+
+
+def test_audit_requires_run_tests_container_is_machine_verifiable() -> None:
+    criteria = [{"criterion": "All tests pass", "priority": "must", "requires": ["run_tests"]}]
+    audits = audit_criteria(criteria, _container_only_caps())
+    assert len(audits) == 1
+    assert audits[0].verdict == "machine_verifiable"
+    assert audits[0].missing_caps == []
+
+
+def test_audit_requires_drive_browser_container_only_is_human_only() -> None:
+    criteria = [{"criterion": "UI looks right", "priority": "must", "requires": ["drive_browser"]}]
+    audits = audit_criteria(criteria, _container_only_caps())
+    assert len(audits) == 1
+    assert audits[0].verdict == "human_only"
+    assert "drive_browser" in audits[0].missing_caps
+
+
+def test_audit_requires_drive_browser_no_human_worker_is_unverifiable() -> None:
+    criteria = [{"criterion": "UI looks right", "priority": "must", "requires": ["drive_browser"]}]
+    audits = audit_criteria(criteria, _empty_worker_caps())
+    assert len(audits) == 1
+    assert audits[0].verdict == "human_only"
+
+
+def test_audit_requires_unknown_cap_is_unverifiable() -> None:
+    criteria = [{"criterion": "Magic check", "priority": "must", "requires": ["teleport_check"]}]
+    audits = audit_criteria(criteria, _container_only_caps())
+    assert len(audits) == 1
+    assert audits[0].verdict == "unverifiable_no_worker"
+
+
+def test_audit_empty_requires_is_machine_verifiable() -> None:
+    criteria = [{"criterion": "Simple check", "priority": "should", "requires": []}]
+    audits = audit_criteria(criteria, _container_only_caps())
+    assert len(audits) == 1
+    assert audits[0].verdict == "machine_verifiable"
+
+
+def test_audit_mixed_criteria() -> None:
+    criteria = [
+        {"criterion": "Tests pass", "priority": "must", "requires": ["run_tests"]},
+        {"criterion": "UI check", "priority": "must", "requires": ["drive_browser"]},
+        {"criterion": "Perf check", "priority": "should", "requires": []},
+    ]
+    audits = audit_criteria(criteria, _container_only_caps())
+    assert audits[0].verdict == "machine_verifiable"
+    assert audits[1].verdict == "human_only"
+    assert audits[2].verdict == "machine_verifiable"
+
+
+# ---------------------------------------------------------------------------
+# validate_requires tests
+# ---------------------------------------------------------------------------
+
+
+def test_validate_requires_must_with_empty_requires_deprecation() -> None:
+    criteria = [{"criterion": "All tests pass", "priority": "must"}]
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        issues = validate_requires(criteria)
+    assert len(issues) == 1
+    assert "empty requires" in issues[0]
+    assert any(issubclass(warning.category, DeprecationWarning) for warning in w)
+
+
+def test_validate_requires_unknown_cap() -> None:
+    criteria = [{"criterion": "Check", "priority": "must", "requires": ["run_tests", "fly_drone"]}]
+    issues = validate_requires(criteria)
+    assert len(issues) == 1
+    assert "fly_drone" in issues[0]
+
+
+def test_validate_requires_all_valid() -> None:
+    criteria = [{"criterion": "Tests", "priority": "must", "requires": ["run_tests", "read_files"]}]
+    issues = validate_requires(criteria)
+    assert issues == []
+
+
+def test_validate_requires_should_with_empty_requires_no_warning() -> None:
+    criteria = [{"criterion": "Nice to have", "priority": "should", "requires": []}]
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        issues = validate_requires(criteria)
+    assert issues == []
+    assert not any(issubclass(warning.category, DeprecationWarning) for warning in w)
+
+
+# ---------------------------------------------------------------------------
+# classify_criteria tests
+# ---------------------------------------------------------------------------
+
+
+def test_classify_criteria_correct_split() -> None:
+    criteria = [
+        {"criterion": "Tests pass", "priority": "must", "requires": ["run_tests"]},
+        {"criterion": "UI check", "priority": "must", "requires": ["drive_browser"]},
+        {"criterion": "Lint clean", "priority": "should", "requires": ["run_linter"]},
+        {"criterion": "Visual check", "priority": "info", "requires": ["inspect_runtime_ui"]},
+    ]
+    machine, human = classify_criteria(criteria, _container_only_caps())
+    assert len(machine) == 2
+    assert len(human) == 2
+    assert machine[0]["criterion"] == "Tests pass"
+    assert machine[1]["criterion"] == "Lint clean"
+    assert human[0]["criterion"] == "UI check"
+    assert human[1]["criterion"] == "Visual check"
+
+
+def test_classify_criteria_all_machine() -> None:
+    criteria = [
+        {"criterion": "Tests", "priority": "must", "requires": ["run_tests"]},
+        {"criterion": "Lint", "priority": "should", "requires": ["run_linter"]},
+    ]
+    machine, human = classify_criteria(criteria, _container_only_caps())
+    assert len(machine) == 2
+    assert len(human) == 0
+
+
+def test_classify_criteria_empty() -> None:
+    machine, human = classify_criteria([], _container_only_caps())
+    assert machine == []
+    assert human == []
+
+
+# ---------------------------------------------------------------------------
+# Worker capability discovery tests
+# ---------------------------------------------------------------------------
+
+
+def test_get_worker_capabilities_explicit_config() -> None:
+    state = {
+        "config": {
+            "workers": {
+                "my-agent": {"verifies": ["run_tests", "read_files"]},
+                "human": {"verifies": ["drive_browser"]},
+            }
+        }
+    }
+    caps = get_worker_capabilities(state)
+    assert caps["my-agent"] == {"run_tests", "read_files"}
+    assert caps["human"] == {"drive_browser"}
+
+
+def test_get_worker_capabilities_default_fallback() -> None:
+    state = {"config": {}}
+    caps = get_worker_capabilities(state)
+    assert len(caps) > 0
+    for agent_caps in caps.values():
+        assert agent_caps == set(DEFAULT_CONTAINER_CAPABILITIES)
+
+
+def test_union_verifies_merges_all() -> None:
+    state = {
+        "config": {
+            "workers": {
+                "a": {"verifies": ["run_tests"]},
+                "b": {"verifies": ["read_files", "run_linter"]},
+            }
+        }
+    }
+    result = union_verifies(state)
+    assert result == {"run_tests", "read_files", "run_linter"}


### PR DESCRIPTION
## Summary

First of three stacked PRs decomposed from `tiebreaker-plus-verifiability-temp` (v0.18.0) which combined verifiability + tiebreaker CLI + auto-trigger in one branch for live-cloud debugging.

Introduces a closed capability registry and a `requires` contract on success criteria, enabling the harness to audit verifiability before critique and defer human-only criteria to a new `awaiting_human_verify` state.

## What this PR contains

- `megaplan/capabilities.py` — closed set of 11 mechanism-shaped capability strings (6 container, 5 human).
- `megaplan/verifiability.py` — validates `requires` against registry + classifies criteria by worker coverage.
- `requires` field on `plan.json` / `revise.json` schemas (backward compatible — defaults to `[]`).
- `verifiability` category added to critique flag enum; `deferred_human` added to review `pass` enum.
- Pre-critique audit injects synthetic `verifiability` flags (fires in both tiny-robustness stub and full critique).
- New state `awaiting_human_verify` + transition via `verify-human` back to `done`.
- CLI commands: `verify-human`, `audit-verifiability`, `status --pending-human`.
- Prompt updates: planning + revise explain the `requires` field; review explains `deferred_human` verdict.
- 29 new tests in `tests/test_verifiability.py` + 3 schema tests. Refreshed tiny-robustness + prompts snapshots.

## What this PR explicitly does NOT contain

- Tiebreaker CLI / researcher+challenger prompts (PR-B, stacked on this branch).
- Tiebreaker auto-trigger (gate routing / iteration pressure / audit) (PR-C, stacked on PR-B).

## Test plan

- [x] `PYENV_VERSION=3.11.11 python -m pytest tests/ -q` → 571 passed, 12 failures (identical to `main` baseline — all pre-existing parallel-critique/parallel-review/schema issues unrelated to this PR).
- [ ] Merge behind PR-B and PR-C, in order.

## Stacked PRs

- **PR-A (this)** `verifiability-contracts` → `main`
- **PR-B** `tiebreaker-cli` → `verifiability-contracts`
- **PR-C** `tiebreaker-auto-trigger` → `tiebreaker-cli`