### PR TITLE
v0.17.1: tiebreaker CLI (PR-B of stacked 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## v0.17.1 — 2026-04-15
+
+### Tiebreaker subcommand (`megaplan tiebreaker`)
+
+New advisory subcommand that produces structured decision context for architectural questions (e.g. when `gate` returns ESCALATE).
+
+- **Two-agent pipeline**: a researcher agent gathers evidence and options, then a challenger agent stress-tests the findings — each in an independent ephemeral session.
+- **CLI**: `megaplan tiebreaker --plan <name> --question "..."` (or `--question-file`), `megaplan tiebreaker status`, `megaplan tiebreaker decide --pick/--escalate/--replan --rationale`.
+- **Structured artifacts**: `tiebreaker_researcher.json`, `tiebreaker_challenger.json`, and a synthesized `tiebreaker.md` with decision-ready sections (options table, evidence summary, agreement/disagreement, fallback plan).
+- **Idempotent**: re-runs produce versioned artifacts (`_v2`, `_v3`, …).
+- **Configurable agents**: `agents.tiebreaker_researcher` and `agents.tiebreaker_challenger` in config, defaulting to codex.
+- **Gate schema**: `TIEBREAKER` added as fourth recommendation, with `tiebreaker_question`, `tiebreaker_flag_ids`, `tiebreaker_fuzzy_group_id` optional fields. Gate prompt documents the new option.
+- **Plan lifecycle**: `tiebreaker_pending` / `tiebreaker_ready` states added with workflow transitions; both are automation-terminal.
+- **Settled-decision immunity**: critique and revise prompts read `tiebreaker_decisions.json` and instruct agents not to re-raise settled concerns without materially new evidence.
+- **Hot-fix**: `_run_tiebreaker` uses `WorkerResult.payload` instead of the nonexistent `.success`/`.parsed`/`.error` attributes — caught by live-cloud smoke run.
+
+Automatic gate-driven tiebreaker routing (pressure analysis, budgeting, audit tracking) lands in v0.18.0.
+
 ## v0.17.0 — 2026-04-15
 
 ### Verifiability contracts

--- a/megaplan/_core/phase_runtime.py
+++ b/megaplan/_core/phase_runtime.py
@@ -99,6 +99,20 @@ PHASE_RUNTIME_POLICY: dict[str, PhaseRuntimePolicy] = {
         escalation_threshold_seconds=None,
         timeout_cap_seconds=None,
     ),
+    "tiebreaker_researcher": PhaseRuntimePolicy(
+        expected_min_seconds=60,
+        expected_max_seconds=DEFAULT_NON_EXECUTE_TIMEOUT_CAP_SECONDS,
+        recommended_next_check_seconds=120,
+        escalation_threshold_seconds=DEFAULT_NON_EXECUTE_TIMEOUT_CAP_SECONDS,
+        timeout_cap_seconds=DEFAULT_NON_EXECUTE_TIMEOUT_CAP_SECONDS,
+    ),
+    "tiebreaker_challenger": PhaseRuntimePolicy(
+        expected_min_seconds=60,
+        expected_max_seconds=DEFAULT_NON_EXECUTE_TIMEOUT_CAP_SECONDS,
+        recommended_next_check_seconds=120,
+        escalation_threshold_seconds=DEFAULT_NON_EXECUTE_TIMEOUT_CAP_SECONDS,
+        timeout_cap_seconds=DEFAULT_NON_EXECUTE_TIMEOUT_CAP_SECONDS,
+    ),
 }
 
 

--- a/megaplan/_core/workflow.py
+++ b/megaplan/_core/workflow.py
@@ -19,6 +19,8 @@ from megaplan.types import (
     STATE_INITIALIZED,
     STATE_PLANNED,
     STATE_PREPPED,
+    STATE_TIEBREAKER_PENDING,
+    STATE_TIEBREAKER_READY,
 )
 
 
