### PR TITLE
Recover all 5 unmerged fixes from per-milestone-robustness (rebased + conflict-resolved)

### DIFF
--- a/megaplan/cli.py
+++ b/megaplan/cli.py
@@ -41,6 +41,7 @@ from megaplan._core import (
     infer_next_steps,
     is_prose_mode,
     json_dump,
+    list_batch_artifacts,
     load_config,
     load_debt_registry,
     load_plan,
@@ -207,6 +208,38 @@ def _build_progress_payload(plan_dir: Path, state: dict[str, Any]) -> dict[str, 
     for batch_idx, batch_ids in enumerate(global_batches, start=1):
         for task_id in batch_ids:
             task_id_to_batch[task_id] = batch_idx
+    # In per-batch execute mode, finalize.json is only rewritten after the
+    # final batch — between batches the per-task status overlay lives in
+    # execution_batch_<n>.json. Apply that overlay so progress reflects the
+    # most recent on-disk truth. Single-execute mode produces no batch
+    # artifacts, so this is a no-op there.
+    batch_status_overlay: dict[str, str] = {}
+    batch_artifacts = list_batch_artifacts(plan_dir)
+    for batch_path in batch_artifacts:
+        try:
+            batch_data = read_json(batch_path)
+        except Exception:
+            continue
+        for update in batch_data.get("task_updates", []) or []:
+            if not isinstance(update, dict):
+                continue
+            task_id = update.get("task_id")
+            status = update.get("status")
+            if isinstance(task_id, str) and isinstance(status, str) and status:
+                batch_status_overlay[task_id] = status
+    progress_source = "finalize.json"
+    if batch_status_overlay:
+        merged_tasks: list[dict[str, Any]] = []
+        for task in tasks:
+            tid = task.get("id")
+            if isinstance(tid, str) and tid in batch_status_overlay:
+                merged = dict(task)
+                merged["status"] = batch_status_overlay[tid]
+                merged_tasks.append(merged)
+            else:
+                merged_tasks.append(task)
+        tasks = merged_tasks
+        progress_source = "execution_batch_*.json"
     tasks_done = sum(1 for t in tasks if t.get("status") == "done")
     tasks_skipped = sum(1 for t in tasks if t.get("status") == "skipped")
     tasks_pending = sum(1 for t in tasks if t.get("status") == "pending")
@@ -228,11 +261,19 @@ def _build_progress_payload(plan_dir: Path, state: dict[str, Any]) -> dict[str, 
         }
         for t in tasks
     ]
+    if progress_source == "execution_batch_*.json":
+        granularity_note = (
+            "Progress reflects per-batch artifacts (latest execution_batch_*.json overlay)."
+        )
+    else:
+        granularity_note = (
+            "Progress reflects the last finalize.json write (between-batch granularity)."
+        )
     return {
         "summary": (
             f"Execution progress: {tasks_done + tasks_skipped}/{tasks_total} tasks tracked, "
             f"{batches_completed}/{len(global_batches)} batches completed. "
-            "Progress reflects the last finalize.json write (between-batch granularity)."
+            f"{granularity_note}"
         ),
         "tasks_total": tasks_total,
         "tasks_done": tasks_done,
@@ -942,6 +983,32 @@ def handle_config(args: argparse.Namespace) -> StepResponse:
                 "profile": resolved,
             }
         raise CliError("invalid_args", f"Unknown profiles action: {profiles_action}")
+    if action == "use-profile":
+        project_dir = Path.cwd()
+        name = args.name
+        profiles = load_profiles(project_dir=project_dir)
+        # resolve_profile raises CliError("unknown_profile", ...) with the list of
+        # known profile names, which is what we want for a clear error.
+        resolved = resolve_profile(name, profiles)
+        config = load_config()
+        agents_section = config.setdefault("agents", {})
+        applied: dict[str, str] = {}
+        for phase, spec in resolved.items():
+            agents_section[phase] = spec
+            applied[phase] = spec
+        save_config(config)
+        return {
+            "success": True,
+            "step": "config",
+            "action": "use-profile",
+            "config_path": str(config_dir() / "config.json"),
+            "profile": name,
+            "applied": applied,
+            "summary": (
+                f"Applied profile '{name}' to user config "
+                f"({len(applied)} agent phase{'s' if len(applied) != 1 else ''} updated)."
+            ),
+        }
     if action == "reset":
         path = config_dir() / "config.json"
         if path.exists():
@@ -2058,6 +2125,17 @@ def build_parser() -> argparse.ArgumentParser:
     )
     profiles_show_parser = profiles_sub.add_parser("show", help="Show the fully resolved phase map for one profile")
     profiles_show_parser.add_argument("name")
+    use_profile_parser = config_sub.add_parser(
+        "use-profile",
+        help="Apply a profile as the user-config default agent routing (writes every agents.<phase>)",
+        description=(
+            "Apply a named profile from built-in/user/project layers as the persisted default "
+            "agent routing in ~/.config/megaplan/config.json. Equivalent to running "
+            "'config set agents.<phase> <agent>' for every phase in the profile, but accepts "
+            "agent specs with model qualifiers (e.g. 'hermes:glm-5.1') the same way profiles do."
+        ),
+    )
+    use_profile_parser.add_argument("name", help="Profile name (see 'megaplan config profiles list')")
 
     step_parser = subparsers.add_parser("step", help="Edit plan step sections without hand-editing markdown")
     step_subparsers = step_parser.add_subparsers(dest="step_action", required=True)

--- a/megaplan/execute/core.py
+++ b/megaplan/execute/core.py
@@ -731,10 +731,29 @@ def handle_execute_one_batch(
         )
 
     tasks = finalize_data.get("tasks", [])
+    # In per-batch execute mode, finalize.json is only rewritten after the
+    # final batch — between batches the per-task status overlay lives in
+    # execution_batch_<n>.json. Apply that overlay so prerequisite checks
+    # see the most recent on-disk truth.
+    batch_status_overlay: dict[str, str] = {}
+    for batch_path in list_batch_artifacts(plan_dir):
+        try:
+            batch_data = read_json(batch_path)
+        except Exception:
+            continue
+        for update in batch_data.get("task_updates", []) or []:
+            if not isinstance(update, dict):
+                continue
+            tid = update.get("task_id")
+            status = update.get("status")
+            if isinstance(tid, str) and isinstance(status, str) and status:
+                batch_status_overlay[tid] = status
     completed_ids = {
         task["id"]
         for task in tasks
-        if task.get("status") in {"done", "skipped"} and isinstance(task.get("id"), str)
+        if isinstance(task.get("id"), str)
+        and batch_status_overlay.get(task["id"], task.get("status"))
+        in {"done", "skipped"}
     }
     for prior_idx in range(batch_number - 1):
         prior_batch = global_batches[prior_idx]

