### PR TITLE
fix(v0.18.1): rework-cycle-aware stall detection in megaplan auto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v0.18.1 — 2026-04-16
+
+### Rework-cycle-aware stall detection in `megaplan auto`
+
+Fixes a false-positive stall in the auto-driver when a plan is in a review→rework loop.
+
+- **Bug**: `megaplan auto` counted iterations at the same `state` and bailed after `--stall-threshold` (default 5). When review returns `needs_rework`, state ping-pongs `finalized ↔ executed ↔ finalized` while execute re-runs batches. From the naive stall counter's view the plan looked "stuck at finalized for 5 iterations" even though new `review.json` / `execution.json` artifacts were being written and real progress was happening. Observed on plan `milestone-m1b-from-docs-state-20260416-1226` — 7 execute batches + 1 review cycle completed, driver exited rc=2.
+- **Fix**: auto's driver loop now tracks `review.json` mtime as a forward-progress marker. When the marker advances, the stall counter resets and a rework-cycle counter increments. The new `--max-review-rework-cycles` flag (default 3, mirroring `execution.max_review_rework_cycles`) caps runaway rework loops independently of `--stall-threshold`.
+- **Helpers**: `_resolve_plan_dir(plan, cwd)` walks up from cwd to find `.megaplan/plans/<plan>`, matching how `megaplan status` resolves plans. `_get_review_marker(plan_dir)` stats `review.json` and returns `None` for plans without a review artifact (e.g. light-robustness plans) — in that case the driver falls back to plain stall detection, preserving existing behavior.
+- **CLI**: `--stall-threshold` help text updated to clarify that it fires only when state AND `review.json` are both unchanged. New `--max-review-rework-cycles` flag added with matching default.
+- **Tests**: `tests/test_auto.py` (new file) covers stall reset on review-marker advance, rework cap enforcement, plain-stall fallback when no review.json exists, and the plan-dir resolver.
+- **Scope**: auto.py driver loop only — execute and review phase logic are untouched.
+
 ## v0.18.0 — 2026-04-15
 
 ### Automated tiebreaker triggering

--- a/megaplan/auto.py
+++ b/megaplan/auto.py
@@ -38,6 +38,11 @@ DEFAULT_MAX_ITERATIONS = 200
 DEFAULT_POLL_SLEEP_SECONDS = 1.0
 DEFAULT_PHASE_TIMEOUT_SECONDS = 3600
 DEFAULT_STATUS_TIMEOUT_SECONDS = 60
+# Cap on review→rework cycles before the driver bails. This mirrors the
+# `execution.max_review_rework_cycles` config the review handler enforces
+# internally (default 3); the auto-driver applies its own cap so that an
+# unexpected-config or mis-routed rework loop cannot spin indefinitely.
+DEFAULT_MAX_REVIEW_REWORK_CYCLES = 3
 ESCALATE_ACTIONS = ("force-proceed", "abort", "fail")
 PHASE_TIMEOUT_EXIT_CODE = 124  # conventional; matches GNU `timeout`
 
@@ -131,12 +136,51 @@ def _phase_command(next_step: str) -> list[str]:
     return [next_step]
 
 