@@ -43,6 +45,7 @@ WORKFLOW: dict[str, list[Transition]] = {
     STATE_CRITIQUED: [
         Transition("gate", STATE_GATED, "gate_unset"),
         Transition("revise", STATE_PLANNED, "gate_iterate"),
+        Transition("tiebreaker", STATE_TIEBREAKER_PENDING, "gate_tiebreaker"),
         Transition("override add-note", STATE_CRITIQUED, "gate_escalate"),
         Transition("override force-proceed", STATE_GATED, "gate_escalate"),
         Transition("override abort", STATE_ABORTED, "gate_escalate"),
@@ -67,6 +70,12 @@ WORKFLOW: dict[str, list[Transition]] = {
     ],
     STATE_AWAITING_HUMAN: [
         Transition("verify-human", STATE_DONE),
+    ],
+    STATE_TIEBREAKER_PENDING: [
+        Transition("tiebreaker-run", STATE_TIEBREAKER_READY),
+    ],
+    STATE_TIEBREAKER_READY: [
+        Transition("tiebreaker-decide", STATE_CRITIQUED),
     ],
 }
 
@@ -185,6 +194,8 @@ def _transition_matches(state: PlanState, condition: str) -> bool:
         return recommendation == "ITERATE"
     if condition == "gate_escalate":
         return recommendation == "ESCALATE"
+    if condition == "gate_tiebreaker":
+        return recommendation == "TIEBREAKER"
     if condition == "gate_proceed_blocked":
         return recommendation == "PROCEED" and not gate.get("passed", False)
     if condition == "gate_proceed":

--- a/megaplan/cli.py
+++ b/megaplan/cli.py
@@ -996,6 +996,9 @@ def build_parser() -> argparse.ArgumentParser:
     from megaplan.chain import build_chain_parser
     build_chain_parser(subparsers)
 
+    from megaplan.tiebreaker import build_tiebreaker_parser
+    build_tiebreaker_parser(subparsers)
+
     return parser
 
 
@@ -1102,6 +1105,13 @@ def main(argv: list[str] | None = None) -> int:
         from megaplan.chain import run_chain_cli
         try:
             return run_chain_cli(root, args)
+        except CliError as error:
+            return error_response(error, root=root)
+
+    if args.command == "tiebreaker":
+        from megaplan.tiebreaker import run_tiebreaker_cli
+        try:
+            return run_tiebreaker_cli(root, args)
         except CliError as error:
             return error_response(error, root=root)
 

--- a/megaplan/handlers.py
+++ b/megaplan/handlers.py
@@ -48,6 +48,8 @@ from megaplan.types import (
     STATE_INITIALIZED,
     STATE_PREPPED,
     STATE_PLANNED,
+    STATE_TIEBREAKER_PENDING,
+    STATE_TIEBREAKER_READY,
     StepResponse,
 )
 from megaplan._core import (
@@ -2272,3 +2274,139 @@ def handle_audit_verifiability(root: Path, args: argparse.Namespace) -> StepResp
         "audits": audit_results,
         "validation_issues": issues,
     }
+
+
+def _build_tiebreaker_reprompt(
+    agent_type: str, state: PlanState, plan_dir: Path, *, root: Path,
+) -> str:
+    if agent_type == "claude":
+        base_prompt = create_claude_prompt("gate", state, plan_dir, root=root)
+    elif agent_type == "hermes":
+        base_prompt = create_hermes_prompt("gate", state, plan_dir, root=root)
+    else:
+        base_prompt = create_codex_prompt("gate", state, plan_dir, root=root)
+    addendum = (
+        "You recommended TIEBREAKER but no flag shows mechanical recurrence signal "
+        "(addressed_then_reopened_count >= 2, or >=2 flags across >=2 iterations). "
+        "Either identify specific flag(s) with iteration history or pick ITERATE."
+    )
+    return f"{base_prompt}\n\n{addendum}"
+
+
+def handle_tiebreaker_run(root: Path, args: argparse.Namespace) -> StepResponse:
+    from megaplan._core import workflow_transition
+    with load_plan_locked(root, args.plan, step="tiebreaker-run") as (plan_dir, state):
+        require_state(state, "tiebreaker-run", {STATE_TIEBREAKER_PENDING})
+        gate_data = read_json(plan_dir / "gate.json")
+        question = gate_data.get("tiebreaker_question", "")
+        flag_ids = gate_data.get("tiebreaker_flag_ids", [])
+        fuzzy_group_id = gate_data.get("tiebreaker_fuzzy_group_id", "")
+        if not question:
+            raise CliError("missing_tiebreaker_question", "Gate artifact missing tiebreaker_question")
+
+        tb_args = argparse.Namespace(
+            plan=args.plan, question=question, question_file=None,
+            output=None, agent=getattr(args, "agent", None),
+            hermes=getattr(args, "hermes", None),
+            phase_model=getattr(args, "phase_model", []),
+            fresh=getattr(args, "fresh", False),
+            persist=getattr(args, "persist", False),
+            ephemeral=getattr(args, "ephemeral", False),
+        )
+        from megaplan.tiebreaker import _run_tiebreaker
+        exit_code = _run_tiebreaker(root, plan_dir, state, tb_args)
+        transition = workflow_transition(state, "tiebreaker-run")
+        state["current_state"] = transition.next_state
+        return {
+            "success": exit_code == 0,
+            "step": "tiebreaker-run",
+            "summary": f"Tiebreaker run {'completed' if exit_code == 0 else 'failed'} for question: {question[:80]}",
+            "state": state["current_state"],
+            "plan": state["name"],
+            "next_step": "tiebreaker decide",
+            "details": {
+                "question": question,
+                "flag_ids": flag_ids,
+                "fuzzy_group_id": fuzzy_group_id,
+            },
+        }
+
+
+def handle_tiebreaker_decide(root: Path, args: argparse.Namespace) -> StepResponse:
+    from megaplan._core import workflow_transition
+    with load_plan_locked(root, args.plan, step="tiebreaker-decide") as (plan_dir, state):
+        require_state(state, "tiebreaker-decide", {STATE_TIEBREAKER_READY})
+        action = getattr(args, "tiebreaker_decide_action", "pick")
+        pick = getattr(args, "pick", None)
+        escalate = getattr(args, "escalate", False)
+        replan = getattr(args, "replan", False)
+        rationale = getattr(args, "rationale", "")
+        if escalate:
+            action = "escalate"
+        elif replan:
+            action = "replan"
+        else:
+            action = "pick"
+
+        gate_data = read_json(plan_dir / "gate.json")
+        flag_ids = gate_data.get("tiebreaker_flag_ids", [])
+        fuzzy_group_id = gate_data.get("tiebreaker_fuzzy_group_id", "")
+        question = gate_data.get("tiebreaker_question", "")
+
+        researcher_files = sorted(plan_dir.glob("tiebreaker_researcher*.json"))
+        challenger_files = sorted(plan_dir.glob("tiebreaker_challenger*.json"))
+        researcher_data = read_json(researcher_files[-1]) if researcher_files else {}
+        challenger_data = read_json(challenger_files[-1]) if challenger_files else {}
+
+        from megaplan.types import TiebreakerDecision
+        decision: TiebreakerDecision = {
+            "fuzzy_group_id": fuzzy_group_id,
+            "flag_ids": flag_ids,
+            "question": question,
+            "researcher_pick": researcher_data.get("recommendation", ""),
+            "challenger_pick": challenger_data.get("recommendation", ""),
+            "human_pick": pick or "",
+            "action": action,
+            "rationale": rationale,
+            "timestamp": now_utc(),
+        }
+
+        decisions_path = plan_dir / "tiebreaker_decisions.json"
+        existing = read_json(decisions_path) if decisions_path.exists() else []
+        if not isinstance(existing, list):
+            existing = []
+        existing.append(decision)
+        atomic_write_json(decisions_path, existing)
+
+        if action == "pick" and flag_ids:
+            registry = load_flag_registry(plan_dir)
+            for flag in registry.get("flags", []):
+                if flag["id"] in flag_ids:
+                    flag["settled_by_tiebreaker"] = fuzzy_group_id
+            save_flag_registry(plan_dir, registry)
+
+        if action == "escalate":
+            state["current_state"] = STATE_AWAITING_HUMAN
+            next_step_val = "override add-note"
+        elif action == "replan":
+            state["current_state"] = STATE_PLANNED
+            next_step_val = "critique"
+        else:
+            transition = workflow_transition(state, "tiebreaker-decide")
+            state["current_state"] = transition.next_state
+            next_step_val = "revise"
+
+        return {
+            "success": True,
+            "step": "tiebreaker-decide",
+            "summary": f"Tiebreaker decided: {action} — {rationale[:80]}",
+            "state": state["current_state"],
+            "plan": state["name"],
+            "next_step": next_step_val,
+            "details": {
+                "action": action,
+                "pick": pick,
+                "fuzzy_group_id": fuzzy_group_id,
+                "flag_ids": flag_ids,
+            },
+        }

--- a/megaplan/prompts/critique.py
+++ b/megaplan/prompts/critique.py
@@ -24,6 +24,24 @@ from ._shared import _planning_debt_block, _render_prep_block
 from .planning import PLAN_TEMPLATE
 
 
+def _settled_decisions_block(decisions: list[dict[str, Any]]) -> str:
+    if not decisions:
+        return ""
+    lines = ["Settled tiebreaker decisions (DO NOT re-raise these concerns under a new surface):"]
+    for d in decisions:
+        gid = d.get("fuzzy_group_id", "?")
+        question = d.get("question", "")
+        pick = d.get("human_pick", d.get("action", ""))
+        rationale = d.get("rationale", "")
+        lines.append(f"- {gid}: {question} -> Decision: {pick}. Rationale: {rationale}")
+    lines.append(
+        "\nOnly raise a new concern about these topics if new evidence *materially* "
+        "changes the settled premise — and if so, explicitly cite which settled "
+        "decision you are challenging and why."
+    )
+    return "\n".join(lines)
+
+
 def _revise_prompt(state: PlanState, plan_dir: Path) -> str:
     project_dir = Path(state["config"]["project_dir"])
     prep_block, prep_instruction = _render_prep_block(plan_dir)
@@ -41,6 +59,15 @@ def _revise_prompt(state: PlanState, plan_dir: Path) -> str:
         }
         for flag in unresolved
     ]
