### PR TITLE
cloud: validate codex.reasoning + switch arnold-merge to gpt-5.5/low

### DIFF
--- a/cloud.yaml
+++ b/cloud.yaml
@@ -9,8 +9,8 @@ agents:
   default: codex
 
 codex:
-  model: gpt-5.4
-  reasoning: high
+  model: gpt-5.5
+  reasoning: low
 
 mode: chain
 

--- a/megaplan/cloud/spec.py
+++ b/megaplan/cloud/spec.py
@@ -20,6 +20,7 @@ VALID_MODES = ("auto", "chain", "idle")
 VALID_PROVIDERS = ("railway", "local", "ssh")
 FUTURE_PROVIDERS = ("fly",)
 KNOWN_TOOLCHAIN_ALIASES = ("rust", "go", "java")
+VALID_CODEX_REASONING = ("minimal", "low", "medium", "high")
 
 
 @dataclass(frozen=True)
@@ -240,9 +241,14 @@ def load_spec(path: Path) -> CloudSpec:
     )
 
     codex_raw = _mapping(raw.get("codex"), "codex")
+    codex_reasoning = _string(codex_raw.get("reasoning"), "codex.reasoning", default="high")
+    if codex_reasoning not in VALID_CODEX_REASONING:
+        raise _invalid(
+            f"codex.reasoning must be one of {', '.join(VALID_CODEX_REASONING)}; got {codex_reasoning!r}"
+        )
     codex = CodexSpec(
         model=_string(codex_raw.get("model"), "codex.model", default="gpt-5.4"),
-        reasoning=_string(codex_raw.get("reasoning"), "codex.reasoning", default="high"),
+        reasoning=codex_reasoning,
     )
 
     mode = _string(raw.get("mode"), "mode", default="idle")

--- a/tests/test_cloud_spec.py
+++ b/tests/test_cloud_spec.py
@@ -122,6 +122,21 @@ def test_load_spec_rejects_unknown_provider(tmp_path: Path) -> None:
         load_spec(_write_spec(tmp_path, payload))
 
 
+@pytest.mark.parametrize("effort", ["minimal", "low", "medium", "high"])
+def test_load_spec_accepts_each_codex_reasoning_effort(tmp_path: Path, effort: str) -> None:
+    payload = _base_spec()
+    payload["codex"] = {"model": "gpt-5.5", "reasoning": effort}
+    spec = load_spec(_write_spec(tmp_path, payload))
+    assert spec.codex.reasoning == effort
+
+
+def test_load_spec_rejects_unknown_codex_reasoning(tmp_path: Path) -> None:
+    payload = _base_spec()
+    payload["codex"] = {"model": "gpt-5.4", "reasoning": "extreme"}
+    with pytest.raises(CliError, match="minimal, low, medium, high"):
+        load_spec(_write_spec(tmp_path, payload))
+
+
 def test_load_spec_rejects_future_provider_with_distinct_error(tmp_path: Path) -> None:
     payload = _base_spec()
     payload["provider"] = "fly"


### PR DESCRIPTION
## Summary
- Validate \`codex.reasoning\` against codex-cli's accepted values (minimal/low/medium/high). Typos now fail at spec-load instead of silently writing a bad config.
- Switch arnold-merge \`cloud.yaml\` to \`model: gpt-5.5\` + \`reasoning: low\`. Smoke-tested in the running container — both work end-to-end via \`codex exec -c model=... -c model_reasoning_effort=...\`.

## Test plan
- [x] \`pytest tests/test_cloud_spec.py\` — 27 passed (includes new parametrized happy-path + reject-unknown cases)
- [x] Live container test: \`codex exec\` with each (default config | gpt-5.5/low override) returned correct output

🤖 Generated with [Claude Code](https://claude.com/claude-code)