+def _resolve_plan_dir(plan: str, cwd: Path | None) -> Path | None:
+    """Best-effort resolution of ``.megaplan/plans/<plan>`` near ``cwd``.
+
+    Walks up parents of ``cwd`` looking for a ``.megaplan/plans/<plan>``
+    directory, matching how ``megaplan status`` resolves plans. Returns
+    ``None`` if the plan dir can't be located — callers should treat that
+    as "no review marker available" and fall back to the plain stall-count.
+    """
+    base = (cwd or Path.cwd()).resolve()
+    for candidate in (base, *base.parents):
+        plan_dir = candidate / ".megaplan" / "plans" / plan
+        if (plan_dir / "state.json").exists():
+            return plan_dir
+    return None
+
+
+def _get_review_marker(plan_dir: Path | None) -> float | None:
+    """Return a monotonically-advancing marker for the current review cycle.
+
+    Uses ``review.json`` mtime — each completed review phase rewrites the
+    file, so the mtime bumps once per review cycle. This is race-free
+    enough for stall detection: the driver only checks the marker between
+    iterations, and mtime granularity (~1s on APFS/ext4) is finer than the
+    minimum review runtime.
+
+    Returns ``None`` when no marker is available (plan dir missing, review
+    not yet run, or stat failed) — the caller must treat ``None == None``
+    as "no progress observed" and fall through to plain stall detection.
+    """
+    if plan_dir is None:
+        return None
+    review_path = plan_dir / "review.json"
+    try:
+        return review_path.stat().st_mtime
+    except (OSError, FileNotFoundError):
+        return None
+
+
 def drive(
     plan: str,
     *,
     cwd: Path | None = None,
     stall_threshold: int = DEFAULT_STALL_THRESHOLD,
     max_iterations: int = DEFAULT_MAX_ITERATIONS,
+    max_review_rework_cycles: int = DEFAULT_MAX_REVIEW_REWORK_CYCLES,
     on_escalate: str = "force-proceed",
     poll_sleep: float = DEFAULT_POLL_SLEEP_SECONDS,
     phase_timeout: float = DEFAULT_PHASE_TIMEOUT_SECONDS,
@@ -156,6 +200,16 @@ def drive(
     last_state: str | None = None
     stall_count = 0
     last_phase: str | None = None
+
+    # Rework-cycle tracking. When review returns `needs_rework`, the plan
+    # ping-pongs `finalized ↔ executed ↔ finalized` while execute re-runs
+    # batches. From the driver's naive view that looks like a stall, but
+    # every completed review rewrites `review.json`, so its mtime is a
+    # reliable "forward progress" marker — each advance means a real
+    # review cycle finished since we last observed the state.
+    plan_dir = _resolve_plan_dir(plan, cwd)
+    last_review_marker = _get_review_marker(plan_dir)
+    rework_cycles_observed = 0
 
     def log(msg: str, **fields: Any) -> None:
         events.append({"msg": msg, **fields})
@@ -233,6 +287,51 @@ def drive(
                 last_phase=last_phase,
                 events=events,
             )
+
+        # Review-cycle progress: a fresh review.json means a real review
+        # pass completed since the last iteration. This counts as forward
+        # progress even when `state` looks unchanged (finalized→executed→
+        # finalized during a needs_rework loop) — reset the stall counter
+        # so execute has a full rework pass before tripping stall detection.
+        current_review_marker = _get_review_marker(plan_dir)
+        if (
+            current_review_marker is not None
+            and current_review_marker != last_review_marker
+        ):
+            if last_review_marker is not None:
+                rework_cycles_observed += 1
+                log(
+                    f"review.json updated — rework cycle {rework_cycles_observed} "
+                    f"observed, resetting stall counter",
+                    rework_cycles_observed=rework_cycles_observed,
+                )
+                stall_count = 0
+            last_review_marker = current_review_marker
+
+            if rework_cycles_observed > max_review_rework_cycles:
+                # Review handler has its own internal cap (see
+                # handlers.py::handle_review — force-proceeds to done when
+                # prior_rework_count hits max_review_rework_cycles). This
+                # driver cap is a belt-and-braces guard against config drift
+                # or unexpected loops the handler didn't catch.
+                log(
+                    f"observed {rework_cycles_observed} rework cycles "
+                    f"(cap={max_review_rework_cycles}) — bailing"
+                )
+                return DriverOutcome(
+                    status="stalled",
+                    plan=plan,
+                    final_state=state,
+                    iterations=iteration,
+                    reason=(
+                        f"exceeded review rework cap "
+                        f"({rework_cycles_observed} cycles > "
+                        f"{max_review_rework_cycles}) — review keeps "
+                        "returning needs_rework without resolving"
+                    ),
+                    last_phase=last_phase,
+                    events=events,
+                )
 
         # Stall detection: same state for stall_threshold+ iterations.
         if state == last_state:
@@ -392,13 +491,30 @@ def build_auto_parser(subparsers: Any) -> None:
         "--stall-threshold",
         type=int,
         default=DEFAULT_STALL_THRESHOLD,
-        help=f"Exit if the plan state doesn't change for this many iterations (default {DEFAULT_STALL_THRESHOLD})",
+        help=(
+            f"Exit if the plan state doesn't change for this many iterations "
+            f"AND no new review.json has been written (default "
+            f"{DEFAULT_STALL_THRESHOLD}). Use --max-review-rework-cycles for "
+            "the rework-loop limit — execute rework can span many iterations "
+            "with state pinned at 'finalized', which is not a real stall."
+        ),
     )
     auto_parser.add_argument(
         "--max-iterations",
         type=int,
         default=DEFAULT_MAX_ITERATIONS,
         help=f"Hard cap on loop iterations (default {DEFAULT_MAX_ITERATIONS})",
+    )
+    auto_parser.add_argument(
+        "--max-review-rework-cycles",
+        type=int,
+        default=DEFAULT_MAX_REVIEW_REWORK_CYCLES,
+        help=(
+            f"Cap on observed review→rework cycles before the driver bails "
+            f"(default {DEFAULT_MAX_REVIEW_REWORK_CYCLES}). A rework cycle is "
+            "counted each time review.json is rewritten while state appears "
+            "stuck at 'finalized'. Mirrors execution.max_review_rework_cycles."
+        ),
     )
     auto_parser.add_argument(
         "--on-escalate",
@@ -449,6 +565,7 @@ def run_auto(root: Path, args: argparse.Namespace) -> int:
         cwd=root,
         stall_threshold=args.stall_threshold,
         max_iterations=args.max_iterations,
+        max_review_rework_cycles=args.max_review_rework_cycles,
         on_escalate=args.on_escalate,
         poll_sleep=args.poll_sleep,
         phase_timeout=args.phase_timeout,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "megaplan-harness"
-version = "0.18.0"
+version = "0.18.1"
 description = "AI agent harness for coordinating Claude and GPT to make and execute extremely robust plans"
 requires-python = ">=3.11"
 license = { text = "OSNL-0.2" }

--- a/tests/test_auto.py
+++ b/tests/test_auto.py
@@ -1,0 +1,202 @@
+"""Tests for megaplan.auto — the auto-driver loop.
+
+Focus: the rework-cycle-aware stall detector added in v0.18.1. A plan in
+``finalized`` state that's doing review→rework loops should not be flagged
+as stalled just because ``state`` hasn't advanced — new ``review.json``
+artifacts indicate real forward progress.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from megaplan import auto
+from megaplan.auto import drive
+
+
+def _make_plan_dir(tmp_path: Path, plan: str) -> Path:
+    """Create a skeletal plan dir that `_resolve_plan_dir` can locate."""
+    plan_dir = tmp_path / ".megaplan" / "plans" / plan
+    plan_dir.mkdir(parents=True)
+    (plan_dir / "state.json").write_text(
+        json.dumps({"name": plan, "current_state": "finalized"}),
+        encoding="utf-8",
+    )
+    return plan_dir
+
+
+def _finalized_status(plan: str) -> dict:
+    """Return a status snapshot that looks like 'review is next'."""
+    return {
+        "success": True,
+        "step": "status",
+        "plan": plan,
+        "state": "finalized",
+        "iteration": 1,
+        "summary": "Plan is in state 'finalized'.",
+        "next_step": "review",
+        "valid_next": ["review"],
+    }
+
+
+def test_stall_counter_resets_when_review_json_is_rewritten(tmp_path: Path) -> None:
+    """Stall detection must be rework-aware.
+
+    Simulates the production bug: state pinned at `finalized` while execute
+    rework and review re-run. Each time review rewrites `review.json`, the
+    stall counter must reset so the driver doesn't bail prematurely.
+    """
+    plan = "rework-plan"
+    plan_dir = _make_plan_dir(tmp_path, plan)
+    review_path = plan_dir / "review.json"
+    review_path.write_text("{}", encoding="utf-8")
+    base_mtime = review_path.stat().st_mtime
+
+    iteration_counter = {"n": 0}
+
+    def fake_status(plan_name: str, cwd=None, timeout=60):
+        # Always return finalized — simulates state ping-pong that looks
+        # stuck to the naive stall counter.
+        return _finalized_status(plan_name)
+
+    def fake_run(args, cwd=None, timeout=None):
+        # Every phase invocation bumps review.json mtime by 1s, simulating
+        # a completed review cycle. Over 6 iterations the driver should
+        # observe ~5 rework cycles — well past the default stall_threshold
+        # of 5, but NOT bail because each cycle resets the counter.
+        iteration_counter["n"] += 1
+        new_mtime = base_mtime + iteration_counter["n"]
+        os.utime(review_path, (new_mtime, new_mtime))
+        return 0, "{}", ""
+
+    # Cap iterations low and allow plenty of rework cycles so we exercise
+    # the reset path without tripping the rework cap.
+    with patch.object(auto, "_status", side_effect=fake_status), \
+         patch.object(auto, "_run_megaplan", side_effect=fake_run):
+        outcome = drive(
+            plan,
+            cwd=tmp_path,
+            stall_threshold=3,  # would normally trip after 3 same-state iters
+            max_iterations=6,
+            max_review_rework_cycles=10,  # high so we exercise reset, not cap
+            poll_sleep=0,
+            writer=lambda _m: None,
+        )
+
+    # We should NOT have stalled — each rework cycle reset the stall counter.
+    assert outcome.status == "cap", (
+        f"expected cap (hit max_iterations) with rework resets, got "
+        f"{outcome.status}: {outcome.reason}"
+    )
+    # And we should have observed multiple rework cycles.
+    rework_events = [
+        e for e in outcome.events if "rework cycle" in e.get("msg", "")
+    ]
+    assert len(rework_events) >= 3, (
+        f"expected at least 3 rework cycles observed, got "
+        f"{len(rework_events)}: {[e['msg'] for e in rework_events]}"
+    )
+
+
+def test_rework_cap_bails_after_exceeding_max_review_rework_cycles(
+    tmp_path: Path,
+) -> None:
+    """The rework-cap guard must stop runaway needs_rework loops."""
+    plan = "rework-cap-plan"
+    plan_dir = _make_plan_dir(tmp_path, plan)
+    review_path = plan_dir / "review.json"
+    review_path.write_text("{}", encoding="utf-8")
+    base_mtime = review_path.stat().st_mtime
+
+    iteration_counter = {"n": 0}
+
+    def fake_status(plan_name: str, cwd=None, timeout=60):
+        return _finalized_status(plan_name)
+
+    def fake_run(args, cwd=None, timeout=None):
+        iteration_counter["n"] += 1
+        new_mtime = base_mtime + iteration_counter["n"]
+        os.utime(review_path, (new_mtime, new_mtime))
+        return 0, "{}", ""
+
+    with patch.object(auto, "_status", side_effect=fake_status), \
+         patch.object(auto, "_run_megaplan", side_effect=fake_run):
+        outcome = drive(
+            plan,
+            cwd=tmp_path,
+            stall_threshold=100,  # effectively disabled — force cap to trip
+            max_iterations=20,
+            max_review_rework_cycles=2,  # tight cap
+            poll_sleep=0,
+            writer=lambda _m: None,
+        )
+
+    assert outcome.status == "stalled"
+    assert "review rework cap" in outcome.reason
+    assert outcome.final_state == "finalized"
+
+
+def test_stall_still_trips_without_review_progress(tmp_path: Path) -> None:
+    """Preserve existing stall detection for non-rework plans.
+
+    When a plan has no ``review.json`` (e.g. light-robustness plans that
+    skip review entirely) the marker stays ``None``, rework tracking is
+    inert, and the driver should fall back to the plain stall counter.
+    """
+    plan = "no-review-plan"
+    _make_plan_dir(tmp_path, plan)  # no review.json on disk
+
+    def fake_status(plan_name: str, cwd=None, timeout=60):
+        return _finalized_status(plan_name)
+
+    def fake_run(args, cwd=None, timeout=None):
+        return 0, "{}", ""
+
+    with patch.object(auto, "_status", side_effect=fake_status), \
+         patch.object(auto, "_run_megaplan", side_effect=fake_run):
+        outcome = drive(
+            plan,
+            cwd=tmp_path,
+            stall_threshold=3,
+            max_iterations=20,
+            poll_sleep=0,
+            writer=lambda _m: None,
+        )
+
+    assert outcome.status == "stalled"
+    assert "stalled at 'finalized'" in outcome.reason
+
+
+def test_resolve_plan_dir_finds_plans_in_parent_tree(tmp_path: Path) -> None:
+    """``_resolve_plan_dir`` must mirror `megaplan status`'s resolution."""
+    plan = "nested-plan"
+    plan_dir = _make_plan_dir(tmp_path, plan)
+
+    # Check cwd itself.
+    assert auto._resolve_plan_dir(plan, tmp_path) == plan_dir
+
+    # Check a child cwd (walks up).
+    child = tmp_path / "nested" / "subdir"
+    child.mkdir(parents=True)
+    assert auto._resolve_plan_dir(plan, child) == plan_dir
+
+    # Unknown plan returns None.
+    assert auto._resolve_plan_dir("does-not-exist", tmp_path) is None
+
+
+def test_get_review_marker_returns_none_when_review_missing(
+    tmp_path: Path,
+) -> None:
+    plan = "no-review"
+    plan_dir = _make_plan_dir(tmp_path, plan)
+    assert auto._get_review_marker(plan_dir) is None
+    assert auto._get_review_marker(None) is None
+
+    (plan_dir / "review.json").write_text("{}", encoding="utf-8")
+    marker = auto._get_review_marker(plan_dir)
+    assert marker is not None
+    assert isinstance(marker, float)


### PR DESCRIPTION
## Summary

Fixes a false-positive stall in `megaplan auto` when a plan is in a review→rework loop.

### The bug

`megaplan auto` counts iterations at the same `state` and bails after `--stall-threshold` (default 5). When review returns `needs_rework`, state ping-pongs `finalized ↔ executed ↔ finalized` while execute re-runs batches. From the naive stall counter's view the plan looks "stuck at finalized for 5 iterations" even though new `review.json` / `execution.json` artifacts are being written and real progress is happening.

Observed on plan `milestone-m1b-from-docs-state-20260416-1226` on production: 7 execute batches + 1 review cycle completed, driver exited rc=2 because execute rework took longer than 5 iterations to complete.

### The fix

`auto.py`'s driver loop now tracks `review.json` mtime as a forward-progress marker. When the marker advances, the stall counter resets and a rework-cycle counter increments. A new `--max-review-rework-cycles` flag (default 3, mirroring `execution.max_review_rework_cycles`) caps runaway rework loops independently of `--stall-threshold`.

Helpers added in `auto.py`:
- `_resolve_plan_dir(plan, cwd)` walks up from cwd to find `.megaplan/plans/<plan>`, matching how `megaplan status` resolves plans.
- `_get_review_marker(plan_dir)` stats `review.json` and returns `None` for plans without a review artifact (e.g. light-robustness plans) — in that case the driver falls back to plain stall detection, preserving existing behavior.

`--stall-threshold` help text was updated to clarify that it fires only when state AND `review.json` are both unchanged.

### Scope

`megaplan/auto.py` driver loop only. **Execute and review phase logic are untouched.**

### Files changed

- `megaplan/auto.py` — helpers + rework-aware stall loop (+115 LOC)
- `tests/test_auto.py` — new file, 5 tests (+190 LOC)
- `pyproject.toml` — bump to `0.18.1`
- `CHANGELOG.md` — `v0.18.1` entry

Net diff: ~130 LOC production, ~190 LOC tests.

## Test plan

- [x] `PYENV_VERSION=3.11.11 python -m pytest tests/ -q` passes before changes (649 passed)
- [x] `PYENV_VERSION=3.11.11 python -m pytest tests/ -q` passes after changes (654 passed — 5 new, no regressions)
- [x] `tests/test_auto.py::test_stall_counter_resets_when_review_json_is_rewritten` — simulated rework loop with stall_threshold=3 runs 6 iterations without stalling, observes ≥3 rework cycles
- [x] `tests/test_auto.py::test_rework_cap_bails_after_exceeding_max_review_rework_cycles` — driver stops with `status=stalled` and "review rework cap" reason
- [x] `tests/test_auto.py::test_stall_still_trips_without_review_progress` — non-review plans preserve existing stall behavior
- [x] `tests/test_auto.py::test_resolve_plan_dir_finds_plans_in_parent_tree` — walks up from child cwd
- [x] `tests/test_auto.py::test_get_review_marker_returns_none_when_review_missing` — graceful fallback when artifact missing
- [ ] Re-run the failing production plan (`milestone-m1b-from-docs-state-20260416-1226` or equivalent) end-to-end to confirm rework cycles no longer cause false-positive stalls

🤖 Generated with [Claude Code](https://claude.com/claude-code)