+    settled_decisions: list[dict[str, Any]] = []
+    decisions_path = plan_dir / "tiebreaker_decisions.json"
+    if decisions_path.exists():
+        decisions_data = read_json(decisions_path)
+        if isinstance(decisions_data, list):
+            settled_decisions = decisions_data
+        elif isinstance(decisions_data, dict):
+            settled_decisions = decisions_data.get("decisions", [])
+    settled_block = _settled_decisions_block(settled_decisions)
     return textwrap.dedent(
         f"""
         You are revising an implementation plan after critique and gate feedback.
@@ -64,6 +91,8 @@ def _revise_prompt(state: PlanState, plan_dir: Path) -> str:
 
         Open significant flags:
         {json_dump(open_flags).strip()}
+
+        {settled_block}
 
         Requirements:
         - Before addressing individual flags, check: does any flag suggest the plan is targeting the wrong code or the wrong root cause? If so, consider whether the plan needs a new approach rather than adjustments. Explain your reasoning.
@@ -100,6 +129,15 @@ def _critique_context(state: PlanState, plan_dir: Path, root: Path | None = None
         for flag in flag_registry["flags"]
         if flag["status"] in {"addressed", "open", "disputed"}
     ]
+    settled_decisions: list[dict[str, Any]] = []
+    decisions_path = plan_dir / "tiebreaker_decisions.json"
+    if decisions_path.exists():
+        decisions_data = read_json(decisions_path)
+        if isinstance(decisions_data, list):
+            settled_decisions = decisions_data
+        elif isinstance(decisions_data, dict):
+            settled_decisions = decisions_data.get("decisions", [])
+
     return {
         "project_dir": project_dir,
         "prep_block": prep_block,
@@ -110,6 +148,7 @@ def _critique_context(state: PlanState, plan_dir: Path, root: Path | None = None
         "unresolved": unresolved,
         "debt_block": _planning_debt_block(plan_dir, root),
         "robustness": configured_robustness(state),
+        "settled_tiebreaker_decisions": settled_decisions,
     }
 
 
@@ -194,6 +233,8 @@ def _build_critique_prompt(
         {json_dump(context["unresolved"]).strip()}
 
         {context["debt_block"]}
+
+        {_settled_decisions_block(context.get("settled_tiebreaker_decisions", []))}
 
         {critique_review_block}
 

--- a/megaplan/prompts/gate.py
+++ b/megaplan/prompts/gate.py
@@ -91,11 +91,12 @@ def _gate_prompt(state: PlanState, plan_dir: Path, root: Path | None = None) -> 
         {robustness}
 
         Requirements:
-        - Decide exactly one of: PROCEED, ITERATE, ESCALATE.
+        - Decide exactly one of: PROCEED, ITERATE, ESCALATE, TIEBREAKER.
         - Use the weighted score, flag details (including `evidence`), plan delta, recurring critiques, and preflight results as judgment context.
         - PROCEED when execution should move forward now.
         - ITERATE when revising the plan is the best next move.
         - ESCALATE when the loop is stuck, churn is recurring, or user intervention is needed.
+        - TIEBREAKER when a flag group reflects an *unresolvable constraint tension* (architectural or philosophical — requires a human call) rather than a plan-quality issue. If the concern is simply that the plan writer hasn't tried hard enough, use ITERATE instead. When recommending TIEBREAKER you MUST provide `tiebreaker_question` (the decision question for human resolution), `tiebreaker_flag_ids` (which flags this resolves), and `tiebreaker_fuzzy_group_id` (which group this resolves). Cite specific flag IDs in your rationale.
         - `signals_assessment`: one paragraph summarizing score trajectory, flag status, and preflight posture.
 
         Flags come in two tiers:

--- a/megaplan/prompts/tiebreaker_challenger.py
+++ b/megaplan/prompts/tiebreaker_challenger.py
@@ -1,0 +1,73 @@
+"""Tiebreaker challenger prompt builder."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+from typing import Any
+
+from megaplan._core import json_dump
+from megaplan.types import PlanState
+
+from ._shared import _render_prep_block
+
+
+def challenger_prompt(
+    question: str,
+    researcher_output: dict[str, Any],
+    state: PlanState,
+    plan_dir: Path,
+    *,
+    root: Path | None = None,
+) -> str:
+    project_dir = Path(state["config"]["project_dir"])
+    prep_block, prep_instruction = _render_prep_block(plan_dir)
+
+    return textwrap.dedent(f"""\
+You are a senior engineer stress-testing a colleague's architectural research.
+Your mandate is **stress-test, not restate**. Do not summarize or agree with
+the researcher's findings — challenge them. Look for what they missed, what
+they assumed without evidence, and where their reasoning breaks under pressure.
+
+Project directory:
+{project_dir}
+
+{prep_block}
+{prep_instruction}
+
+## Decision Question
+
+{question}
+
+## Researcher's Output (JSON)
+
+```json
+{json_dump(researcher_output).strip()}
+```
+
+## Your task
+
+1. **Measurements vs assumptions.** Which of the researcher's claims are backed
+   by actual measurements or code evidence, and which are assumptions dressed as
+   facts? Call out the gap.
+
+2. **Missing options.** Are there viable options the researcher did not consider?
+   For each, describe it and explain why it was likely missed.
+
+3. **Hard cases.** Identify specific scenarios where each proposed option would
+   break or perform poorly. State the scenario, which option breaks, and the
+   severity.
+
+4. **Reframings.** Is the question itself framed correctly? Suggest alternative
+   framings that might dissolve the dilemma.
+
+5. **Aging analysis.** How will each option age over 6-12 months? Which will
+   create the most technical debt or lock-in?
+
+6. **Counter-recommendation.** State your own pick (may agree or disagree with
+   the researcher), with rationale.
+
+## Output format
+
+Respond with a JSON object matching the tiebreaker_challenger schema.
+""")

--- a/megaplan/prompts/tiebreaker_researcher.py
+++ b/megaplan/prompts/tiebreaker_researcher.py
@@ -1,0 +1,79 @@
+"""Tiebreaker researcher prompt builder."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+from megaplan._core import (
+    intent_and_notes_block,
+    json_dump,
+    latest_plan_path,
+    read_json,
+)
+from megaplan.types import PlanState
+
+from ._shared import _render_prep_block
+
+
+def researcher_prompt(
+    question: str,
+    state: PlanState,
+    plan_dir: Path,
+    *,
+    root: Path | None = None,
+) -> str:
+    project_dir = Path(state["config"]["project_dir"])
+    prep_block, prep_instruction = _render_prep_block(plan_dir)
+
+    plan_text = ""
+    try:
+        plan_path = latest_plan_path(plan_dir, state)
+        plan_text = plan_path.read_text(encoding="utf-8")
+    except Exception:
+        pass
+
+    critique_block = ""
+    critique_path = plan_dir / "critique.json"
+    if critique_path.exists():
+        critique_data = read_json(critique_path)
+        critique_block = f"\nCritique history:\n{json_dump(critique_data).strip()}\n"
+
+    return textwrap.dedent(f"""\
+You are a senior engineer researching an architectural/design decision.
+Your mandate is **evidence over opinion**. Every claim you make must cite
+specific file paths, measurements, or documented patterns from the codebase.
+Do not speculate — if you cannot find evidence, say so explicitly.
+
+Project directory:
+{project_dir}
+
+{prep_block}
+{prep_instruction}
+
+{intent_and_notes_block(state)}
+
+Current plan (if any):
+{plan_text or "(no plan yet)"}
+{critique_block}
+## Decision Question
+
+{question}
+
+## Your task
+
+1. **Gather evidence.** Search the codebase for code, patterns, measurements,
+   and documentation relevant to the question. For each piece of evidence,
+   record the claim, evidence type (code/measurement/pattern/doc), the file
+   paths where you found it, and a representative quote.
+
+2. **Enumerate options.** List every viable option you can identify. For each,
+   describe it, state its assumptions, and list its costs.
+
+3. **Make a preliminary pick.** Choose the option you believe is strongest,
+   explain your rationale, and state what you are least sure about.
+
+## Output format
+
+Respond with a JSON object matching the tiebreaker_researcher schema.
+Always cite file paths relative to the project root.
+""")

--- a/megaplan/prompts/tiebreaker_synthesis.py
+++ b/megaplan/prompts/tiebreaker_synthesis.py
@@ -1,0 +1,114 @@
+"""Tiebreaker synthesis renderer — pure function, no LLM calls."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def render_synthesis(
+    question: str,
+    researcher: dict[str, Any],
+    challenger: dict[str, Any],
+) -> str:
+    sections: list[str] = []
+
+    sections.append(f"# Tiebreaker: Decision Brief\n\n## Decision\n\n{question}")
+
+    # Options Considered (table)
+    options = researcher.get("options", [])
+    rows = ["| Option | Description | Assumptions | Costs |", "| --- | --- | --- | --- |"]
+    for opt in options:
+        assumptions = "; ".join(opt.get("assumptions", []))
+        costs = "; ".join(opt.get("costs", []))
+        rows.append(f"| {opt.get('name', '')} | {opt.get('description', '')} | {assumptions} | {costs} |")
+    for missed in challenger.get("missing_options", []):
+        rows.append(f"| {missed.get('name', '')} *(challenger)* | {missed.get('description', '')} | — | — |")
+    sections.append(f"## Options Considered\n\n" + "\n".join(rows))
+
+    # Evidence Summary
+    evidence_lines = []
+    for ev in researcher.get("evidence", []):
+        paths = ", ".join(ev.get("file_paths", []))
+        evidence_lines.append(f"- **{ev.get('claim', '')}** [{ev.get('evidence_type', '')}] ({paths})")
+    if challenger.get("measurements_vs_assumptions"):
+        evidence_lines.append(f"\n*Challenger assessment:* {challenger['measurements_vs_assumptions']}")
+    sections.append(f"## Evidence Summary\n\n" + "\n".join(evidence_lines) if evidence_lines else "## Evidence Summary\n\nNo evidence collected.")
+
+    # Researcher Pick
+    pick = researcher.get("preliminary_pick", {})
+    sections.append(
+        f"## Researcher Pick\n\n"
+        f"**{pick.get('option_name', 'N/A')}** — {pick.get('rationale', '')}\n\n"
+        f"*Least sure about:* {pick.get('what_im_least_sure_about', 'N/A')}"
+    )
+
+    # Challenger Assessment
+    counter = challenger.get("counter_recommendation", {})
+    hard_cases_lines = []
+    for hc in challenger.get("hard_cases", []):
+        hard_cases_lines.append(f"- {hc.get('scenario', '')}: breaks **{hc.get('which_option_breaks', '')}** ({hc.get('severity', '')})")
+    challenger_section = (
+        f"## Challenger Assessment\n\n"
+        f"**Pick:** {counter.get('option_name', 'N/A')} — {counter.get('rationale', '')}\n\n"
+        f"**Agrees with researcher:** {'Yes' if counter.get('agrees_with_researcher') else 'No'}"
+    )
+    if hard_cases_lines:
+        challenger_section += f"\n\n**Hard cases:**\n" + "\n".join(hard_cases_lines)
+    if challenger.get("aging_analysis"):
+        challenger_section += f"\n\n**Aging analysis:** {challenger['aging_analysis']}"
+    sections.append(challenger_section)
+
+    # Where They Agree
+    agrees_with = counter.get("agrees_with_researcher", False)
+    if agrees_with:
+        agree_text = f"Both recommend **{pick.get('option_name', 'N/A')}**."
+    else:
+        agree_text = _find_agreements(researcher, challenger)
+    sections.append(f"## Where They Agree\n\n{agree_text}")
+
+    # Where They Disagree
+    if agrees_with:
+        disagree_text = "No fundamental disagreement on the pick."
+        if challenger.get("measurements_vs_assumptions"):
+            disagree_text += f" However, the challenger notes: {challenger['measurements_vs_assumptions']}"
+    else:
+        disagree_text = (
+            f"Researcher picks **{pick.get('option_name', 'N/A')}**; "
+            f"challenger picks **{counter.get('option_name', 'N/A')}**.\n\n"
+            f"Researcher rationale: {pick.get('rationale', 'N/A')}\n\n"
+            f"Challenger rationale: {counter.get('rationale', 'N/A')}"
+        )
+    sections.append(f"## Where They Disagree\n\n{disagree_text}")
+
+    # Recommended Framing
+    reframings = challenger.get("reframings", [])
+    if reframings:
+        framing_text = "\n".join(f"- {r}" for r in reframings)
+    else:
+        framing_text = "No alternative framings suggested."
+    sections.append(f"## Recommended Framing\n\n{framing_text}")
+
+    # Fallback Plan
+    if agrees_with:
+        fallback_text = f"If **{pick.get('option_name', 'N/A')}** fails, revisit the challenger's hard cases for pivot criteria."
+    else:
+        fallback_text = (
+            f"If the chosen option fails:\n"
+            f"- If **{pick.get('option_name', 'N/A')}** was chosen, consider pivoting to **{counter.get('option_name', 'N/A')}**.\n"
+            f"- If **{counter.get('option_name', 'N/A')}** was chosen, consider pivoting to **{pick.get('option_name', 'N/A')}**."
+        )
+    sections.append(f"## Fallback Plan\n\n{fallback_text}")
+
+    return "\n\n".join(sections) + "\n"
+
+
+def _find_agreements(
+    researcher: dict[str, Any],
+    challenger: dict[str, Any],
+) -> str:
+    researcher_options = {o.get("name") for o in researcher.get("options", [])}
+    challenger_missing = {o.get("name") for o in challenger.get("missing_options", [])}
+    shared = researcher_options - challenger_missing
+    if shared:
+        return f"Both consider these options viable: {', '.join(sorted(shared))}."
+    return "Limited agreement on the option space."

