### PR TITLE
v0.18.0: tiebreaker auto-trigger (PR-C of stacked 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v0.18.0 — 2026-04-15
+
+### Automated tiebreaker triggering
+
+Gate-driven automatic tiebreaker routing with budgeted, audited guardrails. Builds on the advisory `megaplan tiebreaker` subcommand from v0.17.1 — the harness now detects recurring constraint tensions and routes to tiebreaker automatically.
+
+- **Iteration-pressure analysis**: `megaplan/iteration_pressure.py` computes flag recurrence history — fuzzy-groups flags by Jaccard word similarity, tracks `addressed_then_reopened_count`, and renders a pressure table into the gate prompt context.
+- **Mechanical recurrence validation**: harness validates TIEBREAKER recommendations against actual flag history via `_validate_tiebreaker`. Re-prompts the gate once if no mechanical signal exists; force-demotes to ITERATE on second failure.
+- **`tiebreaker-run` top-level command**: auto-driver-callable command that invokes `_run_tiebreaker` inside a plan-locked context and transitions the plan state.
+- **Gate integration**: `handle_gate` detects `TIEBREAKER` recommendations, runs the validator, transitions to `tiebreaker_pending` on approval.
+- **Budget guardrails**: `max_tiebreakers_per_plan` (default 2). Exceeded budgets force-demote to ESCALATE.
+- **Domain blocklist**: `tiebreaker_blocklist` config field skips tiebreaker for specified concern categories.
+- **Spec-level opt-out**: `allow_tiebreaker: false` in config disables the mechanism entirely.
+- **Audit tracking**: `megaplan/audit.py` records tiebreaker usage, timing, and token costs. `megaplan tiebreaker audit` CLI for per-plan and global stats. `handle_tiebreaker_decide` writes an audit record on every decision.
+- **Auto driver**: `drive()` returns `status="awaiting_human"`, `"tiebreaker_pending"`, or `"tiebreaker_ready"` for the matching automation-terminal states and stops cleanly.
+- **Gate prompt**: now includes the Iteration Pressure Analysis block; TIEBREAKER bullet explicitly cites `addressed_then_reopened_count` thresholds.
+
 ## v0.17.1 — 2026-04-15
 
 ### Tiebreaker subcommand (`megaplan tiebreaker`)

--- a/megaplan/audit.py
+++ b/megaplan/audit.py
@@ -1,0 +1,130 @@
+"""Tiebreaker audit tracking — records and aggregates tiebreaker usage stats."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from megaplan._core import atomic_write_json, read_json, resolve_plan_dir
+
+AUDIT_FILE = "tiebreaker_audit.json"
+
+
+def record_tiebreaker_audit(
+    plan_dir: Path,
+    decision: dict[str, Any],
+    researcher_data: dict[str, Any],
+    challenger_data: dict[str, Any],
+    tokens_spent: int = 0,
+    time_seconds: float = 0.0,
+) -> dict[str, Any]:
+    """Append an audit record to tiebreaker_audit.json in plan_dir."""
+    record: dict[str, Any] = {
+        "plan_name": decision.get("question", ""),
+        "tiebreaker_index": _next_index(plan_dir),
+        "fuzzy_group_id": decision.get("fuzzy_group_id", ""),
+        "question": decision.get("question", ""),
+        "researcher_pick": researcher_data.get("recommendation", ""),
+        "challenger_pick": challenger_data.get("recommendation", ""),
+        "human_pick": decision.get("human_pick", ""),
+        "action": decision.get("action", ""),
+        "matched_researcher": decision.get("human_pick", "") == researcher_data.get("recommendation", ""),
+        "matched_challenger": decision.get("human_pick", "") == challenger_data.get("recommendation", ""),
+        "tokens_spent": tokens_spent,
+        "time_seconds": time_seconds,
+        "timestamp": decision.get("timestamp", ""),
+    }
+    records = load_tiebreaker_audit(plan_dir)
+    records.append(record)
+    atomic_write_json(plan_dir / AUDIT_FILE, records)
+    return record
+
+
+def load_tiebreaker_audit(plan_dir: Path) -> list[dict[str, Any]]:
+    """Read audit records from plan_dir. Returns empty list if none exist."""
+    audit_path = plan_dir / AUDIT_FILE
+    if not audit_path.exists():
+        return []
+    data = read_json(audit_path)
+    if not isinstance(data, list):
+        return []
+    return data
+
+
+def aggregate_tiebreaker_audit(root: Path) -> dict[str, Any]:
+    """Cross-plan aggregation for --global flag. Scans all plan directories."""
+    megaplan_dir = root / ".megaplan" / "plans"
+    if not megaplan_dir.is_dir():
+        return {"plans": [], "totals": _empty_totals()}
+
+    plan_summaries: list[dict[str, Any]] = []
+    all_records: list[dict[str, Any]] = []
+
+    for plan_path in sorted(megaplan_dir.iterdir()):
+        if not plan_path.is_dir():
+            continue
+        records = load_tiebreaker_audit(plan_path)
+        if not records:
+            continue
+        all_records.extend(records)
+        plan_summaries.append({
+            "plan_dir": plan_path.name,
+            "tiebreaker_count": len(records),
+            "tokens_spent": sum(r.get("tokens_spent", 0) for r in records),
+            "time_seconds": sum(r.get("time_seconds", 0) for r in records),
+            "matched_researcher": sum(1 for r in records if r.get("matched_researcher")),
+            "matched_challenger": sum(1 for r in records if r.get("matched_challenger")),
+        })
+
+    totals = _compute_totals(all_records)
+    return {"plans": plan_summaries, "totals": totals}
+
+
+def _next_index(plan_dir: Path) -> int:
+    return len(load_tiebreaker_audit(plan_dir))
+
+
+def _empty_totals() -> dict[str, Any]:
+    return {
+        "total_tiebreakers": 0,
+        "total_tokens": 0,
+        "total_time_seconds": 0.0,
+        "matched_researcher_count": 0,
+        "matched_challenger_count": 0,
+    }
+
+
+def _compute_totals(records: list[dict[str, Any]]) -> dict[str, Any]:
+    if not records:
+        return _empty_totals()
+    return {
+        "total_tiebreakers": len(records),
+        "total_tokens": sum(r.get("tokens_spent", 0) for r in records),
+        "total_time_seconds": sum(r.get("time_seconds", 0) for r in records),
+        "matched_researcher_count": sum(1 for r in records if r.get("matched_researcher")),
+        "matched_challenger_count": sum(1 for r in records if r.get("matched_challenger")),
+    }
+
+
+def render_audit_report(data: dict[str, Any]) -> str:
+    """Render audit data as a human-readable text report."""
+    lines: list[str] = []
+    totals = data.get("totals", _empty_totals())
+    lines.append("=== Tiebreaker Audit Report ===")
+    lines.append(f"Total tiebreakers: {totals['total_tiebreakers']}")
+    lines.append(f"Total tokens: {totals['total_tokens']}")
+    lines.append(f"Total time: {totals['total_time_seconds']:.1f}s")
+    lines.append(f"Matched researcher: {totals['matched_researcher_count']}")
+    lines.append(f"Matched challenger: {totals['matched_challenger_count']}")
+
+    plans = data.get("plans", [])
+    if plans:
+        lines.append("")
+        lines.append("Per-plan breakdown:")
+        for p in plans:
+            lines.append(
+                f"  {p['plan_dir']}: {p['tiebreaker_count']} tiebreakers, "
+                f"{p['tokens_spent']} tokens, {p['time_seconds']:.1f}s"
+            )
+
+    return "\n".join(lines)

--- a/megaplan/auto.py
+++ b/megaplan/auto.py
@@ -24,7 +24,13 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from megaplan.types import TERMINAL_STATES
+from megaplan.types import (
+    AUTOMATION_TERMINAL_STATES,
+    STATE_AWAITING_HUMAN,
+    STATE_TIEBREAKER_PENDING,
+    STATE_TIEBREAKER_READY,
+    TERMINAL_STATES,
+)
 
 
 DEFAULT_STALL_THRESHOLD = 5
@@ -182,8 +188,41 @@ def drive(
             valid_next=valid_next,
         )
 
-        # Terminal: plan reached a final state.
-        if state in TERMINAL_STATES:
+        # Terminal: plan reached a final state (or automation-terminal).
+        if state in AUTOMATION_TERMINAL_STATES:
+            if state == STATE_AWAITING_HUMAN:
+                log("plan awaiting human verification — automation stopping")
+                return DriverOutcome(
+                    status="awaiting_human",
+                    plan=plan,
+                    final_state=state,
+                    iterations=iteration,
+                    reason="plan has criteria requiring human verification",
+                    last_phase=last_phase,
+                    events=events,
+                )
+            if state == STATE_TIEBREAKER_PENDING:
+                log("tiebreaker pending — run 'megaplan tiebreaker-run --plan <name>' to execute")
+                return DriverOutcome(
+                    status="tiebreaker_pending",
+                    plan=plan,
+                    final_state=state,
+                    iterations=iteration,
+                    reason="gate recommended tiebreaker — researcher/challenger run needed",
+                    last_phase=last_phase,
+                    events=events,
+                )
+            if state == STATE_TIEBREAKER_READY:
+                log("tiebreaker ready — run 'megaplan tiebreaker decide --plan <name>' to resolve")
+                return DriverOutcome(
+                    status="tiebreaker_ready",
+                    plan=plan,
+                    final_state=state,
+                    iterations=iteration,
+                    reason="tiebreaker synthesis complete — awaiting human decision",
+                    last_phase=last_phase,
+                    events=events,
+                )
             log(f"terminal state reached: {state}")
             return DriverOutcome(
                 status="done" if state == "done" else "aborted",

--- a/megaplan/cli.py
+++ b/megaplan/cli.py
@@ -60,6 +60,7 @@ from megaplan.handlers import (
     handle_prep,
     handle_review,
     handle_revise,
+    handle_tiebreaker_run,
     handle_verify_human,
 )
 from megaplan.loop.handlers import (
@@ -999,6 +1000,20 @@ def build_parser() -> argparse.ArgumentParser:
     from megaplan.tiebreaker import build_tiebreaker_parser
     build_tiebreaker_parser(subparsers)
 
+    # tiebreaker-run is a top-level command because auto.py:_phase_command
+    # translates next_step directly to CLI args.
+    tb_run_parser = subparsers.add_parser(
+        "tiebreaker-run",
+        help="Run tiebreaker researcher+challenger (used by auto driver)",
+    )
+    tb_run_parser.add_argument("--plan", required=True, help="Plan name")
+    tb_run_parser.add_argument("--agent", choices=["claude", "codex", "hermes"], default=None)
+    tb_run_parser.add_argument("--hermes", nargs="?", const="", default=None)
+    tb_run_parser.add_argument("--phase-model", action="append", default=[])
+    tb_run_parser.add_argument("--fresh", action="store_true")
+    tb_run_parser.add_argument("--persist", action="store_true")
+    tb_run_parser.add_argument("--ephemeral", action="store_true")
+
     return parser
 
 
@@ -1026,6 +1041,7 @@ COMMAND_HANDLERS: dict[str, Callable[..., StepResponse]] = {
     "override": handle_override,
     "verify-human": handle_verify_human,
     "audit-verifiability": handle_audit_verifiability,
+    "tiebreaker-run": handle_tiebreaker_run,
 }
 
 

--- a/megaplan/handlers.py
+++ b/megaplan/handlers.py
@@ -670,6 +670,8 @@ def _apply_gate_outcome(
         return result, "revise", summary, []
     if gate_summary["recommendation"] == "ESCALATE":
         return result, "override add-note", summary, []
+    if gate_summary["recommendation"] == "TIEBREAKER":
+        return "tiebreaker_recommended", "tiebreaker", summary, []
     result = "unknown_recommendation"
     summary = f"Gate returned unknown recommendation '{gate_summary['recommendation']}'; treating as escalation."
     return result, "override add-note", summary, []
@@ -1139,6 +1141,103 @@ def handle_revise(root: Path, args: argparse.Namespace) -> StepResponse:
         )
 
 
+def _validate_tiebreaker(
+    state: PlanState,
+    gate_summary: dict[str, Any],
+    plan_dir: Path,
+    worker: WorkerResult,
+    args: argparse.Namespace,
+    agent: str,
+    resolved: tuple,
+    signals_artifact: dict[str, Any],
+    gate_signals: dict[str, Any],
+    root: Path,
+) -> tuple[str, str, str]:
+    """Validate a TIEBREAKER gate recommendation. Returns (result, next_step, summary)."""
+    from megaplan.iteration_pressure import compute_iteration_pressure, has_mechanical_recurrence
+
+    config = state.get("config", {})
+    summary_base = f"Gate recommendation TIEBREAKER: {gate_summary['rationale']}"
+
+    if not config.get("allow_tiebreaker", True):
+        gate_summary["recommendation"] = "ITERATE"
+        gate_summary["rationale"] += " [Auto-downgraded: tiebreaker disabled for this plan]"
+        state["current_state"] = STATE_CRITIQUED
+        return "tiebreaker_rejected_disabled", "revise", summary_base
+
+    tiebreaker_count = state["meta"].get("tiebreaker_count", 0)
+    max_tiebreakers = config.get("max_tiebreakers_per_plan", 2)
+    if tiebreaker_count >= max_tiebreakers:
+        gate_summary["recommendation"] = "ESCALATE"
+        gate_summary["rationale"] += " [Auto-downgraded to ESCALATE: tiebreaker budget exhausted]"
+        state["current_state"] = STATE_CRITIQUED
+        return "tiebreaker_rejected_budget", "override add-note", summary_base
+
+    blocklist = config.get("tiebreaker_blocklist", [])
+    tiebreaker_flag_ids = gate_summary.get("tiebreaker_flag_ids", [])
+    if blocklist and tiebreaker_flag_ids:
+        from megaplan._core import load_flag_registry as _load_flag_registry
+        registry = _load_flag_registry(plan_dir)
+        flag_by_id = {f["id"]: f for f in registry.get("flags", [])}
+        for fid in tiebreaker_flag_ids:
+            flag = flag_by_id.get(fid, {})
+            if flag.get("category", "") in blocklist:
+                gate_summary["recommendation"] = "ITERATE"
+                gate_summary["rationale"] += f" [Auto-downgraded: flag {fid} category in tiebreaker blocklist]"
+                state["current_state"] = STATE_CRITIQUED
+                return "tiebreaker_rejected_blocklist", "revise", summary_base
+
+    required_fields = ("tiebreaker_question", "tiebreaker_flag_ids", "tiebreaker_fuzzy_group_id")
+    missing = [f for f in required_fields if not gate_summary.get(f)]
+    if missing:
+        gate_summary["recommendation"] = "ITERATE"
+        gate_summary["rationale"] += f" [Auto-downgraded: missing required fields {missing}]"
+        state["current_state"] = STATE_CRITIQUED
+        return "tiebreaker_rejected_missing_fields", "revise", summary_base
+
+    entries = compute_iteration_pressure(plan_dir, state)
+    if not has_mechanical_recurrence(entries):
+        reprompt_prompt = _build_tiebreaker_reprompt(agent, state, plan_dir, root=root)
+        retry_worker, _, _, _ = _run_worker(
+            "gate", state, plan_dir, args, root=root,
+            resolved=resolved, prompt_override=reprompt_prompt,
+        )
+        worker = _merge_gate_worker_attempt(worker, retry_worker)
+        retry_payload = worker.payload
+        if retry_payload.get("recommendation") == "TIEBREAKER":
+            entries_retry = compute_iteration_pressure(plan_dir, state)
+            if not has_mechanical_recurrence(entries_retry):
+                gate_summary["recommendation"] = "ITERATE"
+                gate_summary["rationale"] += " [Auto-downgraded: no mechanical recurrence signal after reprompt]"
+                state["current_state"] = STATE_CRITIQUED
+                return "tiebreaker_rejected_no_signal", "revise", summary_base
+        else:
+            gate_summary["recommendation"] = retry_payload.get("recommendation", "ITERATE")
+            gate_summary["rationale"] = retry_payload.get("rationale", gate_summary["rationale"])
+            guidance = build_orchestrator_guidance(
+                gate_payload=retry_payload,
+                signals=signals_artifact["signals"],
+                preflight_passed=all(signals_artifact["preflight_results"].values()),
+                preflight_results=signals_artifact["preflight_results"],
+                robustness=signals_artifact.get("robustness", "standard"),
+                plan_name=state["name"],
+            )
+            new_summary = build_gate_artifact(
+                signals_artifact, retry_payload,
+                override_forced=False, orchestrator_guidance=guidance,
+            )
+            gate_summary.update(new_summary)
+            state["current_state"] = STATE_CRITIQUED
+            if gate_summary["recommendation"] == "PROCEED" and gate_summary.get("passed"):
+                state["current_state"] = STATE_GATED
+                return "success", "finalize", f"Gate recommendation {gate_summary['recommendation']}: {gate_summary['rationale']}"
+            return "success", "revise", f"Gate recommendation {gate_summary['recommendation']}: {gate_summary['rationale']}"
+
+    state["current_state"] = STATE_TIEBREAKER_PENDING
+    state["meta"]["tiebreaker_count"] = tiebreaker_count + 1
+    return "tiebreaker_approved", "tiebreaker-run", summary_base
+
+
 def handle_gate(root: Path, args: argparse.Namespace) -> StepResponse:
     with load_plan_locked(root, args.plan, step="gate") as (plan_dir, state):
         require_state(state, "gate", {STATE_CRITIQUED})
@@ -1177,6 +1276,11 @@ def handle_gate(root: Path, args: argparse.Namespace) -> StepResponse:
             robustness=gate_signals["robustness"],
             plan_dir=plan_dir,
         )
+        if result == "tiebreaker_recommended":
+            result, next_step, summary = _validate_tiebreaker(
+                state, gate_summary, plan_dir, worker, args, agent,
+                resolved, signals_artifact, gate_signals, root,
+            )
         if blocking_unresolved_ids:
             reprompt_prompt = _build_gate_prompt_override(
                 agent,
@@ -2377,6 +2481,9 @@ def handle_tiebreaker_decide(root: Path, args: argparse.Namespace) -> StepRespon
             existing = []
         existing.append(decision)
         atomic_write_json(decisions_path, existing)
+
+        from megaplan.audit import record_tiebreaker_audit
+        record_tiebreaker_audit(plan_dir, decision, researcher_data, challenger_data)
 
         if action == "pick" and flag_ids:
             registry = load_flag_registry(plan_dir)

--- a/megaplan/iteration_pressure.py
+++ b/megaplan/iteration_pressure.py
@@ -1,0 +1,166 @@
+"""Iteration-pressure analysis — detects recurring flags across critique iterations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, TypedDict
+
+from megaplan._core.registries import _concern_word_set, _jaccard_similarity
+from megaplan._core.io import read_json
+from megaplan.types import PlanState
+
+
+class IterationPressureEntry(TypedDict):
+    fuzzy_group_id: str
+    member_flag_ids: list[str]
+    iterations_open: int
+    addressed_then_reopened_count: int
+    representative_concern: str
+
+
+def compute_flag_history(
+    plan_dir: Path, current_iteration: int
+) -> list[dict[str, Any]]:
+    """Scan critique_v{N}.json artifacts to reconstruct per-flag status transitions."""
+    flags_by_id: dict[str, list[dict[str, Any]]] = {}
+    for iteration in range(1, current_iteration + 1):
+        critique_path = plan_dir / f"critique_v{iteration}.json"
+        if not critique_path.exists():
+            continue
+        critique = read_json(critique_path)
+        seen_ids: set[str] = set()
+        for check in critique.get("checks", []):
+            for finding in check.get("findings", []):
+                if finding.get("flagged"):
+                    fid = check.get("id", "")
+                    if fid:
+                        seen_ids.add(fid)
+                        flags_by_id.setdefault(fid, []).append(
+                            {"iteration": iteration, "status": "open", "concern": finding.get("detail", "")}
+                        )
+        for flag in critique.get("flags", []):
+            fid = flag.get("id", "")
+            if fid:
+                seen_ids.add(fid)
+                flags_by_id.setdefault(fid, []).append(
+                    {"iteration": iteration, "status": flag.get("status", "open"), "concern": flag.get("concern", "")}
+                )
+
+    faults_path = plan_dir / "faults.json"
+    if faults_path.exists():
+        faults = read_json(faults_path)
+        for flag in faults.get("flags", []):
+            fid = flag.get("id", "")
+            if fid and fid not in flags_by_id:
+                flags_by_id.setdefault(fid, []).append(
+                    {"iteration": 0, "status": flag.get("status", "open"), "concern": flag.get("concern", "")}
+                )
+
+    result = []
+    for fid, entries in flags_by_id.items():
+        concern = entries[-1].get("concern", "") if entries else ""
+        iterations_seen = sorted({e["iteration"] for e in entries})
+        statuses = [e["status"] for e in entries]
+        reopen_count = 0
+        was_addressed = False
+        for s in statuses:
+            if s in ("addressed", "verified"):
+                was_addressed = True
+            elif s == "open" and was_addressed:
+                reopen_count += 1
+                was_addressed = False
+        result.append({
+            "id": fid,
+            "concern": concern,
+            "iterations": iterations_seen,
+            "iterations_open": len(iterations_seen),
+            "addressed_then_reopened_count": reopen_count,
+        })
+    return result
+
+
+def compute_fuzzy_groups(
+    flags: list[dict[str, Any]], threshold: float = 0.6
+) -> dict[str, list[str]]:
+    """Group flags by Jaccard word similarity on concern text."""
+    word_sets = {f["id"]: _concern_word_set(f.get("concern", "")) for f in flags}
+    assigned: dict[str, str] = {}
+    groups: dict[str, list[str]] = {}
+    group_counter = 0
+
+    for flag in flags:
+        fid = flag["id"]
+        if fid in assigned:
+            continue
+        group_counter += 1
+        gid = f"FG-{group_counter:03d}"
+        groups[gid] = [fid]
+        assigned[fid] = gid
+
+        for other in flags:
+            oid = other["id"]
+            if oid in assigned:
+                continue
+            if _jaccard_similarity(word_sets[fid], word_sets[oid]) >= threshold:
+                groups[gid].append(oid)
+                assigned[oid] = gid
+
+    return groups
+
+
+def compute_iteration_pressure(
+    plan_dir: Path, state: PlanState
+) -> list[IterationPressureEntry]:
+    current_iteration = state.get("iteration", 1)
+    flag_history = compute_flag_history(plan_dir, current_iteration)
+    if not flag_history:
+        return []
+
+    groups = compute_fuzzy_groups(flag_history, threshold=0.6)
+    history_by_id = {f["id"]: f for f in flag_history}
+
+    entries: list[IterationPressureEntry] = []
+    for gid, member_ids in groups.items():
+        members = [history_by_id[fid] for fid in member_ids if fid in history_by_id]
+        if not members:
+            continue
+        all_iterations: set[int] = set()
+        max_reopen = 0
+        for m in members:
+            all_iterations.update(m.get("iterations", []))
+            max_reopen = max(max_reopen, m.get("addressed_then_reopened_count", 0))
+
+        entries.append(IterationPressureEntry(
+            fuzzy_group_id=gid,
+            member_flag_ids=member_ids,
+            iterations_open=len(all_iterations),
+            addressed_then_reopened_count=max_reopen,
+            representative_concern=members[0].get("concern", ""),
+        ))
+    return entries
+
+
+def has_mechanical_recurrence(entries: list[IterationPressureEntry]) -> bool:
+    for entry in entries:
+        if entry["addressed_then_reopened_count"] >= 2:
+            return True
+        if entry["iterations_open"] >= 2 and len(entry["member_flag_ids"]) >= 2:
+            return True
+    return False
+
+
+def render_pressure_table(entries: list[IterationPressureEntry]) -> str:
+    if not entries:
+        return ""
+    lines = [
+        "Iteration Pressure Analysis:",
+        f"{'Group':<10} {'Flags':<6} {'Iters':<6} {'Reopened':<9} Concern",
+        "-" * 72,
+    ]
+    for e in entries:
+        concern = e["representative_concern"][:50]
+        lines.append(
+            f"{e['fuzzy_group_id']:<10} {len(e['member_flag_ids']):<6} "
+            f"{e['iterations_open']:<6} {e['addressed_then_reopened_count']:<9} {concern}"
+        )
+    return "\n".join(lines)

--- a/megaplan/prompts/gate.py
+++ b/megaplan/prompts/gate.py
@@ -16,9 +16,17 @@ from megaplan._core import (
     read_json,
     unresolved_significant_flags,
 )
+from megaplan.iteration_pressure import compute_iteration_pressure, render_pressure_table
 from megaplan.types import FlagRegistry, PlanState
 
 from ._shared import _gate_debt_block
+
+
+def _iteration_pressure_block(state: PlanState, plan_dir: Path) -> str:
+    entries = compute_iteration_pressure(plan_dir, state)
+    if not entries:
+        return ""
+    return render_pressure_table(entries)
 
 
 def _gate_prompt(state: PlanState, plan_dir: Path, root: Path | None = None) -> str:
@@ -87,6 +95,8 @@ def _gate_prompt(state: PlanState, plan_dir: Path, root: Path | None = None) -> 
 
         {debt_block}
 
+        {_iteration_pressure_block(state, plan_dir)}
+
         Robustness level:
         {robustness}
 
@@ -96,7 +106,7 @@ def _gate_prompt(state: PlanState, plan_dir: Path, root: Path | None = None) -> 
         - PROCEED when execution should move forward now.
         - ITERATE when revising the plan is the best next move.
         - ESCALATE when the loop is stuck, churn is recurring, or user intervention is needed.
-        - TIEBREAKER when a flag group reflects an *unresolvable constraint tension* (architectural or philosophical — requires a human call) rather than a plan-quality issue. If the concern is simply that the plan writer hasn't tried hard enough, use ITERATE instead. When recommending TIEBREAKER you MUST provide `tiebreaker_question` (the decision question for human resolution), `tiebreaker_flag_ids` (which flags this resolves), and `tiebreaker_fuzzy_group_id` (which group this resolves). Cite specific flag IDs in your rationale.
+        - TIEBREAKER when a flag group reflects an *unresolvable constraint tension* (architectural or philosophical — requires a human call) rather than a plan-quality issue. Use TIEBREAKER only when the Iteration Pressure Analysis shows `addressed_then_reopened_count >= 2` for a fuzzy group OR the group has >=2 member flags across >=2 iterations. If the concern is simply that the plan writer hasn't tried hard enough, use ITERATE instead. When recommending TIEBREAKER you MUST provide `tiebreaker_question` (the decision question for human resolution), `tiebreaker_flag_ids` (which flags this resolves), and `tiebreaker_fuzzy_group_id` (which group this resolves). Cite specific flag IDs and iterations in your rationale.
         - `signals_assessment`: one paragraph summarizing score trajectory, flag status, and preflight posture.
 
         Flags come in two tiers:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "megaplan-harness"
-version = "0.17.1"
+version = "0.18.0"
 description = "AI agent harness for coordinating Claude and GPT to make and execute extremely robust plans"
 requires-python = ">=3.11"
 license = { text = "OSNL-0.2" }

--- a/tests/test_iteration_pressure.py
+++ b/tests/test_iteration_pressure.py
@@ -1,0 +1,249 @@
+"""Tests for megaplan.iteration_pressure — flag history, fuzzy grouping, pressure computation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from megaplan.iteration_pressure import (
+    IterationPressureEntry,
+    compute_flag_history,
+    compute_fuzzy_groups,
+    compute_iteration_pressure,
+    has_mechanical_recurrence,
+    render_pressure_table,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_critique(plan_dir: Path, iteration: int, flags: list[dict]) -> None:
+    data = {"flags": flags, "checks": []}
+    (plan_dir / f"critique_v{iteration}.json").write_text(
+        json.dumps(data), encoding="utf-8"
+    )
+
+
+def _make_state(iteration: int = 1) -> dict:
+    return {"iteration": iteration, "config": {"project_dir": "/tmp"}}
+
+
+# ---------------------------------------------------------------------------
+# compute_flag_history
+# ---------------------------------------------------------------------------
+
+
+class TestComputeFlagHistory:
+    def test_single_critique(self, tmp_path: Path) -> None:
+        _write_critique(tmp_path, 1, [
+            {"id": "F1", "status": "open", "concern": "missing validation"},
+        ])
+        history = compute_flag_history(tmp_path, 1)
+        assert len(history) == 1
+        assert history[0]["id"] == "F1"
+        assert history[0]["addressed_then_reopened_count"] == 0
+
+    def test_addressed_then_reopened(self, tmp_path: Path) -> None:
+        _write_critique(tmp_path, 1, [
+            {"id": "F1", "status": "open", "concern": "bootstrap race condition"},
+        ])
+        _write_critique(tmp_path, 2, [
+            {"id": "F1", "status": "addressed", "concern": "bootstrap race condition"},
+        ])
+        _write_critique(tmp_path, 3, [
+            {"id": "F1", "status": "open", "concern": "bootstrap race condition"},
+        ])
+        history = compute_flag_history(tmp_path, 3)
+        assert len(history) == 1
+        assert history[0]["addressed_then_reopened_count"] == 1
+
+    def test_double_reopen_gives_count_2(self, tmp_path: Path) -> None:
+        """Flag raised -> addressed -> reopened -> addressed -> reopened = count 2."""
+        _write_critique(tmp_path, 1, [
+            {"id": "F1", "status": "open", "concern": "architectural conflict"},
+        ])
+        _write_critique(tmp_path, 2, [
+            {"id": "F1", "status": "addressed", "concern": "architectural conflict"},
+        ])
+        _write_critique(tmp_path, 3, [
+            {"id": "F1", "status": "open", "concern": "architectural conflict"},
+        ])
+        _write_critique(tmp_path, 4, [
+            {"id": "F1", "status": "addressed", "concern": "architectural conflict"},
+        ])
+        _write_critique(tmp_path, 5, [
+            {"id": "F1", "status": "open", "concern": "architectural conflict"},
+        ])
+        history = compute_flag_history(tmp_path, 5)
+        assert len(history) == 1
+        assert history[0]["addressed_then_reopened_count"] == 2
+
+    def test_faults_only_for_new_flags(self, tmp_path: Path) -> None:
+        _write_critique(tmp_path, 1, [
+            {"id": "F1", "status": "open", "concern": "concern A"},
+        ])
+        faults = {"flags": [
+            {"id": "F1", "status": "open", "concern": "concern A"},
+            {"id": "F2", "status": "open", "concern": "concern B"},
+        ]}
+        (tmp_path / "faults.json").write_text(json.dumps(faults), encoding="utf-8")
+        history = compute_flag_history(tmp_path, 1)
+        ids = {h["id"] for h in history}
+        assert "F1" in ids
+        assert "F2" in ids
+        f2 = [h for h in history if h["id"] == "F2"][0]
+        assert f2["iterations"] == [0]
+
+    def test_no_critiques(self, tmp_path: Path) -> None:
+        history = compute_flag_history(tmp_path, 3)
+        assert history == []
+
+
+# ---------------------------------------------------------------------------
+# compute_fuzzy_groups
+# ---------------------------------------------------------------------------
+
+
+class TestComputeFuzzyGroups:
+    def test_similar_flags_grouped(self) -> None:
+        flags = [
+            {"id": "F1", "concern": "bootstrap race condition in startup"},
+            {"id": "F2", "concern": "bootstrap race condition in initialization"},
+        ]
+        groups = compute_fuzzy_groups(flags, threshold=0.6)
+        assert len(groups) == 1
+        gid = list(groups.keys())[0]
+        assert set(groups[gid]) == {"F1", "F2"}
+
+    def test_dissimilar_flags_separate(self) -> None:
+        flags = [
+            {"id": "F1", "concern": "bootstrap race condition in startup"},
+            {"id": "F2", "concern": "missing input validation for user email"},
+        ]
+        groups = compute_fuzzy_groups(flags, threshold=0.6)
+        assert len(groups) == 2
+
+    def test_empty_flags(self) -> None:
+        groups = compute_fuzzy_groups([], threshold=0.6)
+        assert groups == {}
+
+    def test_single_flag(self) -> None:
+        flags = [{"id": "F1", "concern": "something"}]
+        groups = compute_fuzzy_groups(flags, threshold=0.6)
+        assert len(groups) == 1
+        assert list(groups.values())[0] == ["F1"]
+
+
+# ---------------------------------------------------------------------------
+# compute_iteration_pressure (end-to-end)
+# ---------------------------------------------------------------------------
+
+
+class TestComputeIterationPressure:
+    def test_end_to_end_double_reopen(self, tmp_path: Path) -> None:
+        """v1: open, v2: addressed, v2 critique: reopened, v3: addressed, v3 critique: reopened."""
+        _write_critique(tmp_path, 1, [
+            {"id": "F1", "status": "open", "concern": "store vs RQ first"},
+        ])
+        _write_critique(tmp_path, 2, [
+            {"id": "F1", "status": "addressed", "concern": "store vs RQ first"},
+            {"id": "F1", "status": "open", "concern": "store vs RQ first"},
+        ])
+        _write_critique(tmp_path, 3, [
+            {"id": "F1", "status": "addressed", "concern": "store vs RQ first"},
+            {"id": "F1", "status": "open", "concern": "store vs RQ first"},
+        ])
+        state = _make_state(iteration=3)
+        entries = compute_iteration_pressure(tmp_path, state)
+        assert len(entries) >= 1
+        f1_entry = [e for e in entries if "F1" in e["member_flag_ids"]][0]
+        assert f1_entry["addressed_then_reopened_count"] == 2
+
+    def test_no_pressure_without_critiques(self, tmp_path: Path) -> None:
+        state = _make_state(iteration=1)
+        entries = compute_iteration_pressure(tmp_path, state)
+        assert entries == []
+
+    def test_multiple_groups(self, tmp_path: Path) -> None:
+        _write_critique(tmp_path, 1, [
+            {"id": "F1", "status": "open", "concern": "bootstrap race condition"},
+            {"id": "F2", "status": "open", "concern": "missing email validation"},
+        ])
+        state = _make_state(iteration=1)
+        entries = compute_iteration_pressure(tmp_path, state)
+        assert len(entries) == 2
+
+
+# ---------------------------------------------------------------------------
+# has_mechanical_recurrence
+# ---------------------------------------------------------------------------
+
+
+class TestHasMechanicalRecurrence:
+    def test_true_on_reopen_count(self) -> None:
+        entries: list[IterationPressureEntry] = [
+            IterationPressureEntry(
+                fuzzy_group_id="FG-001",
+                member_flag_ids=["F1"],
+                iterations_open=3,
+                addressed_then_reopened_count=2,
+                representative_concern="test",
+            )
+        ]
+        assert has_mechanical_recurrence(entries) is True
+
+    def test_true_on_multi_flag_multi_iter(self) -> None:
+        entries: list[IterationPressureEntry] = [
+            IterationPressureEntry(
+                fuzzy_group_id="FG-001",
+                member_flag_ids=["F1", "F2"],
+                iterations_open=2,
+                addressed_then_reopened_count=0,
+                representative_concern="test",
+            )
+        ]
+        assert has_mechanical_recurrence(entries) is True
+
+    def test_false_below_threshold(self) -> None:
+        entries: list[IterationPressureEntry] = [
+            IterationPressureEntry(
+                fuzzy_group_id="FG-001",
+                member_flag_ids=["F1"],
+                iterations_open=1,
+                addressed_then_reopened_count=1,
+                representative_concern="test",
+            )
+        ]
+        assert has_mechanical_recurrence(entries) is False
+
+    def test_false_on_empty(self) -> None:
+        assert has_mechanical_recurrence([]) is False
+
+
+# ---------------------------------------------------------------------------
+# render_pressure_table
+# ---------------------------------------------------------------------------
+
+
+class TestRenderPressureTable:
+    def test_renders_nonempty(self) -> None:
+        entries: list[IterationPressureEntry] = [
+            IterationPressureEntry(
+                fuzzy_group_id="FG-001",
+                member_flag_ids=["F1", "F2"],
+                iterations_open=3,
+                addressed_then_reopened_count=2,
+                representative_concern="bootstrap race condition",
+            )
+        ]
+        table = render_pressure_table(entries)
+        assert "FG-001" in table
+        assert "Iteration Pressure" in table
+
+    def test_empty_returns_empty_string(self) -> None:
+        assert render_pressure_table([]) == ""


### PR DESCRIPTION
## Summary

Final of three stacked PRs decomposed from `tiebreaker-plus-verifiability-temp`.

Adds gate-driven automatic tiebreaker routing with budget caps, blocklist, iteration-pressure validation, and audit logging. Turns PR-B's advisory tiebreaker subcommand into a first-class harness phase that auto-drivers can loop through.

**Based on**: `tiebreaker-cli` (PR-B). Ultimately merges on top of `verifiability-contracts` (PR-A, #8) and `tiebreaker-cli` (PR-B, #9).

## What this PR contains

- `megaplan/iteration_pressure.py` — Jaccard-fuzzy flag grouping, recurrence tracking, gate prompt context table.
- `megaplan/audit.py` — per-plan + global tiebreaker audit log; `tiebreaker audit` CLI reads it.
- `_validate_tiebreaker` in `handlers.py` — budget / blocklist / missing-fields / mechanical-recurrence gating with one reprompt retry before auto-downgrade to ITERATE.
- `handle_gate` integration — routes TIEBREAKER outcomes through the validator.
- `tiebreaker-run` top-level CLI command (auto-driver reachable via `next_step` translation).
- Auto-driver terminal-state handling for `awaiting_human` / `tiebreaker_pending` / `tiebreaker_ready`.
- Gate prompt iteration-pressure block; TIEBREAKER bullet tightened to cite the recurrence threshold.
- `handle_tiebreaker_decide` records to the audit log (complementing PR-B's decision-file write).
- 18 new tests in `tests/test_iteration_pressure.py`.

## Test plan

- [x] `PYENV_VERSION=3.11.11 python -m pytest tests/ -q` → 612 passed / 12 failures (identical to baseline on PR-A and PR-B; no new regressions).
- [ ] Merge order: PR-A → PR-B → PR-C.

## Deployment note

The live Railway container today runs `tiebreaker-plus-verifiability-temp` at v0.18.0 (combined). Once all three PRs land in order, `main` will match that working combination under clean history. Do not merge any of the three into `main` until all three are reviewed.

## Stacked PRs

- PR-A `verifiability-contracts` → `main` (#8)
- PR-B `tiebreaker-cli` → `verifiability-contracts` (#9)
- **PR-C (this)** `tiebreaker-auto-trigger` → `tiebreaker-cli`