--- a/megaplan/execute/core.py
+++ b/megaplan/execute/core.py
@@ -40,6 +40,7 @@ from megaplan.execute.quality import (
     _check_done_task_evidence_by_kind,
     _collect_execute_claimed_paths,
     _collect_quality_deviations,
+    _normalize_execute_claimed_path,
     _observe_git_changes,
 )
 from megaplan.execute.timeout import (
@@ -675,8 +676,20 @@ def _append_trace_output(plan_dir: Path, trace_output: str | None) -> bool:
     return True
 
 
-def _compute_execute_scope_drift(project_dir: Path, aggregate_payload: dict[str, Any]):
+def _compute_execute_scope_drift(
+    project_dir: Path,
+    aggregate_payload: dict[str, Any],
+    state: PlanState | None = None,
+):
     files_claimed = _collect_execute_claimed_paths(aggregate_payload, project_dir)
+    if state is not None:
+        config = state.get("config") or {}
+        if config.get("mode") == "doc":
+            output_path = config.get("output_path")
+            if isinstance(output_path, str) and output_path.strip():
+                files_claimed.add(
+                    _normalize_execute_claimed_path(output_path, project_dir)
+                )
     try:
         observed_snapshot, observed_error = _capture_git_status_snapshot(project_dir)
     except Exception:
@@ -870,7 +883,7 @@ def handle_execute_one_batch(
         # _run_and_merge_batch already wrote execution_audit.json; this handler
         # only writes the aggregate execution.json after the batch returns.
         atomic_write_json(plan_dir / "execution.json", aggregate_payload)
-        drift = _compute_execute_scope_drift(project_dir, aggregate_payload)
+        drift = _compute_execute_scope_drift(project_dir, aggregate_payload, state)
         _append_scope_drift_blocker(blocking_reasons, state, drift)
 
     blocked = bool(blocking_reasons)
@@ -1418,7 +1431,7 @@ def handle_execute_auto_loop(
         )
     aggregate_payload["deviations"] = deviations
     atomic_write_json(plan_dir / "execution.json", aggregate_payload)
-    drift = _compute_execute_scope_drift(project_dir, aggregate_payload)
+    drift = _compute_execute_scope_drift(project_dir, aggregate_payload, state)
     atomic_write_json(plan_dir / "execution_audit.json", execution_audit)
     atomic_write_json(plan_dir / "finalize.json", finalize_data)
     atomic_write_text(

--- a/megaplan/hermes_worker.py
+++ b/megaplan/hermes_worker.py
@@ -38,6 +38,48 @@ def _import_hermes_runtime():
     return AIAgent, SessionDB
 
 
+# Fireworks rejects requests with `max_tokens > 4096` unless `stream=true`.
+# When that threshold applies we flip the call to streaming and let
+# run_agent's streaming path reassemble the response into the same shape the
+# rest of megaplan expects.  Streaming lives entirely inside the worker —
+# downstream callers never see streaming semantics.
+_FIREWORKS_STREAM_MAX_TOKENS = 4096
+
+
+def _no_op_stream(_text: str) -> None:
+    """Sentinel callback that activates run_agent's streaming path.
+
+    AIAgent decides between streaming and non-streaming based on whether a
+    stream consumer is registered.  We don't need the deltas, just the side
+    effect of forcing `stream=True` on the underlying chat.completions call.
+    """
+    return None
+_no_op_stream._megaplan_force_stream = True  # type: ignore[attr-defined]
+
+
+def _provider_requires_streaming(model: str | None, max_tokens: int | None) -> bool:
+    """Return True when this provider/max_tokens pair must use streaming.
+
+    Today only Fireworks has this constraint (max_tokens > 4096 must stream).
+    Other providers (OpenRouter, DeepSeek-direct, MiniMax, etc.) accept
+    non-streamed high-max_tokens requests, so we keep the opt-in narrow.
+    """
+    if not model or not isinstance(model, str):
+        return False
+    if not model.startswith("fireworks:"):
+        return False
+    if max_tokens is None:
+        return False
+    return max_tokens > _FIREWORKS_STREAM_MAX_TOKENS
+
+
+def _streaming_run_kwargs(model: str | None, max_tokens: int | None) -> dict:
+    """Build the run_conversation kwargs needed to force streaming when required."""
+    if _provider_requires_streaming(model, max_tokens):
+        return {"stream_callback": _no_op_stream}
+    return {}
+
+
 def _toolsets_for_phase(phase: str) -> list[str] | None:
     """Return toolsets for a given megaplan phase.
 
@@ -147,8 +189,15 @@ def parse_agent_output(
     step: str,
     project_dir: Path,
     plan_dir: Path,
+    run_kwargs: dict | None = None,
 ) -> tuple[dict, str]:
-    """Parse a Hermes agent result into a structured payload."""
+    """Parse a Hermes agent result into a structured payload.
+
+    ``run_kwargs`` is forwarded to any follow-up ``agent.run_conversation``
+    calls (template / summary fallbacks) so providers that require streaming
+    (e.g. Fireworks at high max_tokens) keep streaming on those calls too.
+    """
+    extra_run_kwargs = run_kwargs or {}
     raw_output = result.get("final_response", "") or ""
     messages = result.get("messages", [])
 
@@ -166,6 +215,7 @@ def parse_agent_output(
             summary_result = agent.run_conversation(
                 user_message=summary_prompt,
                 conversation_history=messages,
+                **extra_run_kwargs,
             )
             raw_output = summary_result.get("final_response", "") or ""
             messages = summary_result.get("messages", messages)
@@ -254,6 +304,7 @@ def parse_agent_output(
             summary_result = agent.run_conversation(
                 user_message=summary_prompt,
                 conversation_history=messages,
+                **extra_run_kwargs,
             )
             summary_output = summary_result.get("final_response", "") or ""
             if summary_output.strip():
@@ -454,6 +505,14 @@ def run_hermes_step(
         else None
     )
 
+    # Cap output tokens to prevent repetition loops (Qwen generates 330K+
+    # of repeated text without a limit). Sized to fit large finalize.json
+    # task graphs and multi-batch execute outputs on plans with ~15+ tasks.
+    # Also drives the Fireworks streaming gate below — any value >4096 forces
+    # streaming on `fireworks:*` models because Fireworks rejects >4096 max_tokens
+    # without `stream=true`.
+    agent_max_tokens = 65536 if step == "execute" else 32768
+
     def _make_agent(agent_model: str, extra_kwargs: dict) -> "AIAgent":
         current_agent = AIAgent(
             model=agent_model,
@@ -463,10 +522,7 @@ def run_hermes_step(
             enabled_toolsets=toolsets,
             session_id=session_id,
             session_db=SessionDB(),
-            # Cap output tokens to prevent repetition loops (Qwen generates 330K+
-            # of repeated text without a limit). Sized to fit large finalize.json
-            # task graphs and multi-batch execute outputs on plans with ~15+ tasks.
-            max_tokens=65536 if step == "execute" else 32768,
+            max_tokens=agent_max_tokens,
             reasoning_config=_reasoning_off,
             **extra_kwargs,
         )
@@ -502,10 +558,17 @@ def run_hermes_step(
             return exc.message
         return str(exc) or exc.__class__.__name__
 
-    def _run_attempt(current_agent, current_output_path: Path | None) -> tuple[dict, dict, str]:
+    def _run_attempt(current_agent, current_output_path: Path | None, *, current_model: str | None = None) -> tuple[dict, dict, str]:
+        # Force streaming for providers that require it at this max_tokens
+        # (e.g. Fireworks rejects max_tokens > 4096 unless stream=true).
+        # The streaming response is reassembled inside run_agent into the
+        # same shape non-streaming returns, so the rest of megaplan is
+        # unchanged.
+        run_kwargs = _streaming_run_kwargs(current_model or model, agent_max_tokens)
         current_result = current_agent.run_conversation(
             user_message=prompt,
             conversation_history=conversation_history,
+            **run_kwargs,
         )
         current_payload, current_raw_output = parse_agent_output(
             current_agent,
@@ -515,6 +578,7 @@ def run_hermes_step(
             step=step,
             project_dir=project_dir,
             plan_dir=plan_dir,
+            run_kwargs=run_kwargs,
         )
         clean_parsed_payload(current_payload, schema, step)
         messages = current_result.get("messages", [])

--- a/megaplan/hermes_worker.py
+++ b/megaplan/hermes_worker.py
@@ -547,6 +547,17 @@ def run_hermes_step(
     # The JSON template in the prompt is sufficient; _parse_json_response
     # handles code fences and markdown wrapping.
 
+    # Install the project_dir sandbox whenever a toolset is active.  This
+    # pins TERMINAL_CWD and wraps the terminal/write_file/patch handlers so
+    # the model can't escape the worktree even if its prompt context tells
+    # it to (see megaplan/sandbox.py).  Phases without tools (no toolsets)
+    # don't need it.
+    from contextlib import ExitStack
+    _sandbox_stack = ExitStack()
+    if toolsets:
+        from megaplan.sandbox import install_sandbox
+        _sandbox_stack.enter_context(install_sandbox(project_dir))
+
     # Run — with fallback to OpenRouter for MiniMax if primary API fails
     started = time.monotonic()
     try:
@@ -618,6 +629,7 @@ def run_hermes_step(
     finally:
         sys.stdout = real_stdout
         sys.stderr = real_stderr
+        _sandbox_stack.close()
     elapsed_ms = int((time.monotonic() - started) * 1000)
 
     cost_usd = result.get("estimated_cost_usd", 0.0) or 0.0

--- a/megaplan/parallel_critique.py
+++ b/megaplan/parallel_critique.py
@@ -11,7 +11,12 @@ from pathlib import Path
 from typing import Any
 
 from megaplan._core import get_effective, read_json, schemas_root
-from megaplan.hermes_worker import _toolsets_for_phase, clean_parsed_payload, parse_agent_output
+from megaplan.hermes_worker import (
+    _streaming_run_kwargs,
+    _toolsets_for_phase,
+    clean_parsed_payload,
+    parse_agent_output,
+)
 from megaplan.prompts.critique import single_check_critique_prompt, write_single_check_template
 from megaplan.prompts.critique_joke import single_check_critique_joke_prompt
 from megaplan.types import CliError, PlanState
@@ -70,6 +75,10 @@ def _run_check(
         else None
     )
 
+    # Cap output tokens to match the main-line hermes worker (Qwen repetition
+    # mitigation). Drives the Fireworks streaming gate below.
+    agent_max_tokens = 32768
+
     def _make_agent(m: str, kw: dict) -> "AIAgent":
         a = AIAgent(
             model=m,
@@ -79,7 +88,7 @@ def _run_check(
             enabled_toolsets=_toolsets_for_phase("critique"),
             session_id=str(uuid.uuid4()),
             session_db=SessionDB(),
-            max_tokens=32768,
+            max_tokens=agent_max_tokens,
             reasoning_config=_reasoning_off,
             **kw,
         )
@@ -91,8 +100,16 @@ def _run_check(
             return exc.message
         return str(exc) or exc.__class__.__name__
 
-    def _run_attempt(current_agent, current_output_path: Path) -> tuple[dict[str, Any], dict[str, Any], list[str], list[str], float]:
-        current_result = current_agent.run_conversation(user_message=prompt)
+    def _run_attempt(current_agent, current_output_path: Path, *, current_model: str | None = None) -> tuple[dict[str, Any], dict[str, Any], list[str], list[str], float]:
+        # Force streaming for providers that require it at this max_tokens
+        # (Fireworks rejects max_tokens > 4096 unless stream=true).  The
+        # streaming response is reassembled into the same shape non-streaming
+        # would return — downstream code is unchanged.
+        run_kwargs = _streaming_run_kwargs(current_model or model, agent_max_tokens)
+        current_result = current_agent.run_conversation(
+            user_message=prompt,
+            **run_kwargs,
+        )
         payload, raw_output = parse_agent_output(
             current_agent,
             current_result,
@@ -101,6 +118,7 @@ def _run_check(
             step="critique",
             project_dir=project_dir,
             plan_dir=plan_dir,
+            run_kwargs=run_kwargs,
         )
         clean_parsed_payload(payload, schema, "critique")
         payload_checks = payload.get("checks")

--- a/megaplan/receipts/drift.py
+++ b/megaplan/receipts/drift.py
@@ -48,9 +48,17 @@ def compute_scope_drift(
     files_missing = sorted(files_claimed - files_in_diff)
     loc_added = sum(loc_by_file.values())
     loc_added_outside_claimed = sum(loc_by_file.get(path, 0) for path in files_added)
+    # ``files_missing`` means the executor claimed it changed a file that
+    # isn't in the diff — i.e. fabricated work, or work that landed in the
+    # wrong tree (sandbox escape).  Treat this at least as seriously as
+    # writes-without-claims: low for any miss, high once the count is
+    # comparable to a real-but-noisy diff (>3 files claimed-but-missing
+    # is well past "model forgot to list one").
     if files_added and loc_added_outside_claimed > 20:
         severity: Literal["none", "low", "high"] = "high"
-    elif files_added or loc_added_outside_claimed > 0:
+    elif len(files_missing) > 3:
+        severity = "high"
+    elif files_added or loc_added_outside_claimed > 0 or files_missing:
         severity = "low"
     else:
         severity = "none"

--- a/megaplan/sandbox.py
+++ b/megaplan/sandbox.py
@@ -1,0 +1,315 @@
+"""Project-directory sandbox for hermes tool calls.
+
+Background
+----------
+The hermes worker invokes ``AIAgent`` from the vendored agent SDK to run
+megaplan phases.  In bakeoff runs each profile gets its own worktree
+(``.megaplan-worktrees/<plan>/<profile>/``) and the worktree path is
+communicated to the model via a ``Project directory: <abs path>`` line in
+the prompt.
+
+The execute prompt also embeds user-authored idea text — and that text can
+contain its own ``Project: ...`` line.  When a model resolves the conflict by
+trusting the user-authored line (we observed DeepSeek do exactly this), it
+prefixes every ``terminal`` call with ``cd <wrong-abs-path> && ...`` and
+issues ``write_file`` / ``patch`` calls with absolute paths under the wrong
+repo.  The audit catches the resulting empty diff after the fact, but by
+then writes have landed in the wrong tree.
+
+This module enforces the boundary at the **tool layer** so that no matter
+what the prompt says, the model cannot exec or write outside ``project_dir``.
+
+Three knobs:
+
+1. ``TERMINAL_CWD`` env var is pinned to ``project_dir`` so the terminal
+   tool's default cwd is the worktree (mirrors the Claude/CLI happy path
+   at ``cli.py:7260``).
+
+2. The registered handlers for ``terminal``, ``write_file``, and ``patch``
+   are wrapped to validate / coerce paths before dispatch.  Refusal is a
+   hard error returned to the model so it can correct itself; we don't
+   silently rewrite the call.
+
+3. ``read_file`` and ``search_files`` are intentionally **not** sandboxed —
+   the model legitimately needs to read e.g. ``/tmp/phase-6-idea.txt`` and
+   the megaplan template files.  Only writes / exec are bounded.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+logger = logging.getLogger(__name__)
+
+# Tool names we sandbox.  Keep in sync with the registry.register() calls
+# in tools/terminal_tool.py and tools/file_tools.py.
+SANDBOXED_EXEC_TOOLS = ("terminal",)
+SANDBOXED_WRITE_TOOLS = ("write_file", "patch")
+
+# Match a leading ``cd <path> && ...`` (with optional quoting) so we can
+# inspect the target directory before letting the command through.  We only
+# look at the *leading* cd because the terminal backend runs each command in
+# a fresh shell with a known cwd — a mid-command ``cd`` only affects the
+# rest of that one command, not subsequent invocations.
+_LEADING_CD_RE = re.compile(
+    r"""^\s*cd\s+
+        (?:
+            "(?P<dq>[^"]+)"      # double-quoted path
+          | '(?P<sq>[^']+)'      # single-quoted path
+          | (?P<bare>[^\s&|;]+)  # unquoted path (stops at shell separators)
+        )
+        \s*&&\s*
+        (?P<rest>.+)$
+    """,
+    re.VERBOSE | re.DOTALL,
+)
+
+# V4A patch directives that name a file.  We require the named path to live
+# inside project_dir — otherwise a malicious patch could write outside the
+# worktree even with a sandboxed write_file.
+_V4A_FILE_DIRECTIVES = re.compile(
+    r"^\s*\*\*\*\s+(?:Update|Add|Delete)\s+File:\s*(.+?)\s*$",
+    re.MULTILINE,
+)
+
+
+class SandboxViolation(Exception):
+    """Raised when a tool call escapes the project_dir sandbox."""
+
+
+def _normalize(path: Path) -> Path:
+    """Resolve symlinks where possible; fall back to absolute form."""
+    try:
+        return path.resolve()
+    except (OSError, RuntimeError):
+        return path.absolute()
+
+
+def _is_within(candidate: Path, root: Path) -> bool:
+    """Return True iff ``candidate`` is ``root`` or a descendant."""
+    try:
+        candidate.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def _coerce_path(raw: str, project_dir: Path) -> Path:
+    """Resolve a user-supplied path against project_dir, expanding ``~``.
+
+    Relative paths resolve under ``project_dir``.  Absolute paths are kept
+    as-is; the caller decides whether they fall inside the boundary.
+    """
+    expanded = os.path.expanduser(raw)
+    p = Path(expanded)
+    if not p.is_absolute():
+        p = project_dir / p
+    return _normalize(p)
+
+
+def validate_terminal_command(command: str, project_dir: Path) -> str:
+    """Return a command safe to run with cwd=project_dir, or raise.
+
+    Strips a leading ``cd <project_dir-or-child> && ...`` prefix (since the
+    shell will run with cwd=project_dir anyway) and refuses any leading
+    ``cd <path>`` whose target escapes ``project_dir``.
+
+    Mid-command ``cd`` calls aren't inspected: they only scope to that one
+    shell invocation and don't leak across tool calls.  The terminal
+    backend runs each command in a fresh shell rooted at TERMINAL_CWD.
+    """
+    if not isinstance(command, str):
+        raise SandboxViolation("terminal command must be a string")
+
+    project_dir = _normalize(project_dir)
+    match = _LEADING_CD_RE.match(command)
+    if not match:
+        return command
+
+    target_raw = match.group("dq") or match.group("sq") or match.group("bare")
+    rest = match.group("rest")
+    target = _coerce_path(target_raw, project_dir)
+
+    if not _is_within(target, project_dir):
+        raise SandboxViolation(
+            f"refusing terminal command: leading `cd {target_raw}` targets "
+            f"{target}, which is outside the project directory {project_dir}. "
+            "Run commands relative to the project directory; do not `cd` to "
+            "an absolute path outside the worktree."
+        )
+
+    # Target is inside project_dir.  Strip the leading cd so the command
+    # runs at the correct cwd regardless of how the model wrote it.
+    if target == project_dir:
+        return rest
+    rel = target.relative_to(project_dir)
+    return f"cd {rel} && {rest}" if str(rel) != "." else rest
+
+
+def validate_write_path(raw_path: str, project_dir: Path) -> str:
+    """Return a write path inside ``project_dir``, or raise.
+
+    Both absolute paths outside ``project_dir`` and relative paths that
+    traverse out via ``..`` are rejected.  The returned string is the
+    resolved absolute path the caller can safely write to.
+    """
+    if not raw_path or not isinstance(raw_path, str):
+        raise SandboxViolation("write path must be a non-empty string")
+
+    project_dir = _normalize(project_dir)
+    target = _coerce_path(raw_path, project_dir)
+    if not _is_within(target, project_dir):
+        raise SandboxViolation(
+            f"refusing write to {raw_path}: resolves to {target}, which is "
+            f"outside the project directory {project_dir}. Use a path "
+            "relative to the project directory or an absolute path within it."
+        )
+    return str(target)
+
+
+def validate_v4a_patch(patch_content: str, project_dir: Path) -> None:
+    """Raise if any *** {Update,Add,Delete} File: directive escapes project_dir."""
+    if not isinstance(patch_content, str):
+        raise SandboxViolation("patch content must be a string")
+    project_dir = _normalize(project_dir)
+    for match in _V4A_FILE_DIRECTIVES.finditer(patch_content):
+        validate_write_path(match.group(1), project_dir)
+
+
+# --------------------------------------------------------------------------
+# Handler wrappers
+# --------------------------------------------------------------------------
+
+
+def _refusal(tool: str, message: str) -> str:
+    logger.warning("sandbox refused %s: %s", tool, message)
+    return json.dumps({"error": f"sandbox: {message}"}, ensure_ascii=False)
+
+
+def _wrap_terminal(handler, project_dir: Path):
+    def wrapper(args, **kw):
+        try:
+            cmd = args.get("command", "") if isinstance(args, dict) else ""
+            new_cmd = validate_terminal_command(cmd, project_dir)
+        except SandboxViolation as exc:
+            return _refusal("terminal", str(exc))
+        new_args = dict(args) if isinstance(args, dict) else {}
+        new_args["command"] = new_cmd
+        # Force workdir override too — even if the model passed an explicit
+        # workdir arg, it must stay inside project_dir.
+        workdir = new_args.get("workdir")
+        if workdir:
+            try:
+                resolved = _coerce_path(workdir, project_dir)
+            except Exception:
+                resolved = None
+            if resolved is None or not _is_within(resolved, project_dir):
+                return _refusal(
+                    "terminal",
+                    f"workdir {workdir!r} resolves outside the project "
+                    f"directory {project_dir}",
+                )
+            new_args["workdir"] = str(resolved)
+        return handler(new_args, **kw)
+
+    return wrapper
+
+
+def _wrap_write_file(handler, project_dir: Path):
+    def wrapper(args, **kw):
+        if not isinstance(args, dict):
+            return handler(args, **kw)
+        raw = args.get("path", "")
+        try:
+            safe = validate_write_path(raw, project_dir)
+        except SandboxViolation as exc:
+            return _refusal("write_file", str(exc))
+        new_args = dict(args)
+        new_args["path"] = safe
+        return handler(new_args, **kw)
+
+    return wrapper
+
+
+def _wrap_patch(handler, project_dir: Path):
+    def wrapper(args, **kw):
+        if not isinstance(args, dict):
+            return handler(args, **kw)
+        mode = args.get("mode", "replace")
+        new_args = dict(args)
+        try:
+            if mode == "replace":
+                raw = args.get("path", "")
+                if raw:
+                    new_args["path"] = validate_write_path(raw, project_dir)
+            elif mode == "patch":
+                patch_content = args.get("patch", "") or ""
+                validate_v4a_patch(patch_content, project_dir)
+        except SandboxViolation as exc:
+            return _refusal("patch", str(exc))
+        return handler(new_args, **kw)
+
+    return wrapper
+
+
+_WRAPPERS = {
+    "terminal": _wrap_terminal,
+    "write_file": _wrap_write_file,
+    "patch": _wrap_patch,
+}
+
+
+@contextmanager
+def install_sandbox(project_dir: Path) -> Iterator[None]:
+    """Pin tool calls to ``project_dir`` for the duration of the with-block.
+
+    Sets ``TERMINAL_CWD`` and wraps the relevant registry handlers in place.
+    Restores both on exit.  Idempotent — safe to nest, but inner uses of
+    the same project_dir are no-ops.
+    """
+    project_dir = _normalize(Path(project_dir))
+    if not project_dir.exists():
+        raise ValueError(
+            f"sandbox project_dir does not exist: {project_dir}. "
+            "Refusing to install sandbox against a missing directory."
+        )
+
+    # Snapshot the env var so nested or sequential calls restore correctly.
+    prior_env = os.environ.get("TERMINAL_CWD")
+    os.environ["TERMINAL_CWD"] = str(project_dir)
+
+    # Lazy-import the registry — the agent SDK pulls in heavy modules and
+    # we don't want to require them when running in --mock or non-hermes
+    # paths.  If the registry isn't importable here we still get the
+    # TERMINAL_CWD pin, which is the most important guard.
+    wrapped = []
+    try:
+        from tools.registry import registry as _registry  # type: ignore
+    except Exception as exc:
+        logger.debug("sandbox: tool registry unavailable, env-only mode: %s", exc)
+        _registry = None
+
+    if _registry is not None:
+        for name, wrapper_factory in _WRAPPERS.items():
+            entry = _registry._tools.get(name)
+            if entry is None:
+                continue
+            original = entry.handler
+            entry.handler = wrapper_factory(original, project_dir)
+            wrapped.append((entry, original))
+
+    try:
+        yield
+    finally:
+        for entry, original in wrapped:
+            entry.handler = original
+        if prior_env is None:
+            os.environ.pop("TERMINAL_CWD", None)
+        else:
+            os.environ["TERMINAL_CWD"] = prior_env

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,8 +9,9 @@ import pytest
 import megaplan
 import megaplan.cli as cli_module
 import megaplan._core.io as io_module
+import megaplan.profiles as profiles_module
 from megaplan._core import get_effective
-from megaplan.types import DEFAULTS
+from megaplan.types import CliError, DEFAULT_AGENT_ROUTING, DEFAULTS
 
 
 @pytest.fixture
@@ -273,3 +274,78 @@ def test_handle_init_explicit_robustness_beats_config_default(
     assert response["robustness"] == "light"
     assert state["config"]["auto_approve"] is True
     assert state["config"]["robustness"] == "light"
+
+
+def test_handle_config_use_profile_writes_all_phase_keys_and_preserves_unrelated(
+    isolated_config_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Make sure user-layer profiles.toml lookup also goes through the isolated dir
+    # so a stray real ~/.config/megaplan/profiles.toml can't contaminate the test.
+    monkeypatch.setattr(
+        profiles_module,
+        "config_dir",
+        lambda home=None: isolated_config_dir,
+    )
+
+    isolated_config_dir.mkdir(parents=True, exist_ok=True)
+    config_path = isolated_config_dir / "config.json"
+    # Pre-seed unrelated keys to verify they survive, plus a stale agents.plan
+    # value to verify it gets overwritten by the profile.
+    config_path.write_text(
+        json.dumps(
+            {
+                "execution": {"auto_approve": True, "robustness": "robust"},
+                "agents": {"plan": "codex"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    response = megaplan.handle_config(
+        Namespace(config_action="use-profile", name="standard")
+    )
+
+    assert response["success"] is True
+    assert response["action"] == "use-profile"
+    assert response["profile"] == "standard"
+    # All 12 phases from DEFAULT_AGENT_ROUTING should be present in `applied`.
+    assert set(response["applied"].keys()) == set(DEFAULT_AGENT_ROUTING.keys())
+
+    on_disk = json.loads(config_path.read_text(encoding="utf-8"))
+
+    # Unrelated section preserved verbatim.
+    assert on_disk["execution"] == {"auto_approve": True, "robustness": "robust"}
+
+    # Every phase from the standard profile written, and the stale plan value
+    # was overwritten.
+    for phase in DEFAULT_AGENT_ROUTING:
+        assert phase in on_disk["agents"]
+    assert on_disk["agents"]["plan"] == "claude"
+    # Spec values from `config profiles show standard` should match what was
+    # written to disk.
+    shown = megaplan.handle_config(
+        Namespace(config_action="profiles", profiles_action="show", name="standard")
+    )
+    assert on_disk["agents"] == shown["profile"]
+
+
+def test_handle_config_use_profile_unknown_profile_raises(
+    isolated_config_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        profiles_module,
+        "config_dir",
+        lambda home=None: isolated_config_dir,
+    )
+
+    with pytest.raises(CliError) as exc_info:
+        megaplan.handle_config(
+            Namespace(config_action="use-profile", name="definitely-not-a-profile")
+        )
+
+    assert exc_info.value.code == "unknown_profile"
+    # The error message should list at least one known built-in profile so the
+    # user can recover without consulting docs.
+    assert "standard" in exc_info.value.message

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -1297,7 +1297,8 @@ def test_execute_deduplicates_task_updates_and_blocks_incomplete_coverage(
     assert response["state"] == megaplan.STATE_FINALIZED
     assert response["next_step"] == "execute"
     assert response["summary"] == (
-        "Blocked: 1/2 tasks have no executor update; 1/2 sense checks have no executor acknowledgment. "
+        "[scope_drift=low] Blocked: 1/2 tasks have no executor update; "
+        "1/2 sense checks have no executor acknowledgment. "
         "Re-run execute to complete tracking."
     )
     assert "Duplicate task_update for 'T1' — last entry wins." in response["deviations"]

--- a/tests/test_hermes_worker_fireworks_streaming.py
+++ b/tests/test_hermes_worker_fireworks_streaming.py
@@ -1,0 +1,412 @@
+"""Tests for the Fireworks streaming workaround in the Hermes worker.
+
+Fireworks rejects requests with ``max_tokens > 4096`` unless ``stream=true``.
+The hermes worker must:
+  (a) detect Fireworks-prefixed models with high max_tokens and force the
+      streaming path so the call succeeds, with reassembly hidden from the
+      rest of megaplan; and
+  (b) when Fireworks does return a real 400 (or any other error), propagate
+      it as a hard failure rather than silently degrading to empty output.
+
+These tests don't hit the network — they exercise the streaming flag plumbing
+and the failure propagation by mocking ``AIAgent``.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from megaplan._core import atomic_write_json, atomic_write_text, read_json, schemas_root
+from megaplan.audits.robustness import checks_for_robustness
+from megaplan.hermes_worker import (
+    _no_op_stream,
+    _provider_requires_streaming,
+    _streaming_run_kwargs,
+    parse_agent_output,
+)
+from megaplan.parallel_critique import _run_check
+from megaplan.prompts.critique import write_single_check_template
+from megaplan.types import CliError, PlanState
+from megaplan.workers import STEP_SCHEMA_FILENAMES
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _state(project_dir: Path, *, iteration: int = 1) -> PlanState:
+    return {
+        "name": "fireworks-streaming-test",
+        "idea": "force streaming for fireworks",
+        "current_state": "planned",
+        "iteration": iteration,
+        "created_at": "2026-04-01T00:00:00Z",
+        "config": {
+            "project_dir": str(project_dir),
+            "auto_approve": False,
+            "robustness": "standard",
+        },
+        "sessions": {},
+        "plan_versions": [
+            {
+                "version": iteration,
+                "file": f"plan_v{iteration}.md",
+                "hash": "sha256:test",
+                "timestamp": "2026-04-01T00:00:00Z",
+            }
+        ],
+        "history": [],
+        "meta": {
+            "significant_counts": [],
+            "weighted_scores": [],
+            "plan_deltas": [],
+            "recurring_critiques": [],
+            "total_cost_usd": 0.0,
+            "overrides": [],
+            "notes": [],
+        },
+        "last_gate": {},
+    }
+
+
+def _scaffold(tmp_path: Path) -> tuple[Path, Path, PlanState]:
+    plan_dir = tmp_path / "plan"
+    project_dir = tmp_path / "project"
+    plan_dir.mkdir()
+    project_dir.mkdir()
+    (project_dir / ".git").mkdir()
+    state = _state(project_dir)
+    atomic_write_text(plan_dir / "plan_v1.md", "# Plan\nDo it.\n")
+    atomic_write_json(
+        plan_dir / "plan_v1.meta.json",
+        {
+            "version": 1,
+            "timestamp": "2026-04-01T00:00:00Z",
+            "hash": "sha256:test",
+            "success_criteria": [{"criterion": "criterion", "priority": "must"}],
+            "questions": [],
+            "assumptions": [],
+        },
+    )
+    atomic_write_json(plan_dir / "faults.json", {"flags": []})
+    return plan_dir, project_dir, state
+
+
+def _critique_schema() -> dict:
+    return read_json(schemas_root(REPO_ROOT) / STEP_SCHEMA_FILENAMES["critique"])
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def test_provider_requires_streaming_only_fires_for_fireworks_with_high_max_tokens() -> None:
+    # Fireworks + > 4096 → must stream
+    assert _provider_requires_streaming("fireworks:accounts/fireworks/models/kimi-k2p6", 8192) is True
+    assert _provider_requires_streaming("fireworks:foo", 4097) is True
+
+    # Fireworks at the threshold — Fireworks itself only requires streaming
+    # for ``> 4096``, so 4096 must NOT force streaming.
+    assert _provider_requires_streaming("fireworks:foo", 4096) is False
+    assert _provider_requires_streaming("fireworks:foo", None) is False
+
+    # Other providers don't need this even at very high max_tokens
+    assert _provider_requires_streaming("openrouter/anthropic/claude", 16384) is False
+    assert _provider_requires_streaming("deepseek:deepseek-v4-pro", 16384) is False
+    assert _provider_requires_streaming("minimax:MiniMax-M2", 16384) is False
+    assert _provider_requires_streaming(None, 16384) is False
+
+
+def test_streaming_run_kwargs_returns_callback_only_when_required() -> None:
+    # Fireworks high max_tokens → callback present
+    kwargs = _streaming_run_kwargs("fireworks:foo", 8192)
+    assert "stream_callback" in kwargs
+    assert kwargs["stream_callback"] is _no_op_stream
+
+    # Other provider → empty kwargs (no streaming forced)
+    assert _streaming_run_kwargs("openrouter/anthropic/claude", 16384) == {}
+    assert _streaming_run_kwargs("fireworks:foo", 4096) == {}
+
+
+# ---------------------------------------------------------------------------
+# Streaming gets enabled end-to-end through parallel_critique
+# ---------------------------------------------------------------------------
+
+
+def test_run_check_uses_streaming_for_fireworks_high_max_tokens(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """End-to-end: a Fireworks model + max_tokens=8192 must hit the agent's
+    streaming path.  We assert that ``stream_callback`` is forwarded to
+    ``run_conversation`` so AIAgent flips on streaming and reassembles.
+    """
+    plan_dir, project_dir, state = _scaffold(tmp_path)
+    check = checks_for_robustness("standard")[0]
+    schema = _critique_schema()
+    payload = {
+        "checks": [
+            {
+                "id": check["id"],
+                "question": check["question"],
+                "guidance": check["guidance"],
+                "prior_findings": [],
+                "findings": [
+                    {
+                        "detail": "Streaming reassembled the response correctly for the fireworks call.",
+                        "flagged": False,
+                    }
+                ],
+            }
+        ],
+        "flags": [],
+        "verified_flag_ids": [],
+        "disputed_flag_ids": [],
+    }
+
+    class FakeSessionDB:
+        pass
+
+    class FakeAIAgent:
+        instances: list["FakeAIAgent"] = []
+
+        def __init__(self, **kwargs: object) -> None:
+            self.kwargs = kwargs
+            self.calls: list[dict[str, object]] = []
+            self._print_fn = None
+            self.__class__.instances.append(self)
+
+        def run_conversation(self, **kwargs: object) -> dict[str, object]:
+            self.calls.append(kwargs)
+            return {
+                "final_response": json.dumps(payload),
+                "messages": [{"role": "assistant", "content": json.dumps(payload)}],
+                "estimated_cost_usd": 0.0,
+            }
+
+    monkeypatch.setitem(sys.modules, "run_agent", ModuleType("run_agent"))
+    monkeypatch.setitem(sys.modules, "hermes_state", ModuleType("hermes_state"))
+    sys.modules["run_agent"].AIAgent = FakeAIAgent
+    sys.modules["hermes_state"].SessionDB = FakeSessionDB
+
+    _run_check(
+        0,
+        check,
+        state=state,
+        plan_dir=plan_dir,
+        root=tmp_path,
+        model="fireworks:accounts/fireworks/models/kimi-k2p6",
+        schema=schema,
+        project_dir=project_dir,
+    )
+
+    assert len(FakeAIAgent.instances) == 1
+    agent = FakeAIAgent.instances[0]
+    # max_tokens=32768 (parallel_critique default after merging main's Qwen-cap
+    # values) > 4096, so the Fireworks streaming workaround must be active.
+    assert agent.kwargs["max_tokens"] == 32768
+    assert agent.calls, "agent should have been invoked"
+    # The call must carry a stream_callback — that's how AIAgent decides to
+    # request stream=true on the underlying chat.completions call.
+    assert "stream_callback" in agent.calls[0]
+    assert agent.calls[0]["stream_callback"] is _no_op_stream
+
+
+def test_run_check_does_not_force_streaming_for_other_providers(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Sanity check: non-Fireworks providers must NOT receive a stream_callback.
+
+    Streaming is a Fireworks-only quirk — adding it everywhere would change
+    the wire format for every provider.
+    """
+    plan_dir, project_dir, state = _scaffold(tmp_path)
+    check = checks_for_robustness("standard")[0]
+    schema = _critique_schema()
+    payload = {
+        "checks": [
+            {
+                "id": check["id"],
+                "question": check["question"],
+                "guidance": check["guidance"],
+                "prior_findings": [],
+                "findings": [
+                    {"detail": "Non-fireworks providers never need streaming.", "flagged": False}
+                ],
+            }
+        ],
+        "flags": [],
+        "verified_flag_ids": [],
+        "disputed_flag_ids": [],
+    }
+
+    class FakeSessionDB:
+        pass
+
+    class FakeAIAgent:
+        instances: list["FakeAIAgent"] = []
+
+        def __init__(self, **kwargs: object) -> None:
+            self.kwargs = kwargs
+            self.calls: list[dict[str, object]] = []
+            self._print_fn = None
+            self.__class__.instances.append(self)
+
+        def run_conversation(self, **kwargs: object) -> dict[str, object]:
+            self.calls.append(kwargs)
+            return {
+                "final_response": json.dumps(payload),
+                "messages": [{"role": "assistant", "content": json.dumps(payload)}],
+                "estimated_cost_usd": 0.0,
+            }
+
+    monkeypatch.setitem(sys.modules, "run_agent", ModuleType("run_agent"))
+    monkeypatch.setitem(sys.modules, "hermes_state", ModuleType("hermes_state"))
+    sys.modules["run_agent"].AIAgent = FakeAIAgent
+    sys.modules["hermes_state"].SessionDB = FakeSessionDB
+
+    _run_check(
+        0,
+        check,
+        state=state,
+        plan_dir=plan_dir,
+        root=tmp_path,
+        model="openrouter/anthropic/claude-opus-4.6",
+        schema=schema,
+        project_dir=project_dir,
+    )
+
+    agent = FakeAIAgent.instances[0]
+    assert "stream_callback" not in agent.calls[0]
+
+
+# ---------------------------------------------------------------------------
+# Real Fireworks 400 must propagate (no silent degradation)
+# ---------------------------------------------------------------------------
+
+
+def test_run_check_propagates_fireworks_400(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """If Fireworks returns a real 400, the worker must raise — not return
+    empty output.  This is what kept the bakeoff plan stalled at ``planned``
+    state with an empty critique_output.json: the call failed but the worker
+    must not paper over it.
+    """
+    plan_dir, project_dir, state = _scaffold(tmp_path)
+    check = checks_for_robustness("standard")[0]
+    schema = _critique_schema()
+
+    class FakeSessionDB:
+        pass
+
+    class FailingAIAgent:
+        instances: list["FailingAIAgent"] = []
+
+        def __init__(self, **kwargs: object) -> None:
+            self.kwargs = kwargs
+            self.__class__.instances.append(self)
+            self._print_fn = None
+
+        def run_conversation(self, **kwargs: object):
+            # Mirror the real Fireworks SDK error shape — even with stream=true
+            # set (we did our part), Fireworks can still 400 for other reasons
+            # and the worker must surface it.
+            raise RuntimeError(
+                "Error code: 400 - {'error': {'message': 'Bad request', "
+                "'param': 'messages', 'code': 'BAD_REQUEST', 'type': 'error'}, "
+                "'request_id': 'chatcmpl-test'}"
+            )
+
+    monkeypatch.setitem(sys.modules, "run_agent", ModuleType("run_agent"))
+    monkeypatch.setitem(sys.modules, "hermes_state", ModuleType("hermes_state"))
+    sys.modules["run_agent"].AIAgent = FailingAIAgent
+    sys.modules["hermes_state"].SessionDB = FakeSessionDB
+
+    with pytest.raises(RuntimeError, match="400"):
+        _run_check(
+            0,
+            check,
+            state=state,
+            plan_dir=plan_dir,
+            root=tmp_path,
+            model="fireworks:accounts/fireworks/models/kimi-k2p6",
+            schema=schema,
+            project_dir=project_dir,
+        )
+
+
+# ---------------------------------------------------------------------------
+# parse_agent_output forwards run_kwargs to its summary fallback
+# ---------------------------------------------------------------------------
+
+
+def test_parse_agent_output_summary_prompt_carries_streaming_kwargs(tmp_path: Path) -> None:
+    """The follow-up "summary" run_conversation call (used when the model
+    finished with tool calls but no JSON) must also carry the stream_callback
+    so it doesn't get rejected by Fireworks for the same max_tokens reason.
+    """
+    plan_dir, project_dir, state = _scaffold(tmp_path)
+    check = checks_for_robustness("standard")[0]
+    output_path = write_single_check_template(plan_dir, state, check, "critique_check_x.json")
+    payload = {
+        "checks": [
+            {
+                "id": check["id"],
+                "question": check["question"],
+                "guidance": check["guidance"],
+                "prior_findings": [],
+                "findings": [
+                    {"detail": "Recovered JSON via the summary fallback prompt.", "flagged": False}
+                ],
+            }
+        ],
+        "flags": [],
+        "verified_flag_ids": [],
+        "disputed_flag_ids": [],
+    }
+
+    class FakeAgent:
+        def __init__(self, followup: dict[str, object]) -> None:
+            self.followup = followup
+            self.calls: list[dict[str, object]] = []
+
+        def run_conversation(self, **kwargs: object) -> dict[str, object]:
+            self.calls.append(kwargs)
+            return self.followup
+
+    initial_result = {
+        "final_response": "",
+        "messages": [
+            {
+                "role": "assistant",
+                "tool_calls": [{"function": {"name": "read_file", "arguments": "{}"}}],
+            }
+        ],
+    }
+    followup = {
+        "final_response": json.dumps(payload),
+        "messages": [{"role": "assistant", "content": json.dumps(payload)}],
+    }
+    agent = FakeAgent(followup)
+
+    parse_agent_output(
+        agent,
+        initial_result,
+        output_path=output_path,
+        schema=_critique_schema(),
+        step="critique",
+        project_dir=project_dir,
+        plan_dir=plan_dir,
+        run_kwargs=_streaming_run_kwargs("fireworks:foo", 8192),
+    )
+
+    assert len(agent.calls) == 1
+    assert agent.calls[0].get("stream_callback") is _no_op_stream

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -1,0 +1,514 @@
+"""Tests for the project_dir tool sandbox.
+
+The sandbox enforces — at the *tool layer* — that an LLM running in a hermes
+worker cannot exec or write outside the worktree it was given via
+``state["config"]["project_dir"]``.  This is the root-cause guard for the
+phase-6 bakeoff regression where a model resolved a conflicting
+``Project: ...`` line in user-authored idea text by writing into the main
+repo instead of its assigned worktree.
+
+These tests exercise the sandbox without hitting any model:
+
+  * ``validate_terminal_command`` strips a leading ``cd <project>/...`` and
+    refuses ``cd`` to anything outside the worktree.
+  * ``validate_write_path`` resolves to inside ``project_dir`` or raises.
+  * ``install_sandbox`` wraps the tool registry handlers so the same
+    refusal/coercion happens when a tool dispatch comes through the agent.
+
+The mock-registry pattern mirrors the live ``tools.registry`` singleton —
+each tool has a ``handler`` attribute the wrapper swaps in place.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from megaplan.sandbox import (
+    SandboxViolation,
+    install_sandbox,
+    validate_terminal_command,
+    validate_v4a_patch,
+    validate_write_path,
+)
+
+
+# ---------------------------------------------------------------------------
+# validate_terminal_command
+# ---------------------------------------------------------------------------
+
+
+def test_terminal_command_without_cd_passes_through(tmp_path: Path) -> None:
+    cmd = "pytest tests/ -x"
+    assert validate_terminal_command(cmd, tmp_path) == cmd
+
+
+def test_terminal_command_strips_leading_cd_to_project_dir(tmp_path: Path) -> None:
+    """A leading ``cd <project_dir> &&`` is redundant once cwd is pinned —
+    the sandbox strips it so the rest of the command runs at the right cwd."""
+    cmd = f"cd {tmp_path} && ls -la"
+    assert validate_terminal_command(cmd, tmp_path) == "ls -la"
+
+
+def test_terminal_command_keeps_cd_to_subdir(tmp_path: Path) -> None:
+    """A ``cd <project_dir>/subdir`` is legitimate scoping — the sandbox
+    rewrites it to a relative cd so it works regardless of starting cwd."""
+    sub = tmp_path / "src"
+    sub.mkdir()
+    cmd = f"cd {sub} && pytest"
+    assert validate_terminal_command(cmd, tmp_path) == "cd src && pytest"
+
+
+def test_terminal_command_refuses_cd_outside_project_dir(tmp_path: Path) -> None:
+    """The bakeoff regression: model prefixes commands with ``cd <other_repo>``.
+    The sandbox MUST refuse, not silently ignore."""
+    other = tmp_path.parent / "some-other-repo"
+    other.mkdir(exist_ok=True)
+    project = tmp_path / "worktree"
+    project.mkdir()
+    cmd = f"cd {other} && touch f.txt"
+    with pytest.raises(SandboxViolation, match="outside the project directory"):
+        validate_terminal_command(cmd, project)
+
+
+def test_terminal_command_refuses_cd_with_traversal(tmp_path: Path) -> None:
+    project = tmp_path / "worktree"
+    project.mkdir()
+    cmd = f"cd {project}/../escape && rm -rf ."
+    with pytest.raises(SandboxViolation):
+        validate_terminal_command(cmd, project)
+
+
+def test_terminal_command_refuses_quoted_escape(tmp_path: Path) -> None:
+    project = tmp_path / "worktree"
+    project.mkdir()
+    other = tmp_path / "elsewhere"
+    other.mkdir()
+    cmd = f'cd "{other}" && echo hi'
+    with pytest.raises(SandboxViolation):
+        validate_terminal_command(cmd, project)
+
+
+# ---------------------------------------------------------------------------
+# validate_write_path
+# ---------------------------------------------------------------------------
+
+
+def test_write_path_relative_resolves_under_project(tmp_path: Path) -> None:
+    safe = validate_write_path("src/foo.py", tmp_path)
+    assert Path(safe) == (tmp_path / "src/foo.py").resolve()
+
+
+def test_write_path_absolute_inside_project_passes(tmp_path: Path) -> None:
+    target = tmp_path / "a/b.py"
+    safe = validate_write_path(str(target), tmp_path)
+    assert Path(safe) == target.resolve()
+
+
+def test_write_path_absolute_outside_project_refused(tmp_path: Path) -> None:
+    project = tmp_path / "worktree"
+    project.mkdir()
+    other = tmp_path / "elsewhere/file.py"
+    with pytest.raises(SandboxViolation, match="outside the project directory"):
+        validate_write_path(str(other), project)
+
+
+def test_write_path_traversal_refused(tmp_path: Path) -> None:
+    project = tmp_path / "worktree"
+    project.mkdir()
+    with pytest.raises(SandboxViolation):
+        validate_write_path("../../etc/passwd", project)
+
+
+def test_write_path_empty_refused(tmp_path: Path) -> None:
+    with pytest.raises(SandboxViolation):
+        validate_write_path("", tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# validate_v4a_patch
+# ---------------------------------------------------------------------------
+
+
+def test_v4a_patch_inside_project_passes(tmp_path: Path) -> None:
+    patch = (
+        "*** Begin Patch\n"
+        "*** Update File: src/main.py\n"
+        "@@\n"
+        "-old\n"
+        "+new\n"
+        "*** End Patch\n"
+    )
+    validate_v4a_patch(patch, tmp_path)  # no raise
+
+
+def test_v4a_patch_with_absolute_outside_refused(tmp_path: Path) -> None:
+    project = tmp_path / "worktree"
+    project.mkdir()
+    other = tmp_path / "elsewhere"
+    other.mkdir()
+    patch = (
+        "*** Begin Patch\n"
+        f"*** Add File: {other}/leak.py\n"
+        "+leaked\n"
+        "*** End Patch\n"
+    )
+    with pytest.raises(SandboxViolation):
+        validate_v4a_patch(patch, project)
+
+
+# ---------------------------------------------------------------------------
+# install_sandbox: end-to-end through a fake registry
+# ---------------------------------------------------------------------------
+
+
+class _FakeEntry:
+    def __init__(self, handler):
+        self.handler = handler
+
+
+class _FakeRegistry:
+    def __init__(self, names):
+        self._tools = {name: _FakeEntry(self._make_handler(name)) for name in names}
+        self.calls: list[tuple[str, dict]] = []
+
+    def _make_handler(self, name):
+        def handler(args, **kw):
+            self.calls.append((name, dict(args) if isinstance(args, dict) else args))
+            return json.dumps({"ok": True, "tool": name, "args": args})
+        return handler
+
+
+@pytest.fixture
+def fake_tools_registry(monkeypatch):
+    """Install a fake ``tools.registry`` module so ``install_sandbox`` wraps it.
+
+    The real registry is part of the vendored agent SDK, which pulls in heavy
+    deps.  The sandbox is decoupled from the SDK by name — it imports
+    ``tools.registry`` lazily — so a stub in sys.modules is enough to test the
+    wrapping behavior without bringing in the SDK.
+    """
+    fake_registry = _FakeRegistry(["terminal", "write_file", "patch", "read_file"])
+    fake_module = types.ModuleType("tools.registry")
+    fake_module.registry = fake_registry
+    fake_tools_pkg = types.ModuleType("tools")
+    monkeypatch.setitem(sys.modules, "tools", fake_tools_pkg)
+    monkeypatch.setitem(sys.modules, "tools.registry", fake_module)
+    return fake_registry
+
+
+def test_install_sandbox_pins_terminal_cwd(tmp_path, monkeypatch, fake_tools_registry):
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+    with install_sandbox(tmp_path):
+        assert os.environ["TERMINAL_CWD"] == str(tmp_path.resolve())
+    assert "TERMINAL_CWD" not in os.environ
+
+
+def test_install_sandbox_restores_prior_terminal_cwd(tmp_path, monkeypatch, fake_tools_registry):
+    monkeypatch.setenv("TERMINAL_CWD", "/some/prior/value")
+    with install_sandbox(tmp_path):
+        assert os.environ["TERMINAL_CWD"] == str(tmp_path.resolve())
+    assert os.environ["TERMINAL_CWD"] == "/some/prior/value"
+
+
+def test_install_sandbox_refuses_terminal_cd_escape(tmp_path, fake_tools_registry):
+    """The smoking-gun scenario: model emits ``cd /escape/path && touch f.txt``
+    with project_dir set to the worktree.  The sandbox MUST refuse — the
+    tool layer does not silently let writes land in the wrong tree."""
+    project = tmp_path / "worktree"
+    project.mkdir()
+    escape = tmp_path / "main-repo"
+    escape.mkdir()
+
+    with install_sandbox(project):
+        terminal_handler = fake_tools_registry._tools["terminal"].handler
+        result = terminal_handler({"command": f"cd {escape} && touch f.txt"})
+        # Refusal is a JSON error returned to the model so it can adjust.
+        parsed = json.loads(result)
+        assert "error" in parsed
+        assert "outside the project directory" in parsed["error"]
+
+    # The unwrapped handler was never called — refusal is hard, not silent.
+    assert fake_tools_registry.calls == []
+
+
+def test_install_sandbox_strips_leading_cd_to_project(tmp_path, fake_tools_registry):
+    project = tmp_path / "worktree"
+    project.mkdir()
+
+    with install_sandbox(project):
+        terminal_handler = fake_tools_registry._tools["terminal"].handler
+        terminal_handler({"command": f"cd {project} && ls"})
+
+    # The redundant cd was stripped — the underlying handler saw just `ls`.
+    assert len(fake_tools_registry.calls) == 1
+    name, args = fake_tools_registry.calls[0]
+    assert name == "terminal"
+    assert args["command"] == "ls"
+
+
+def test_install_sandbox_refuses_write_outside_project(tmp_path, fake_tools_registry):
+    project = tmp_path / "worktree"
+    project.mkdir()
+    escape = tmp_path / "main-repo"
+
+    with install_sandbox(project):
+        wf = fake_tools_registry._tools["write_file"].handler
+        result = wf({"path": str(escape / "leaked.py"), "content": "leak"})
+        parsed = json.loads(result)
+        assert "error" in parsed
+        assert "outside the project directory" in parsed["error"]
+
+    assert fake_tools_registry.calls == []
+
+
+def test_install_sandbox_resolves_relative_write_to_project(tmp_path, fake_tools_registry):
+    with install_sandbox(tmp_path):
+        wf = fake_tools_registry._tools["write_file"].handler
+        wf({"path": "src/foo.py", "content": "hi"})
+
+    assert len(fake_tools_registry.calls) == 1
+    name, args = fake_tools_registry.calls[0]
+    assert name == "write_file"
+    # The handler sees a fully resolved absolute path under project_dir.
+    assert args["path"] == str((tmp_path / "src/foo.py").resolve())
+
+
+def test_install_sandbox_refuses_patch_outside_project(tmp_path, fake_tools_registry):
+    project = tmp_path / "worktree"
+    project.mkdir()
+    escape = tmp_path / "main-repo"
+
+    with install_sandbox(project):
+        patch_handler = fake_tools_registry._tools["patch"].handler
+        result = patch_handler({
+            "mode": "replace",
+            "path": str(escape / "f.py"),
+            "old_string": "a",
+            "new_string": "b",
+        })
+        parsed = json.loads(result)
+        assert "error" in parsed
+
+    assert fake_tools_registry.calls == []
+
+
+def test_install_sandbox_refuses_v4a_patch_outside_project(tmp_path, fake_tools_registry):
+    project = tmp_path / "worktree"
+    project.mkdir()
+    escape = tmp_path / "main-repo"
+    escape.mkdir()
+
+    patch_blob = (
+        "*** Begin Patch\n"
+        f"*** Add File: {escape}/leaked.py\n"
+        "+leaked\n"
+        "*** End Patch\n"
+    )
+    with install_sandbox(project):
+        patch_handler = fake_tools_registry._tools["patch"].handler
+        result = patch_handler({"mode": "patch", "patch": patch_blob})
+        parsed = json.loads(result)
+        assert "error" in parsed
+
+    assert fake_tools_registry.calls == []
+
+
+def test_install_sandbox_does_not_lock_down_reads(tmp_path, fake_tools_registry):
+    """Reads outside project_dir are intentionally allowed — the model
+    legitimately needs to read /tmp/<idea>.txt and template files."""
+    other = tmp_path / "elsewhere/idea.txt"
+    other.parent.mkdir()
+    other.write_text("idea content")
+
+    project = tmp_path / "worktree"
+    project.mkdir()
+    with install_sandbox(project):
+        read_handler = fake_tools_registry._tools["read_file"].handler
+        # Should pass through unmodified, no refusal.
+        read_handler({"path": str(other)})
+
+    assert len(fake_tools_registry.calls) == 1
+    assert fake_tools_registry.calls[0][0] == "read_file"
+
+
+def test_install_sandbox_restores_handlers_on_exit(tmp_path, fake_tools_registry):
+    original_terminal = fake_tools_registry._tools["terminal"].handler
+
+    with install_sandbox(tmp_path):
+        wrapped = fake_tools_registry._tools["terminal"].handler
+        assert wrapped is not original_terminal
+
+    assert fake_tools_registry._tools["terminal"].handler is original_terminal
+
+
+def test_install_sandbox_rejects_missing_project_dir(tmp_path):
+    missing = tmp_path / "does-not-exist"
+    with pytest.raises(ValueError, match="does not exist"):
+        with install_sandbox(missing):
+            pass
+
+
+def test_hermes_worker_installs_sandbox_for_execute(monkeypatch, tmp_path, fake_tools_registry):
+    """End-to-end: ``run_hermes_step`` for the execute phase must install the
+    sandbox so the agent's tool calls are bounded to project_dir.
+
+    We mock the agent so no model is invoked.  The test checks that:
+      * ``TERMINAL_CWD`` is set to project_dir while the agent runs, AND
+      * tool registry handlers are wrapped while the agent runs.
+    """
+    from megaplan import hermes_worker as hw
+    from megaplan._core import atomic_write_json, atomic_write_text, schemas_root
+    from megaplan.workers import STEP_SCHEMA_FILENAMES
+
+    project_dir = tmp_path / "worktree"
+    project_dir.mkdir()
+    plan_dir = tmp_path / "plan"
+    plan_dir.mkdir()
+    (project_dir / ".git").mkdir()
+
+    state = {
+        "name": "sandbox-test",
+        "idea": "test",
+        "current_state": "planned",
+        "iteration": 1,
+        "created_at": "2026-05-01T00:00:00Z",
+        "config": {
+            "project_dir": str(project_dir),
+            "auto_approve": False,
+            "robustness": "standard",
+            "mode": "code",
+        },
+        "sessions": {},
+        "plan_versions": [
+            {"version": 1, "file": "plan_v1.md", "hash": "sha256:test", "timestamp": "2026-05-01T00:00:00Z"}
+        ],
+        "history": [],
+        "meta": {
+            "significant_counts": [],
+            "weighted_scores": [],
+            "plan_deltas": [],
+            "recurring_critiques": [],
+            "total_cost_usd": 0.0,
+            "overrides": [],
+            "notes": [],
+        },
+        "last_gate": {},
+    }
+
+    atomic_write_text(plan_dir / "plan_v1.md", "# Plan\n")
+    atomic_write_json(
+        plan_dir / "plan_v1.meta.json",
+        {
+            "version": 1,
+            "timestamp": "2026-05-01T00:00:00Z",
+            "hash": "sha256:test",
+            "success_criteria": [{"criterion": "do x", "priority": "must"}],
+            "questions": [],
+            "assumptions": [],
+        },
+    )
+    atomic_write_json(plan_dir / "faults.json", {"flags": []})
+
+    # Capture sandbox state observed during agent invocation.
+    observed: dict = {}
+
+    class FakeSessionDB:
+        def get_messages_as_conversation(self, *_a, **_kw):
+            return None
+
+    class FakeAIAgent:
+        def __init__(self, **kwargs):
+            self._print_fn = None
+
+        def set_response_format(self, *a, **kw):
+            pass
+
+        def run_conversation(self, **kwargs):
+            # Snapshot env + handler identity at the moment the agent runs.
+            observed["TERMINAL_CWD"] = os.environ.get("TERMINAL_CWD")
+            observed["terminal_handler"] = fake_tools_registry._tools["terminal"].handler
+            # Return a payload the parser will accept.  For execute we
+            # need files_claimed + summary.
+            payload = {
+                "files_claimed": [],
+                "summary": "did nothing",
+                "tasks_completed": [],
+                "tests_run": [],
+                "issues": [],
+                "next_steps": [],
+            }
+            return {
+                "final_response": json.dumps(payload),
+                "messages": [{"role": "assistant", "content": json.dumps(payload)}],
+                "estimated_cost_usd": 0.0,
+            }
+
+    monkeypatch.setitem(sys.modules, "run_agent", types.ModuleType("run_agent"))
+    monkeypatch.setitem(sys.modules, "hermes_state", types.ModuleType("hermes_state"))
+    sys.modules["run_agent"].AIAgent = FakeAIAgent
+    sys.modules["hermes_state"].SessionDB = FakeSessionDB
+
+    # Stub the prompt builder so the test doesn't need the full prompt
+    # machinery.  The prompt content doesn't matter — we're checking the
+    # sandbox installs around the agent invocation.
+    monkeypatch.setattr(hw, "create_hermes_prompt", lambda *a, **kw: "go")
+    monkeypatch.setattr(hw, "validate_payload", lambda step, payload: None)
+    monkeypatch.setattr(hw, "parse_agent_output", lambda agent, result, **kw: (
+        json.loads(result["final_response"]),
+        result["final_response"],
+    ))
+    monkeypatch.setattr(hw, "clean_parsed_payload", lambda *a, **kw: None)
+
+    # Save the original terminal handler so we can confirm it was wrapped
+    # *during* the agent run, then restored after.
+    original_terminal_handler = fake_tools_registry._tools["terminal"].handler
+
+    repo_root = Path(__file__).resolve().parents[1]
+    monkeypatch.setattr(hw, "read_json", lambda p: {} if "schemas" in str(p) else json.loads(Path(p).read_text()))
+    monkeypatch.setattr(hw, "schemas_root", lambda root: repo_root / "megaplan" / "schemas")
+    # Bypass the schema-name lookup — execute schema file may not exist on disk in this minimal setup.
+    monkeypatch.setattr("megaplan.schemas.get_execution_schema_key", lambda *a, **kw: STEP_SCHEMA_FILENAMES.get("execute", "execute_v2.json"))
+
+    monkeypatch.delenv("MEGAPLAN_MOCK", raising=False)
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+
+    hw.run_hermes_step(
+        "execute",
+        state,
+        plan_dir,
+        root=repo_root,
+        fresh=True,
+        model="openrouter/anthropic/claude-opus-4.6",
+    )
+
+    # The sandbox was active while the agent ran:
+    assert observed["TERMINAL_CWD"] == str(project_dir.resolve())
+    assert observed["terminal_handler"] is not original_terminal_handler
+
+    # And restored after:
+    assert os.environ.get("TERMINAL_CWD") is None
+    assert fake_tools_registry._tools["terminal"].handler is original_terminal_handler
+
+
+def test_install_sandbox_refuses_workdir_arg_escape(tmp_path, fake_tools_registry):
+    """The model can also pass an explicit ``workdir`` arg — that path must
+    also stay inside project_dir.  Otherwise a benign-looking ``ls`` with
+    workdir=/escape/repo would still leak."""
+    project = tmp_path / "worktree"
+    project.mkdir()
+    escape = tmp_path / "main-repo"
+    escape.mkdir()
+
+    with install_sandbox(project):
+        terminal_handler = fake_tools_registry._tools["terminal"].handler
+        result = terminal_handler({"command": "ls", "workdir": str(escape)})
+        parsed = json.loads(result)
+        assert "error" in parsed
+
+    assert fake_tools_registry.calls == []

--- a/tests/test_scope_drift_doc_mode.py
+++ b/tests/test_scope_drift_doc_mode.py
@@ -1,0 +1,111 @@
+"""Regression tests for doc-mode scope-drift handling.
+
+Doc-mode plans declare their deliverable via the init-time ``output_path``
+config and per-task evidence is ``sections_written`` rather than
+``files_changed``. The execute scope-drift detector previously consulted
+only ``payload.files_changed``, so the deliverable was always flagged as
+unclaimed. Under robust+ robustness this blocked the finalized -> executed
+transition with no recovery path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import megaplan.execute.core as execute_core
+
+
+@pytest.fixture
+def patched_snapshot(monkeypatch: pytest.MonkeyPatch):
+    """Force a known git status snapshot containing the doc deliverable."""
+
+    def _snapshot(_: Path) -> tuple[dict[str, str], str | None]:
+        return ({"docs/foo.md": "deliverable-hash"}, None)
+
+    monkeypatch.setattr(execute_core, "_capture_git_status_snapshot", _snapshot)
+
+
+@pytest.fixture
+def patched_loc(monkeypatch: pytest.MonkeyPatch):
+    """Pretend ``docs/foo.md`` has 264 LOC, well above the 20 LOC threshold."""
+
+    def _loc(_project_dir: Path, paths: set[str]) -> dict[str, int]:
+        return {path: 264 for path in paths}
+
+    monkeypatch.setattr(execute_core, "collect_loc_by_file", _loc)
+
+
+def _empty_payload() -> dict[str, Any]:
+    return {"files_changed": []}
+
+
+def test_doc_mode_output_path_in_files_claimed(
+    tmp_path: Path,
+    patched_snapshot: None,
+    patched_loc: None,
+) -> None:
+    """When mode == doc, the configured output_path is treated as claimed."""
+
+    state: dict[str, Any] = {
+        "config": {
+            "project_dir": str(tmp_path),
+            "mode": "doc",
+            "output_path": "docs/foo.md",
+        }
+    }
+
+    drift = execute_core._compute_execute_scope_drift(
+        tmp_path,
+        _empty_payload(),
+        state,
+    )
+
+    assert drift.files_added == []
+    assert drift.severity != "high"
+    assert drift.loc_added_outside_claimed == 0
+
+
+def test_code_mode_unchanged_unclaimed_doc_still_flagged(
+    tmp_path: Path,
+    patched_snapshot: None,
+    patched_loc: None,
+) -> None:
+    """Code-mode behavior is unchanged: an unclaimed deliverable is still flagged."""
+
+    state: dict[str, Any] = {
+        "config": {
+            "project_dir": str(tmp_path),
+            "mode": "code",
+            # output_path is irrelevant for code mode and must not be auto-claimed
+            "output_path": "docs/foo.md",
+        }
+    }
+
+    drift = execute_core._compute_execute_scope_drift(
+        tmp_path,
+        _empty_payload(),
+        state,
+    )
+
+    assert drift.files_added == ["docs/foo.md"]
+    assert drift.loc_added_outside_claimed == 264
+    assert drift.severity == "high"
+
+
+def test_compute_scope_drift_without_state_is_safe(
+    tmp_path: Path,
+    patched_snapshot: None,
+    patched_loc: None,
+) -> None:
+    """Backwards compatibility: callers may still omit state."""
+
+    drift = execute_core._compute_execute_scope_drift(
+        tmp_path,
+        _empty_payload(),
+    )
+
+    assert drift.files_added == ["docs/foo.md"]
+    assert drift.severity == "high"


### PR DESCRIPTION
## Summary

Recovered all 5 unmerged production-bug-fix commits from the stale branch \`megaplan/per-milestone-robustness-20260503\` (had 6 unique commits; 1 superseded by main's broader per-milestone feature). The remaining 5 are cherry-picked onto current main with conflict resolutions where needed:

| # | SHA | Subject | Notes |
|---|---|---|---|
| 1 | \`47eabd14\` | Apply per-batch status overlay in progress and prerequisite checks | Clean apply |
| 2 | \`0feb2bc1\` | fix(execute): include doc-mode output_path in files_claimed for scope drift | Clean apply; new \`tests/test_scope_drift_doc_mode.py\` |
| 3 | \`f59f2578\` | tests: cover handle_config use-profile writing all phase keys | Recovered from related stash@{1}; cloud.yaml portion of stash dropped (file removed from main) |
| 4 | \`6ef0d1c5\` | fix(drift): escalate severity when files_missing is non-empty | Clean apply |
| 5 | \`903d9b10\` | tests(execute): update expected summary to include \`[scope_drift=low]\` prefix | Test repair for #4 — the existing test asserted the pre-fix summary; behavior is now correct so the test asserts the now-correct format |
| 6 | \`741f6b94\` | fix(hermes): enforce project_dir sandbox at the tool layer | Resolved hermes_worker.py conflict: kept main's \`sys.stderr = real_stderr\` AND added \`_sandbox_stack.close()\` in the same \`finally:\`. New files: \`megaplan/sandbox.py\` (315 LoC) + \`tests/test_sandbox.py\` (514 LoC, 26 tests, all pass) |
| 7 | \`4ced1808\` | fix(hermes): force streaming for Fireworks calls when max_tokens > 4096 | Resolved two-file conflict: main introduced phase-aware caps (\`65536/32768\` for Qwen repetition mitigation) and the branch parameterised the same line as \`agent_max_tokens\` for streaming-gate control. Resolution feeds main's larger caps **through** \`agent_max_tokens\` so both fixes coexist — Qwen cap holds AND Fireworks streaming auto-engages because \`agent_max_tokens > 4096\`. Same shape in \`parallel_critique.py\`. New \`tests/test_hermes_worker_fireworks_streaming.py\` (412 LoC, 6 tests) updated to assert the new \`32768\` cap. |

## Test plan

- [x] Baseline on main: **3 failed, 1575 passed, 20 skipped** (3 pre-existing failures unrelated to this work):
  - \`tests/test_checks.py::test_validate_critique_checks_rejects_light_mode_stray_checks\`
  - \`tests/test_init_plan.py::test_handle_plan_failure_clears_active_step\`
  - \`tests/test_schemas.py::test_finalize_schema_tracks_structured_execution_fields\`
- [x] After all commits: **3 failed (same 3), 1612 passed, 20 skipped** — zero regressions, +37 new tests pass (sandbox + Fireworks streaming + drift-doc-mode + config use-profile)
- [x] \`megaplan.hermes_worker\` and \`megaplan.sandbox\` import cleanly
- [ ] Reviewer: confirm conflict resolutions for hermes_worker.py + parallel_critique.py read sensibly

## Conflict resolution notes (for reviewer)

### \`hermes_worker.py\` — sandbox enforcement (commit 6)
Main added \`sys.stderr = real_stderr\` in the \`finally:\` block. The cherry-pick added \`_sandbox_stack.close()\`. Both needed; resolution preserves stdout, stderr, AND sandbox close in the same finally.

### \`hermes_worker.py\` + \`parallel_critique.py\` — Fireworks streaming (commit 7)
Main's reasoning: hardcode high \`max_tokens\` (65536/32768) at the AIAgent call site to prevent Qwen repetition loops. Branch's reasoning: hoist \`max_tokens\` to a variable so a downstream streaming gate can check whether the value exceeds Fireworks' 4096 threshold. Resolution: hoist the variable (using main's higher caps as the value) — the streaming gate auto-engages because \`agent_max_tokens > 4096\` regardless of which value is in use. Updated the Fireworks streaming test assertion from \`8192\` to \`32768\` to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)