--- a/megaplan/schemas.py
+++ b/megaplan/schemas.py
@@ -117,7 +117,7 @@ SCHEMAS: dict[str, dict[str, Any]] = {
         "properties": {
             "recommendation": {
                 "type": "string",
-                "enum": ["PROCEED", "ITERATE", "ESCALATE"],
+                "enum": ["PROCEED", "ITERATE", "ESCALATE", "TIEBREAKER"],
             },
             "rationale": {"type": "string"},
             "signals_assessment": {"type": "string"},
@@ -160,6 +160,12 @@ SCHEMAS: dict[str, dict[str, Any]] = {
                     "required": ["flag_id", "concern", "subsystem", "rationale"],
                 },
             },
+            "tiebreaker_question": {"type": "string"},
+            "tiebreaker_flag_ids": {
+                "type": "array",
+                "items": {"type": "string"},
+            },
+            "tiebreaker_fuzzy_group_id": {"type": "string"},
         },
         "required": [
             "recommendation",
@@ -363,6 +369,100 @@ SCHEMAS: dict[str, dict[str, Any]] = {
             "reasoning": {"type": "string"},
         },
         "required": ["spec_updates", "next_action", "reasoning"],
+    },
+    "tiebreaker_researcher.json": {
+        "type": "object",
+        "properties": {
+            "question": {"type": "string"},
+            "evidence": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "claim": {"type": "string"},
+                        "evidence_type": {
+                            "type": "string",
+                            "enum": ["code", "measurement", "pattern", "doc"],
+                        },
+                        "file_paths": {"type": "array", "items": {"type": "string"}},
+                        "quote": {"type": "string"},
+                    },
+                    "required": ["claim", "evidence_type", "file_paths", "quote"],
+                },
+            },
+            "options": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "description": {"type": "string"},
+                        "assumptions": {"type": "array", "items": {"type": "string"}},
+                        "costs": {"type": "array", "items": {"type": "string"}},
+                    },
+                    "required": ["name", "description", "assumptions", "costs"],
+                },
+            },
+            "preliminary_pick": {
+                "type": "object",
+                "properties": {
+                    "option_name": {"type": "string"},
+                    "rationale": {"type": "string"},
+                    "what_im_least_sure_about": {"type": "string"},
+                },
+                "required": ["option_name", "rationale", "what_im_least_sure_about"],
+            },
+        },
+        "required": ["question", "evidence", "options", "preliminary_pick"],
+    },
+    "tiebreaker_challenger.json": {
+        "type": "object",
+        "properties": {
+            "measurements_vs_assumptions": {"type": "string"},
+            "missing_options": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "description": {"type": "string"},
+                        "why_missed": {"type": "string"},
+                    },
+                    "required": ["name", "description", "why_missed"],
+                },
+            },
+            "hard_cases": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "scenario": {"type": "string"},
+                        "which_option_breaks": {"type": "string"},
+                        "severity": {"type": "string"},
+                    },
+                    "required": ["scenario", "which_option_breaks", "severity"],
+                },
+            },
+            "reframings": {"type": "array", "items": {"type": "string"}},
+            "aging_analysis": {"type": "string"},
+            "counter_recommendation": {
+                "type": "object",
+                "properties": {
+                    "option_name": {"type": "string"},
+                    "rationale": {"type": "string"},
+                    "agrees_with_researcher": {"type": "boolean"},
+                },
+                "required": ["option_name", "rationale", "agrees_with_researcher"],
+            },
+        },
+        "required": [
+            "measurements_vs_assumptions",
+            "missing_options",
+            "hard_cases",
+            "reframings",
+            "aging_analysis",
+            "counter_recommendation",
+        ],
     },
     "loop_execute.json": {
         "type": "object",

--- a/megaplan/tiebreaker.py
+++ b/megaplan/tiebreaker.py
@@ -1,0 +1,295 @@
+"""Tiebreaker subcommand — structured decision support for architectural questions.
+
+Runs two independent subagents (researcher → challenger) then synthesizes
+their output into a human-readable decision brief.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from megaplan._core import (
+    atomic_write_json,
+    atomic_write_text,
+    read_json,
+    resolve_plan_dir,
+)
+from megaplan.prompts.tiebreaker_challenger import challenger_prompt
+from megaplan.prompts.tiebreaker_researcher import researcher_prompt
+from megaplan.prompts.tiebreaker_synthesis import render_synthesis
+from megaplan.types import CliError, PlanState
+from megaplan.workers import run_step_with_worker
+
+
+# ---------------------------------------------------------------------------
+# Version-suffix logic
+# ---------------------------------------------------------------------------
+
+
+def _next_version_suffix(plan_dir: Path) -> str:
+    """Scan for existing tiebreaker_researcher* artifacts and return the next suffix.
+
+    First run → "", second → "_v2", third → "_v3", etc.
+    """
+    existing = sorted(plan_dir.glob("tiebreaker_researcher*.json"))
+    count = len(existing)
+    if count == 0:
+        return ""
+    return f"_v{count + 1}"
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+
+def _run_tiebreaker(
+    root: Path,
+    plan_dir: Path,
+    state: PlanState,
+    args: argparse.Namespace,
+) -> int:
+    question = _resolve_question(args)
+    suffix = _next_version_suffix(plan_dir)
+
+    researcher_file = f"tiebreaker_researcher{suffix}.json"
+    challenger_file = f"tiebreaker_challenger{suffix}.json"
+    synthesis_file = f"tiebreaker{suffix}.md"
+
+    # -- Researcher pass --
+    r_prompt = researcher_prompt(question, state, plan_dir, root=root)
+    resolved = _build_resolved(args, "tiebreaker_researcher")
+
+    researcher_result, r_agent, _, _ = run_step_with_worker(
+        "tiebreaker_researcher",
+        dict(state),  # FLAG-003: shallow copy to prevent state pollution
+        plan_dir,
+        args,
+        root=root,
+        resolved=resolved,
+        prompt_override=r_prompt,
+    )
+    researcher_data = researcher_result.payload or {}
+    atomic_write_json(plan_dir / researcher_file, researcher_data)
+    sys.stderr.write(f"[tiebreaker] researcher done → {researcher_file}\n")
+
+    # -- Challenger pass --
+    c_prompt = challenger_prompt(
+        question, researcher_data, state, plan_dir, root=root
+    )
+    resolved_c = _build_resolved(args, "tiebreaker_challenger")
+
+    challenger_result, c_agent, _, _ = run_step_with_worker(
+        "tiebreaker_challenger",
+        dict(state),  # FLAG-003: shallow copy
+        plan_dir,
+        args,
+        root=root,
+        resolved=resolved_c,
+        prompt_override=c_prompt,
+    )
+    challenger_data = challenger_result.payload or {}
+    atomic_write_json(plan_dir / challenger_file, challenger_data)
+    sys.stderr.write(f"[tiebreaker] challenger done → {challenger_file}\n")
+
+    # -- Synthesis --
+    synthesis_md = render_synthesis(question, researcher_data, challenger_data)
+    atomic_write_text(plan_dir / synthesis_file, synthesis_md)
+    sys.stderr.write(f"[tiebreaker] synthesis → {synthesis_file}\n")
+
+    output_path = getattr(args, "output", None)
+    if output_path:
+        Path(output_path).write_text(synthesis_md, encoding="utf-8")
+        sys.stderr.write(f"[tiebreaker] also written to {output_path}\n")
+
+    payload = {
+        "success": True,
+        "plan": state["name"],
+        "question": question,
+        "researcher_agent": r_agent,
+        "challenger_agent": c_agent,
+        "artifacts": {
+            "researcher": researcher_file,
+            "challenger": challenger_file,
+            "synthesis": synthesis_file,
+        },
+    }
+    sys.stdout.write(json.dumps(payload, indent=2) + "\n")
+    return 0
+
+
+def _build_resolved(
+    args: argparse.Namespace, step: str
+) -> tuple[str, str, bool, str | None]:
+    """Build a resolved tuple for ephemeral mode (FLAG-002)."""
+    from megaplan.workers import resolve_agent_mode
+
+    agent, _mode, _refreshed, model = resolve_agent_mode(step, args)
+    return (agent, "ephemeral", True, model)
+
+
+def _resolve_question(args: argparse.Namespace) -> str:
+    question_file = getattr(args, "question_file", None)
+    question_inline = getattr(args, "question", None)
+    if question_file:
+        path = Path(question_file)
+        if not path.exists():
+            raise CliError("missing_file", f"Question file not found: {question_file}")
+        return path.read_text(encoding="utf-8").strip()
+    if question_inline:
+        return question_inline.strip()
+    raise CliError("invalid_args", "Provide --question or --question-file")
+
+
+# ---------------------------------------------------------------------------
+# Status
+# ---------------------------------------------------------------------------
+
+
+def _run_tiebreaker_status(
+    root: Path,
+    plan_dir: Path,
+    state: PlanState,
+) -> int:
+    researcher_files = sorted(plan_dir.glob("tiebreaker_researcher*.json"))
+    challenger_files = sorted(plan_dir.glob("tiebreaker_challenger*.json"))
+    synthesis_files = sorted(plan_dir.glob("tiebreaker*.md"))
+
+    runs: list[dict[str, Any]] = []
+    for rf in researcher_files:
+        suffix = rf.stem.replace("tiebreaker_researcher", "")
+        cf = plan_dir / f"tiebreaker_challenger{suffix}.json"
+        sf = plan_dir / f"tiebreaker{suffix}.md"
+        runs.append({
+            "suffix": suffix or "(first)",
+            "researcher": rf.name,
+            "challenger": cf.name if cf.exists() else None,
+            "synthesis": sf.name if sf.exists() else None,
+            "complete": cf.exists() and sf.exists(),
+        })
+
+    payload = {
+        "success": True,
+        "plan": state["name"],
+        "runs": runs,
+        "total_runs": len(runs),
+    }
+    sys.stdout.write(json.dumps(payload, indent=2) + "\n")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# CLI plumbing
+# ---------------------------------------------------------------------------
+
+
+def _add_common_agent_args(parser: argparse.ArgumentParser) -> None:
+    """Add the agent/session flags that resolve_agent_mode expects (FLAG-001)."""
+    parser.add_argument(
+        "--agent",
+        choices=["claude", "codex", "hermes"],
+        default=None,
+        help="Agent to use for tiebreaker steps",
+    )
+    parser.add_argument(
+        "--hermes",
+        nargs="?",
+        const="",
+        default=None,
+        help="Use Hermes agent. Optional: specify model",
+    )
+    parser.add_argument(
+        "--phase-model",
+        action="append",
+        default=[],
+        help="Per-step model override, e.g. --phase-model tiebreaker_researcher=hermes:openai/gpt-5",
+    )
+    parser.add_argument("--fresh", action="store_true")
+    parser.add_argument("--persist", action="store_true")
+    parser.add_argument("--ephemeral", action="store_true")
+
+
+def build_tiebreaker_parser(subparsers: Any) -> None:
+    tb_parser = subparsers.add_parser(
+        "tiebreaker",
+        help="Run structured decision support for architectural questions",
+    )
+    tb_sub = tb_parser.add_subparsers(dest="tiebreaker_action")
+
+    # Default (run) action args live on the top-level tiebreaker parser.
+    tb_parser.add_argument("--plan", default=None, help="Plan name")
+    question_group = tb_parser.add_mutually_exclusive_group()
+    question_group.add_argument("--question", help="Decision question (inline)")
+    question_group.add_argument("--question-file", help="Path to decision question file")
+    tb_parser.add_argument("--output", help="Additional output path for the synthesis markdown")
+    _add_common_agent_args(tb_parser)
+
+    # Status subcommand
+    status_parser = tb_sub.add_parser("status", help="Show tiebreaker run status")
+    status_parser.add_argument("--plan", default=None, help="Plan name")
+
+    # Decide subcommand
+    decide_parser = tb_sub.add_parser("decide", help="Record human tiebreaker decision")
+    decide_parser.add_argument("--plan", default=None, help="Plan name")
+    decide_group = decide_parser.add_mutually_exclusive_group(required=True)
+    decide_group.add_argument("--pick", help="Option name to pick")
+    decide_group.add_argument("--escalate", action="store_true", help="Escalate to human outside tool")
+    decide_group.add_argument("--replan", action="store_true", help="Question itself is wrong; replan")
+    decide_parser.add_argument("--rationale", required=True, help="Rationale for the decision")
+
+    # Audit subcommand
+    audit_parser = tb_sub.add_parser("audit", help="Show tiebreaker usage stats")
+    audit_group = audit_parser.add_mutually_exclusive_group()
+    audit_group.add_argument("--plan", default=None, help="Plan name")
+    audit_group.add_argument("--global", dest="global_audit", action="store_true", help="Aggregate across all plans")
+
+
+def run_tiebreaker_cli(root: Path, args: argparse.Namespace) -> int:
+    action = getattr(args, "tiebreaker_action", None)
+    plan_name = getattr(args, "plan", None)
+
+    if action == "audit":
+        return _run_tiebreaker_audit(root, plan_name)
+
+    plan_dir = resolve_plan_dir(root, plan_name)
+    state: PlanState = read_json(plan_dir / "state.json")
+
+    if action == "status":
+        return _run_tiebreaker_status(root, plan_dir, state)
+
+    if action == "decide":
+        from megaplan.handlers import handle_tiebreaker_decide
+        response = handle_tiebreaker_decide(root, args)
+        sys.stdout.write(json.dumps(response, indent=2) + "\n")
+        return 0 if response.get("success") else 1
+
+    return _run_tiebreaker(root, plan_dir, state, args)
+
+
+def _run_tiebreaker_audit(root: Path, plan_name: str | None) -> int:
+    try:
+        from megaplan.audit import (
+            aggregate_tiebreaker_audit,
+            load_tiebreaker_audit,
+            render_audit_report,
+        )
+    except ImportError:
+        sys.stdout.write("Tiebreaker audit requires megaplan.audit (introduced in v0.18.0).\n")
+        return 1
+    if plan_name:
+        plan_dir = resolve_plan_dir(root, plan_name)
+        records = load_tiebreaker_audit(plan_dir)
+        from megaplan.audit import _compute_totals
+        data = {"plans": [{"plan_dir": plan_dir.name, "tiebreaker_count": len(records),
+                           "tokens_spent": sum(r.get("tokens_spent", 0) for r in records),
+                           "time_seconds": sum(r.get("time_seconds", 0) for r in records),
+                           "matched_researcher": sum(1 for r in records if r.get("matched_researcher")),
+                           "matched_challenger": sum(1 for r in records if r.get("matched_challenger"))}],
+                "totals": _compute_totals(records)}
+    else:
+        data = aggregate_tiebreaker_audit(root)
+    sys.stdout.write(render_audit_report(data) + "\n")
+    return 0

--- a/megaplan/types.py
+++ b/megaplan/types.py
@@ -19,8 +19,14 @@ STATE_EXECUTED = "executed"
 STATE_DONE = "done"
 STATE_ABORTED = "aborted"
 STATE_AWAITING_HUMAN = "awaiting_human_verify"
+STATE_TIEBREAKER_PENDING = "tiebreaker_pending"
+STATE_TIEBREAKER_READY = "tiebreaker_ready"
 TERMINAL_STATES = {STATE_DONE, STATE_ABORTED}
-AUTOMATION_TERMINAL_STATES = TERMINAL_STATES | {STATE_AWAITING_HUMAN}
+AUTOMATION_TERMINAL_STATES = TERMINAL_STATES | {
+    STATE_AWAITING_HUMAN,
+    STATE_TIEBREAKER_PENDING,
+    STATE_TIEBREAKER_READY,
+}
 
 
 # ---------------------------------------------------------------------------
@@ -34,6 +40,12 @@ class PlanConfig(TypedDict, total=False):
     mode: str
     output_path: str
     agents: dict[str, str]
+    workers: NotRequired[dict[str, Any]]
+    max_tiebreakers_per_plan: int
+    tiebreaker_blocklist: list[str]
+    allow_tiebreaker: bool
+    tiebreaker_token_budget: int
+    tiebreaker_time_budget_minutes: int
 
 
 class PlanMeta(TypedDict, total=False):
@@ -141,6 +153,7 @@ class FlagRecord(_FlagRecordRequired, total=False):
     verified: bool
     verified_in: str
     addressed_in: str
+    settled_by_tiebreaker: str
 
 
 class FlagRegistry(TypedDict):
@@ -158,6 +171,18 @@ class SettledDecision(TypedDict, total=False):
     id: str
     decision: str
     rationale: str
+
+
+class TiebreakerDecision(TypedDict, total=False):
+    fuzzy_group_id: str
+    flag_ids: list[str]
+    question: str
+    researcher_pick: str
+    challenger_pick: str
+    human_pick: str
+    action: str
+    rationale: str
+    timestamp: str
 
 
 class GatePayload(TypedDict):
@@ -279,6 +304,8 @@ DEFAULT_AGENT_ROUTING: dict[str, str] = {
     "loop_plan": "claude",
     "loop_execute": "codex",
     "review": "codex",
+    "tiebreaker_researcher": "codex",
+    "tiebreaker_challenger": "codex",
 }
 KNOWN_AGENTS = ["claude", "codex", "hermes"]
 ROBUSTNESS_LEVELS = ("tiny", "light", "standard", "robust", "superrobust")

--- a/megaplan/workers.py
+++ b/megaplan/workers.py
@@ -59,6 +59,8 @@ STEP_SCHEMA_FILENAMES: dict[str, str] = {
     "loop_plan": "loop_plan.json",
     "loop_execute": "loop_execute.json",
     "review": "review.json",
+    "tiebreaker_researcher": "tiebreaker_researcher.json",
+    "tiebreaker_challenger": "tiebreaker_challenger.json",
 }
 
 # Derive required keys per step from SCHEMAS so they aren't duplicated.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "megaplan-harness"
-version = "0.17.0"
+version = "0.17.1"
 description = "AI agent harness for coordinating Claude and GPT to make and execute extremely robust plans"
 requires-python = ">=3.11"
 license = { text = "OSNL-0.2" }

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -363,8 +363,13 @@ def test_gate_schema_is_strict_and_requires_core_fields() -> None:
         "settled_decisions",
         "flag_resolutions",
         "accepted_tradeoffs",
+        "tiebreaker_question",
+        "tiebreaker_flag_ids",
+        "tiebreaker_fuzzy_group_id",
     ]
-    assert schema["properties"]["recommendation"]["enum"] == ["PROCEED", "ITERATE", "ESCALATE"]
+    assert schema["properties"]["recommendation"]["enum"] == [
+        "PROCEED", "ITERATE", "ESCALATE", "TIEBREAKER",
+    ]
 
 
 def test_plan_schema_has_core_fields_only() -> None:
@@ -518,3 +523,26 @@ def test_critique_schema_accepts_verifiability_category() -> None:
     critique = SCHEMAS["critique.json"]
     category_enum = critique["properties"]["flags"]["items"]["properties"]["category"]["enum"]
     assert "verifiability" in category_enum
+
+
+def test_gate_schema_accepts_tiebreaker_recommendation() -> None:
+    schema = SCHEMAS["gate.json"]
+    assert "TIEBREAKER" in schema["properties"]["recommendation"]["enum"]
+    props = schema["properties"]
+    assert "tiebreaker_question" in props
+    assert "tiebreaker_flag_ids" in props
+    assert "tiebreaker_fuzzy_group_id" in props
+
+
+def test_tiebreaker_schemas_registered() -> None:
+    assert "tiebreaker_researcher.json" in SCHEMAS
+    assert "tiebreaker_challenger.json" in SCHEMAS
+    researcher = SCHEMAS["tiebreaker_researcher.json"]
+    challenger = SCHEMAS["tiebreaker_challenger.json"]
+    assert researcher["type"] == "object"
+    assert challenger["type"] == "object"
+    assert "evidence" in researcher["properties"]
+    assert "options" in researcher["properties"]
+    assert "preliminary_pick" in researcher["properties"]
+    assert "counter_recommendation" in challenger["properties"]
+    assert "missing_options" in challenger["properties"]

--- a/tests/test_tiebreaker.py
+++ b/tests/test_tiebreaker.py
@@ -1,0 +1,278 @@
+"""Tests for megaplan.tiebreaker — prompts, schemas, synthesis, version suffix, status."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import validate, ValidationError
+
+from megaplan.schemas import SCHEMAS
+from megaplan.prompts.tiebreaker_researcher import researcher_prompt
+from megaplan.prompts.tiebreaker_challenger import challenger_prompt
+from megaplan.prompts.tiebreaker_synthesis import render_synthesis
+from megaplan.tiebreaker import _next_version_suffix, _run_tiebreaker_status
+from megaplan.types import PlanState
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_state(tmp_path: Path) -> PlanState:
+    plan_dir = tmp_path / "plan"
+    plan_dir.mkdir()
+    return {
+        "name": "test-plan",
+        "config": {"project_dir": str(tmp_path)},
+        "idea": "Test idea",
+        "intent": "Test intent",
+        "user_notes": "",
+        "meta": {"notes": []},
+        "iteration": 1,
+        "history": [],
+    }
+
+
+def _minimal_researcher_payload() -> dict:
+    return {
+        "question": "Should we use REST or gRPC?",
+        "evidence": [
+            {
+                "claim": "Existing API uses REST",
+                "evidence_type": "code",
+                "file_paths": ["src/api.py"],
+                "quote": "app = Flask(__name__)",
+            }
+        ],
+        "options": [
+            {
+                "name": "REST",
+                "description": "Keep using REST",
+                "assumptions": ["Team knows REST"],
+                "costs": ["No streaming"],
+            },
+            {
+                "name": "gRPC",
+                "description": "Switch to gRPC",
+                "assumptions": ["Team can learn protobuf"],
+                "costs": ["Migration effort"],
+            },
+        ],
+        "preliminary_pick": {
+            "option_name": "REST",
+            "rationale": "Lower migration cost",
+            "what_im_least_sure_about": "Streaming needs",
+        },
+    }
+
+
+def _minimal_challenger_payload() -> dict:
+    return {
+        "measurements_vs_assumptions": "REST claim is code-backed; streaming need is assumed",
+        "missing_options": [
+            {
+                "name": "GraphQL",
+                "description": "Use GraphQL as middle ground",
+                "why_missed": "Not considered due to team bias",
+            }
+        ],
+        "hard_cases": [
+            {
+                "scenario": "High-throughput event stream",
+                "which_option_breaks": "REST",
+                "severity": "high",
+            }
+        ],
+        "reframings": ["Consider hybrid: REST for CRUD, gRPC for streams"],
+        "aging_analysis": "REST ages well for simple CRUD; gRPC ages better for microservices",
+        "counter_recommendation": {
+            "option_name": "gRPC",
+            "rationale": "Better long-term fit",
+            "agrees_with_researcher": False,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. Researcher prompt rendering
+# ---------------------------------------------------------------------------
+
+
+class TestResearcherPrompt:
+    def test_contains_question(self, tmp_path: Path) -> None:
+        state = _make_state(tmp_path)
+        plan_dir = tmp_path / "plan"
+        result = researcher_prompt("Should we use REST or gRPC?", state, plan_dir, root=tmp_path)
+        assert "Should we use REST or gRPC?" in result
+
+    def test_evidence_over_opinion_directive(self, tmp_path: Path) -> None:
+        state = _make_state(tmp_path)
+        plan_dir = tmp_path / "plan"
+        result = researcher_prompt("Q?", state, plan_dir, root=tmp_path)
+        assert "evidence over opinion" in result.lower()
+
+    def test_file_path_citation_instructions(self, tmp_path: Path) -> None:
+        state = _make_state(tmp_path)
+        plan_dir = tmp_path / "plan"
+        result = researcher_prompt("Q?", state, plan_dir, root=tmp_path)
+        assert "file path" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# 2. Challenger prompt rendering
+# ---------------------------------------------------------------------------
+
+
+class TestChallengerPrompt:
+    def test_contains_researcher_json(self, tmp_path: Path) -> None:
+        state = _make_state(tmp_path)
+        plan_dir = tmp_path / "plan"
+        researcher_data = _minimal_researcher_payload()
+        result = challenger_prompt("Q?", researcher_data, state, plan_dir, root=tmp_path)
+        assert "Should we use REST or gRPC?" in result
+        assert "preliminary_pick" in result
+
+    def test_stress_test_directive(self, tmp_path: Path) -> None:
+        state = _make_state(tmp_path)
+        plan_dir = tmp_path / "plan"
+        result = challenger_prompt("Q?", {}, state, plan_dir, root=tmp_path)
+        assert "stress-test" in result.lower()
+
+    def test_no_session_context(self, tmp_path: Path) -> None:
+        state = _make_state(tmp_path)
+        plan_dir = tmp_path / "plan"
+        result = challenger_prompt("Q?", {}, state, plan_dir, root=tmp_path)
+        assert "session" not in result.lower() or "session context" not in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# 3. Synthesis rendering
+# ---------------------------------------------------------------------------
+
+
+class TestSynthesisRendering:
+    def test_all_section_headers_present(self) -> None:
+        researcher = _minimal_researcher_payload()
+        challenger = _minimal_challenger_payload()
+        md = render_synthesis("Should we use REST or gRPC?", researcher, challenger)
+        for header in [
+            "## Decision",
+            "## Options Considered",
+            "## Evidence Summary",
+            "## Researcher Pick",
+            "## Challenger Assessment",
+            "## Where They Agree",
+            "## Where They Disagree",
+            "## Recommended Framing",
+            "## Fallback Plan",
+        ]:
+            assert header in md, f"Missing section header: {header}"
+
+    def test_options_table_columns(self) -> None:
+        researcher = _minimal_researcher_payload()
+        challenger = _minimal_challenger_payload()
+        md = render_synthesis("Q?", researcher, challenger)
+        assert "| Option | Description | Assumptions | Costs |" in md
+
+    def test_question_appears_in_decision(self) -> None:
+        md = render_synthesis("My question?", _minimal_researcher_payload(), _minimal_challenger_payload())
+        assert "My question?" in md
+
+    def test_challenger_missing_options_in_table(self) -> None:
+        researcher = _minimal_researcher_payload()
+        challenger = _minimal_challenger_payload()
+        md = render_synthesis("Q?", researcher, challenger)
+        assert "GraphQL" in md
+        assert "*(challenger)*" in md
+
+
+# ---------------------------------------------------------------------------
+# 4. Schema validation
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaValidation:
+    def test_researcher_schema_valid_payload(self) -> None:
+        schema = SCHEMAS["tiebreaker_researcher.json"]
+        validate(instance=_minimal_researcher_payload(), schema=schema)
+
+    def test_researcher_schema_missing_required(self) -> None:
+        schema = SCHEMAS["tiebreaker_researcher.json"]
+        with pytest.raises(ValidationError):
+            validate(instance={"question": "Q?"}, schema=schema)
+
+    def test_challenger_schema_valid_payload(self) -> None:
+        schema = SCHEMAS["tiebreaker_challenger.json"]
+        validate(instance=_minimal_challenger_payload(), schema=schema)
+
+    def test_challenger_schema_missing_required(self) -> None:
+        schema = SCHEMAS["tiebreaker_challenger.json"]
+        with pytest.raises(ValidationError):
+            validate(instance={"measurements_vs_assumptions": "x"}, schema=schema)
+
+
+# ---------------------------------------------------------------------------
+# 5. Version suffix logic
+# ---------------------------------------------------------------------------
+
+
+class TestVersionSuffix:
+    def test_first_run_no_suffix(self, tmp_path: Path) -> None:
+        assert _next_version_suffix(tmp_path) == ""
+
+    def test_second_run_v2(self, tmp_path: Path) -> None:
+        (tmp_path / "tiebreaker_researcher.json").write_text("{}")
+        assert _next_version_suffix(tmp_path) == "_v2"
+
+    def test_third_run_v3(self, tmp_path: Path) -> None:
+        (tmp_path / "tiebreaker_researcher.json").write_text("{}")
+        (tmp_path / "tiebreaker_researcher_v2.json").write_text("{}")
+        assert _next_version_suffix(tmp_path) == "_v3"
+
+
+# ---------------------------------------------------------------------------
+# 6. Status output
+# ---------------------------------------------------------------------------
+
+
+class TestTiebreakerStatus:
+    def test_no_artifacts(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        state: PlanState = {"name": "test-plan", "config": {"project_dir": str(tmp_path)}, "intent": "", "user_notes": "", "iteration": 1, "history": []}
+        _run_tiebreaker_status(tmp_path, tmp_path, state)
+        out = json.loads(capsys.readouterr().out)
+        assert out["total_runs"] == 0
+        assert out["runs"] == []
+
+    def test_partial_run(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        (tmp_path / "tiebreaker_researcher.json").write_text("{}")
+        state: PlanState = {"name": "test-plan", "config": {"project_dir": str(tmp_path)}, "intent": "", "user_notes": "", "iteration": 1, "history": []}
+        _run_tiebreaker_status(tmp_path, tmp_path, state)
+        out = json.loads(capsys.readouterr().out)
+        assert out["total_runs"] == 1
+        assert out["runs"][0]["complete"] is False
+        assert out["runs"][0]["challenger"] is None
+
+    def test_complete_run(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        (tmp_path / "tiebreaker_researcher.json").write_text("{}")
+        (tmp_path / "tiebreaker_challenger.json").write_text("{}")
+        (tmp_path / "tiebreaker.md").write_text("# Synthesis")
+        state: PlanState = {"name": "test-plan", "config": {"project_dir": str(tmp_path)}, "intent": "", "user_notes": "", "iteration": 1, "history": []}
+        _run_tiebreaker_status(tmp_path, tmp_path, state)
+        out = json.loads(capsys.readouterr().out)
+        assert out["total_runs"] == 1
+        assert out["runs"][0]["complete"] is True
+
+    def test_multiple_runs(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        (tmp_path / "tiebreaker_researcher.json").write_text("{}")
+        (tmp_path / "tiebreaker_challenger.json").write_text("{}")
+        (tmp_path / "tiebreaker.md").write_text("")
+        (tmp_path / "tiebreaker_researcher_v2.json").write_text("{}")
+        state: PlanState = {"name": "test-plan", "config": {"project_dir": str(tmp_path)}, "intent": "", "user_notes": "", "iteration": 1, "history": []}
+        _run_tiebreaker_status(tmp_path, tmp_path, state)
+        out = json.loads(capsys.readouterr().out)
+        assert out["total_runs"] == 2
+        assert out["runs"][0]["complete"] is True
+        assert out["runs"][1]["complete"] is False


### PR DESCRIPTION
## Summary

Second of three stacked PRs decomposed from `tiebreaker-plus-verifiability-temp`.

Introduces the `megaplan tiebreaker` subcommand — a two-agent pipeline (researcher + challenger) that produces structured decision context for architectural questions. Also wires up the plan-lifecycle machinery (states, handlers, schemas, prompts) so PR-C can add automatic gate-driven routing on top.

**Based on**: `verifiability-contracts` (PR-A). Merges cleanly once PR-A lands.

## What this PR contains

- `megaplan/tiebreaker.py` + `megaplan/prompts/tiebreaker_{researcher,challenger,synthesis}.py`
- New states `tiebreaker_pending` / `tiebreaker_ready` + workflow transitions + phase-runtime policies
- `handle_tiebreaker_run` / `handle_tiebreaker_decide` handlers (decide records to `tiebreaker_decisions.json`, settles flags)
- Gate schema: `TIEBREAKER` recommendation + `tiebreaker_question` / `tiebreaker_flag_ids` / `tiebreaker_fuzzy_group_id`
- Schemas: `tiebreaker_researcher.json`, `tiebreaker_challenger.json`
- Critique + revise prompts read settled decisions and instruct agents not to re-raise without new evidence
- `PlanConfig`: `max_tiebreakers_per_plan`, `tiebreaker_blocklist`, `allow_tiebreaker`, token/time budgets
- `DEFAULT_AGENT_ROUTING` routes tiebreaker_researcher + tiebreaker_challenger to codex
- `FlagRecord.settled_by_tiebreaker`, `TiebreakerDecision` TypedDict
- **Hot-fix**: `_run_tiebreaker` uses `WorkerResult.payload` instead of nonexistent `.success`/`.parsed`/`.error` attributes (caught by live-cloud smoke run on the Railway container)

## What this PR explicitly does NOT contain

- Automatic gate-driven routing, iteration pressure, budget validation — all in PR-C
- `_validate_tiebreaker` in handlers.py (needs iteration_pressure module from PR-C)
- `_apply_gate_outcome` TIEBREAKER branch and `handle_gate` integration — PR-C
- Audit recording on `handle_tiebreaker_decide` (audit.py module in PR-C; a function-local try/except gracefully no-ops `tiebreaker audit` CLI until PR-C lands)

## Test plan

- [x] `PYENV_VERSION=3.11.11 python -m pytest tests/ -q` → 594 passed / 12 failures (identical to PR-A baseline; no new regressions).
- [ ] Merge PR-A first, rebase on main, then merge this.

## Stacked PRs

- PR-A `verifiability-contracts` → `main` (#8)
- **PR-B (this)** `tiebreaker-cli` → `verifiability-contracts`
- PR-C `tiebreaker-auto-trigger` → `tiebreaker-cli` (next)