### PR TITLE
Post-decomp consolidation + hermes availability fix + stash recovery

### DIFF
--- a/megaplan/__init__.py
+++ b/megaplan/__init__.py
@@ -43,7 +43,7 @@ from megaplan.cli import handle_setup, handle_setup_global, handle_config
 from megaplan._core import infer_next_steps, resume_plan, workflow_includes_step, workflow_next
 from megaplan.cli import handle_status, handle_audit, handle_progress, handle_list, main, cli_entry
 
-__version__ = "0.8.1"
+__version__ = "0.21.0"
 
 __all__ = [
     # Types

--- a/megaplan/handlers/review.py
+++ b/megaplan/handlers/review.py
@@ -316,6 +316,126 @@ def _synthesize_review_rework_items(checks: list[dict[str, Any]]) -> list[dict[s
             )
     return rework_items
 
+
+def _finalize_review_outcome(
+    *,
+    root: Path,
+    args: argparse.Namespace,
+    plan_dir: Path,
+    state: PlanState,
+    worker: WorkerResult,
+    agent: str,
+    mode: str,
+    refreshed: bool,
+    robustness: str,
+) -> StepResponse:
+    """Post-worker bookkeeping shared by both review paths.
+
+    The single-worker (claude/codex/mock) and parallel-hermes branches of
+    :func:`handle_review` previously inlined the same ~100-line block of
+    verdict-merging, state advancement, receipt emission, and response
+    construction. This helper is the single owner of that flow.
+    """
+    issues = list(worker.payload.get("issues", []))
+    finalize_data = read_json(plan_dir / "finalize.json")
+
+    review_verdict = worker.payload.get("review_verdict")
+    if review_verdict not in {"approved", "needs_rework"}:
+        issues.append("Invalid review_verdict; expected 'approved' or 'needs_rework'.")
+        review_verdict = "needs_rework"
+
+    verdict_count, total_tasks, check_count, total_checks, missing_evidence = _merge_review_verdicts(
+        worker.payload, finalize_data, issues,
+    )
+    atomic_write_json(plan_dir / "finalize.json", finalize_data)
+    atomic_write_text(plan_dir / "final.md", render_final_md(finalize_data, phase="review"))
+    finalize_hash = sha256_file(plan_dir / "finalize.json")
+
+    result, next_state, next_step = _resolve_review_outcome(
+        plan_dir,
+        review_verdict, verdict_count, total_tasks,
+        check_count, total_checks, missing_evidence,
+        robustness,
+        state, issues,
+        criteria=worker.payload.get("criteria", []),
+    )
+    state["current_state"] = next_state
+
+    clear_active_step(state)
+    apply_session_update(state, "review", agent, worker.session_id, mode=mode, refreshed=refreshed)
+    append_history(
+        state,
+        make_history_entry(
+            "review",
+            duration_ms=worker.duration_ms, cost_usd=worker.cost_usd,
+            result=result,
+            worker=worker, agent=agent, mode=mode,
+            output_file="review.json",
+            prompt_tokens=worker.prompt_tokens,
+            completion_tokens=worker.completion_tokens,
+            total_tokens=worker.total_tokens,
+            artifact_hash=sha256_file(plan_dir / "review.json"),
+            finalize_hash=finalize_hash,
+        ),
+    )
+    try:
+        artifact_hash = sha256_file(plan_dir / "review.json")
+        receipt = build_receipt(
+            phase="review",
+            state=state,
+            plan_dir=plan_dir,
+            args=args,
+            worker=worker,
+            agent=agent,
+            mode=mode,
+            output_file="review.json",
+            artifact_hash=artifact_hash,
+            verdict=review_verdict,
+        )
+        write_receipt(
+            plan_dir,
+            receipt,
+            project_dir=Path(state["config"]["project_dir"]),
+        )
+    except Exception:
+        log.warning("Review receipt emission failed", exc_info=True)
+    save_state_merge_meta(plan_dir, state)
+
+    passed = sum(1 for c in worker.payload.get("criteria", []) if c.get("pass") in (True, "pass"))
+    total = len(worker.payload.get("criteria", []))
+    if result == "blocked":
+        summary = _build_review_blocked_message(
+            verdict_count=verdict_count, total_tasks=total_tasks,
+            check_count=check_count, total_checks=total_checks,
+            missing_reviewer_evidence=missing_evidence,
+        )
+    elif result == "needs_rework":
+        summary = "Review requested another execute pass. Re-run execute using the review findings as context."
+    else:
+        summary = f"Review complete: {passed}/{total} success criteria passed."
+
+    response: StepResponse = {
+        "success": result == "success",
+        "step": "review",
+        "summary": summary,
+        "artifacts": ["review.json", "finalize.json", "final.md"],
+        "monitor_hint": build_monitor_hint(plan_dir),
+        "next_step": next_step,
+        "state": next_state,
+        "issues": issues,
+        "rework_items": list(worker.payload.get("rework_items", [])),
+    }
+    _emit_phase_result(
+        phase="review",
+        state=state,
+        plan_dir=plan_dir,
+        exit_kind="success",
+    )
+    _attach_next_step_runtime(response)
+    attach_agent_fallback(response, args)
+    return response
+
+
 def handle_review(root: Path, args: argparse.Namespace) -> StepResponse:
     with load_plan_locked(root, args.plan, step="review") as (plan_dir, state):
         require_state(state, "review", {STATE_EXECUTED})
@@ -371,104 +491,17 @@ def handle_review(root: Path, args: argparse.Namespace) -> StepResponse:
                     resolved=(agent_type, mode, refreshed, model),
                 )
                 atomic_write_json(plan_dir / "review.json", worker.payload)
-                issues = list(worker.payload.get("issues", []))
-                finalize_data = read_json(plan_dir / "finalize.json")
-
-                review_verdict = worker.payload.get("review_verdict")
-                if review_verdict not in {"approved", "needs_rework"}:
-                    issues.append("Invalid review_verdict; expected 'approved' or 'needs_rework'.")
-                    review_verdict = "needs_rework"
-
-                verdict_count, total_tasks, check_count, total_checks, missing_evidence = _merge_review_verdicts(
-                    worker.payload, finalize_data, issues,
-                )
-                atomic_write_json(plan_dir / "finalize.json", finalize_data)
-                atomic_write_text(plan_dir / "final.md", render_final_md(finalize_data, phase="review"))
-                finalize_hash = sha256_file(plan_dir / "finalize.json")
-
-                result, next_state, next_step = _resolve_review_outcome(
-                    plan_dir,
-                    review_verdict, verdict_count, total_tasks,
-                    check_count, total_checks, missing_evidence,
-                    robustness,
-                    state, issues,
-                    criteria=worker.payload.get("criteria", []),
-                )
-                state["current_state"] = next_state
-
-                clear_active_step(state)
-                apply_session_update(state, "review", agent, worker.session_id, mode=mode, refreshed=refreshed)
-                append_history(
-                    state,
-                    make_history_entry(
-                        "review",
-                        duration_ms=worker.duration_ms, cost_usd=worker.cost_usd,
-                        result=result,
-                        worker=worker, agent=agent, mode=mode,
-                        output_file="review.json",
-                        prompt_tokens=worker.prompt_tokens,
-                        completion_tokens=worker.completion_tokens,
-                        total_tokens=worker.total_tokens,
-                        artifact_hash=sha256_file(plan_dir / "review.json"),
-                        finalize_hash=finalize_hash,
-                    ),
-                )
-                try:
-                    artifact_hash = sha256_file(plan_dir / "review.json")
-                    receipt = build_receipt(
-                        phase="review",
-                        state=state,
-                        plan_dir=plan_dir,
-                        args=args,
-                        worker=worker,
-                        agent=agent,
-                        mode=mode,
-                        output_file="review.json",
-                        artifact_hash=artifact_hash,
-                        verdict=review_verdict,
-                    )
-                    write_receipt(
-                        plan_dir,
-                        receipt,
-                        project_dir=Path(state["config"]["project_dir"]),
-                    )
-                except Exception:
-                    log.warning("Review receipt emission failed", exc_info=True)
-                save_state_merge_meta(plan_dir, state)
-
-                passed = sum(1 for c in worker.payload.get("criteria", []) if c.get("pass") in (True, "pass"))
-                total = len(worker.payload.get("criteria", []))
-                if result == "blocked":
-                    summary = _build_review_blocked_message(
-                        verdict_count=verdict_count, total_tasks=total_tasks,
-                        check_count=check_count, total_checks=total_checks,
-                        missing_reviewer_evidence=missing_evidence,
-                    )
-                elif result == "needs_rework":
-                    summary = "Review requested another execute pass. Re-run execute using the review findings as context."
-                else:
-                    summary = f"Review complete: {passed}/{total} success criteria passed."
-
-                response: StepResponse = {
-                    "success": result == "success",
-                    "step": "review",
-                    "summary": summary,
-                    "artifacts": ["review.json", "finalize.json", "final.md"],
-                    "monitor_hint": build_monitor_hint(plan_dir),
-                    "next_step": next_step,
-                    "state": next_state,
-                    "issues": issues,
-                    "rework_items": list(worker.payload.get("rework_items", [])),
-                }
-                _emit_phase_result(
-                    phase="review",
-                    state=state,
+                return _finalize_review_outcome(
+                    root=root,
+                    args=args,
                     plan_dir=plan_dir,
-                    exit_kind="success",
+                    state=state,
+                    worker=worker,
+                    agent=agent,
+                    mode=mode,
+                    refreshed=refreshed,
+                    robustness=robustness,
                 )
-                _attach_next_step_runtime(response)
-                attach_agent_fallback(response, args)
-                return response
 
             run_id = None
             try:
@@ -528,102 +561,14 @@ def handle_review(root: Path, args: argparse.Namespace) -> StepResponse:
                 save_state_merge_meta(plan_dir, state)
                 raise
 
-        issues = list(worker.payload.get("issues", []))
-        finalize_data = read_json(plan_dir / "finalize.json")
-
-        review_verdict = worker.payload.get("review_verdict")
-        if review_verdict not in {"approved", "needs_rework"}:
-            issues.append("Invalid review_verdict; expected 'approved' or 'needs_rework'.")
-            review_verdict = "needs_rework"
-
-        verdict_count, total_tasks, check_count, total_checks, missing_evidence = _merge_review_verdicts(
-            worker.payload, finalize_data, issues,
-        )
-
-        atomic_write_json(plan_dir / "finalize.json", finalize_data)
-        atomic_write_text(plan_dir / "final.md", render_final_md(finalize_data, phase="review"))
-        finalize_hash = sha256_file(plan_dir / "finalize.json")
-
-        result, next_state, next_step = _resolve_review_outcome(
-            plan_dir,
-            review_verdict, verdict_count, total_tasks,
-            check_count, total_checks, missing_evidence,
-            robustness,
-            state, issues,
-            criteria=worker.payload.get("criteria", []),
-        )
-        state["current_state"] = next_state
-
-        clear_active_step(state)
-        apply_session_update(state, "review", agent, worker.session_id, mode=mode, refreshed=refreshed)
-        append_history(
-            state,
-            make_history_entry(
-                "review",
-                duration_ms=worker.duration_ms, cost_usd=worker.cost_usd,
-                result=result,
-                worker=worker, agent=agent, mode=mode,
-                output_file="review.json",
-                prompt_tokens=worker.prompt_tokens,
-                completion_tokens=worker.completion_tokens,
-                total_tokens=worker.total_tokens,
-                artifact_hash=sha256_file(plan_dir / "review.json"),
-                finalize_hash=finalize_hash,
-            ),
-        )
-        try:
-            artifact_hash = sha256_file(plan_dir / "review.json")
-            receipt = build_receipt(
-                phase="review",
-                state=state,
-                plan_dir=plan_dir,
-                args=args,
-                worker=worker,
-                agent=agent,
-                mode=mode,
-                output_file="review.json",
-                artifact_hash=artifact_hash,
-                verdict=review_verdict,
-            )
-            write_receipt(
-                plan_dir,
-                receipt,
-                project_dir=Path(state["config"]["project_dir"]),
-            )
-        except Exception:
-            log.warning("Review receipt emission failed", exc_info=True)
-        save_state_merge_meta(plan_dir, state)
-
-        passed = sum(1 for c in worker.payload.get("criteria", []) if c.get("pass") in (True, "pass"))
-        total = len(worker.payload.get("criteria", []))
-        if result == "blocked":
-            summary = _build_review_blocked_message(
-                verdict_count=verdict_count, total_tasks=total_tasks,
-                check_count=check_count, total_checks=total_checks,
-                missing_reviewer_evidence=missing_evidence,
-            )
-        elif result == "needs_rework":
-            summary = "Review requested another execute pass. Re-run execute using the review findings as context."
-        else:
-            summary = f"Review complete: {passed}/{total} success criteria passed."
-
-        response: StepResponse = {
-            "success": result == "success",
-            "step": "review",
-            "summary": summary,
-            "artifacts": ["review.json", "finalize.json", "final.md"],
-            "monitor_hint": build_monitor_hint(plan_dir),
-            "next_step": next_step,
-            "state": next_state,
-            "issues": issues,
-            "rework_items": list(worker.payload.get("rework_items", [])),
-        }
-        _emit_phase_result(
-            phase="review",
-            state=state,
+        return _finalize_review_outcome(
+            root=root,
+            args=args,
             plan_dir=plan_dir,
-            exit_kind="success",
+            state=state,
+            worker=worker,
+            agent=agent,
+            mode=mode,
+            refreshed=refreshed,
+            robustness=robustness,
         )
-        _attach_next_step_runtime(response)
-        attach_agent_fallback(response, args)
-        return response

--- a/megaplan/pricing/codex.py
+++ b/megaplan/pricing/codex.py
@@ -9,6 +9,19 @@ Rates are USD per 1M tokens. ``cached`` covers OpenAI's prefix-cache hit price
 (input prefix that the API already saw), which is roughly 90% off the full
 input rate. ``reasoning_output_tokens`` is billed at the same rate as regular
 output, so we add the two before applying the output rate.
+
+## API shape
+
+``cost_from_usage(prompt_tokens, completion_tokens, model, *,
+cached_prompt_tokens=0)`` matches :mod:`megaplan.pricing.claude` and
+:mod:`megaplan.pricing.fireworks`. ``prompt_tokens`` is the full input
+count (including any cached prefix) and ``cached_prompt_tokens`` is the
+portion of that input billed at the cheaper cached rate.
+
+If a caller has the raw codex ``total_token_usage`` dict (with
+``input_tokens`` / ``cached_input_tokens`` / ``output_tokens`` /
+``reasoning_output_tokens``), use :func:`cost_from_codex_usage_dict` to
+extract counts and bill in one call.
 """
 
 from __future__ import annotations
@@ -25,7 +38,46 @@ PRICING: dict[str, dict[str, float]] = {
 DEFAULT_MODEL = "gpt-5.5"
 
 
-def cost_from_usage(usage: dict[str, Any] | None, model: str | None = None) -> float:
+def cost_from_usage(
+    prompt_tokens: int,
+    completion_tokens: int,
+    model: str | None,
+    *,
+    cached_prompt_tokens: int = 0,
+) -> float:
+    """Compute USD cost from a token count + model name.
+
+    ``prompt_tokens`` is the full input token count (including any cached
+    prefix). ``cached_prompt_tokens`` is the portion of that input billed
+    at the cheaper cached rate; if unset, everything in ``prompt_tokens``
+    is billed at the full input rate.
+
+    ``completion_tokens`` should be the sum of regular output and any
+    reasoning-output tokens (both billed at the output rate).
+
+    Unknown ``model`` falls back to :data:`DEFAULT_MODEL`. ``None`` /
+    empty model also falls back. Returns ``0.0`` on parse error.
+    """
+    rates = PRICING.get(model or DEFAULT_MODEL, PRICING[DEFAULT_MODEL])
+    try:
+        prompt = int(prompt_tokens or 0)
+        completion = int(completion_tokens or 0)
+        cached = int(cached_prompt_tokens or 0)
+    except (TypeError, ValueError):
+        return 0.0
+    cached = max(0, min(cached, prompt))  # cached can't exceed prompt total
+    uncached = prompt - cached
+    return (
+        uncached * rates["input"]
+        + cached * rates["cached"]
+        + completion * rates["output"]
+    ) / 1_000_000
+
+
+def cost_from_codex_usage_dict(
+    usage: dict[str, Any] | None,
+    model: str | None = None,
+) -> float:
     """Return the USD cost for a codex ``total_token_usage`` blob.
 
     ``usage`` is the dict under ``info.total_token_usage`` in a codex
@@ -35,24 +87,20 @@ def cost_from_usage(usage: dict[str, Any] | None, model: str | None = None) -> f
          "output_tokens": 1089, "reasoning_output_tokens": 230,
          "total_tokens": 67696}
 
-    Missing keys default to 0. Unknown ``model`` falls back to
-    :data:`DEFAULT_MODEL`. Returns ``0.0`` for ``None`` / empty input.
+    Missing keys default to 0. Returns ``0.0`` for ``None`` / empty input.
     """
     if not isinstance(usage, dict):
         return 0.0
-    rates = PRICING.get(model or DEFAULT_MODEL, PRICING[DEFAULT_MODEL])
     try:
-        input_tokens = int(usage.get("input_tokens", 0) or 0)
-        cached = int(usage.get("cached_input_tokens", 0) or 0)
+        prompt_tokens = int(usage.get("input_tokens", 0) or 0)
+        cached_prompt_tokens = int(usage.get("cached_input_tokens", 0) or 0)
         output_tokens = int(usage.get("output_tokens", 0) or 0)
-        reasoning = int(usage.get("reasoning_output_tokens", 0) or 0)
+        reasoning_tokens = int(usage.get("reasoning_output_tokens", 0) or 0)
     except (TypeError, ValueError):
         return 0.0
-    full_in = max(input_tokens - cached, 0)
-    out = output_tokens + reasoning
-    cost = (
-        full_in * rates["input"]
-        + cached * rates["cached"]
-        + out * rates["output"]
-    ) / 1_000_000
-    return float(cost)
+    return cost_from_usage(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=output_tokens + reasoning_tokens,
+        model=model,
+        cached_prompt_tokens=cached_prompt_tokens,
+    )

--- a/megaplan/prompts/__init__.py
+++ b/megaplan/prompts/__init__.py
@@ -207,37 +207,74 @@ def _resolve_builder(
     return builder
 
 
+# Steps that accept a ``root`` keyword (project root). ``review`` doesn't —
+# it threads extra prompt kwargs (e.g. pre_check_flags) instead.
+_ROOT_BEARING_STEPS = {"prep", "critique", "gate", "finalize", "execute"}
+
+# Maps the agent name used by callers to the (builder_dict, display_label)
+# tuple used internally. Adding a new agent means appending one entry.
+_AGENT_REGISTRY: dict[str, tuple[dict[str, "_PromptBuilder"], str]] = {
+    "claude": (_CLAUDE_PROMPT_BUILDERS, "Claude"),
+    "codex": (_CODEX_PROMPT_BUILDERS, "Codex"),
+    "hermes": (_HERMES_PROMPT_BUILDERS, "Hermes"),
+}
+
+
+def create_prompt(
+    agent: str,
+    step: str,
+    state: PlanState,
+    plan_dir: Path,
+    root: Path | None = None,
+    **prompt_kwargs: object,
+) -> str:
+    """Render the prompt for ``(agent, step)``.
+
+    ``agent`` is one of ``"claude"`` / ``"codex"`` / ``"hermes"``. All
+    three resolve to the same shape:
+
+    * ``step == "review"`` forwards ``prompt_kwargs`` to the builder.
+    * Root-bearing steps forward ``root``.
+    * Everything else calls the builder with just ``(state, plan_dir)``.
+
+    The output always carries the harness-guard prefix.
+
+    Thin per-agent wrappers — ``create_claude_prompt``, ``create_codex_prompt``,
+    ``create_hermes_prompt`` — preserve the historical API used by 80+
+    call sites across the codebase.
+    """
+    try:
+        builders, label = _AGENT_REGISTRY[agent]
+    except KeyError as exc:
+        raise CliError(
+            "unsupported_agent",
+            f"create_prompt: unknown agent {agent!r}; "
+            f"expected one of {sorted(_AGENT_REGISTRY)}",
+        ) from exc
+    builder = _resolve_builder(builders, step, state, label)
+    if step == "review":
+        return _prepend_harness_guard(builder(state, plan_dir, **prompt_kwargs))
+    if step in _ROOT_BEARING_STEPS:
+        return _prepend_harness_guard(builder(state, plan_dir, root=root))
+    return _prepend_harness_guard(builder(state, plan_dir))
+
+
 def create_claude_prompt(
     step: str, state: PlanState, plan_dir: Path, root: Path | None = None, **prompt_kwargs: object
 ) -> str:
-    builder = _resolve_builder(_CLAUDE_PROMPT_BUILDERS, step, state, "Claude")
-    if step == "review":
-        return _prepend_harness_guard(builder(state, plan_dir, **prompt_kwargs))
-    if step in {"prep", "critique", "gate", "finalize", "execute"}:
-        return _prepend_harness_guard(builder(state, plan_dir, root=root))
-    return _prepend_harness_guard(builder(state, plan_dir))
+    return create_prompt("claude", step, state, plan_dir, root=root, **prompt_kwargs)
 
 
 def create_codex_prompt(
     step: str, state: PlanState, plan_dir: Path, root: Path | None = None, **prompt_kwargs: object
 ) -> str:
-    builder = _resolve_builder(_CODEX_PROMPT_BUILDERS, step, state, "Codex")
-    if step == "review":
-        return _prepend_harness_guard(builder(state, plan_dir, **prompt_kwargs))
-    if step in {"prep", "critique", "gate", "finalize", "execute"}:
-        return _prepend_harness_guard(builder(state, plan_dir, root=root))
-    return _prepend_harness_guard(builder(state, plan_dir))
+    return create_prompt("codex", step, state, plan_dir, root=root, **prompt_kwargs)
 
 
 def create_hermes_prompt(
     step: str, state: PlanState, plan_dir: Path, root: Path | None = None, **prompt_kwargs: object
 ) -> str:
-    builder = _resolve_builder(_HERMES_PROMPT_BUILDERS, step, state, "Hermes")
-    if step == "review":
-        return _prepend_harness_guard(builder(state, plan_dir, **prompt_kwargs))
-    if step in {"prep", "critique", "gate", "finalize", "execute"}:
-        return _prepend_harness_guard(builder(state, plan_dir, root=root))
-    return _prepend_harness_guard(builder(state, plan_dir))
+    return create_prompt("hermes", step, state, plan_dir, root=root, **prompt_kwargs)
 
 
 __all__ = [
@@ -289,4 +326,5 @@ __all__ = [
     "create_claude_prompt",
     "create_codex_prompt",
     "create_hermes_prompt",
+    "create_prompt",
 ]

--- a/megaplan/workers/_impl.py
+++ b/megaplan/workers/_impl.py
@@ -804,7 +804,7 @@ def _codex_step_cost(
     model, current_total_usage)``. Any failure to read the JSONL or compute
     the delta returns zeros and a ``None`` usage blob — never raises.
     """
-    from megaplan.pricing.codex import cost_from_usage
+    from megaplan.pricing.codex import cost_from_codex_usage_dict
 
     if not session_id:
         return 0.0, 0, 0, None, None
@@ -833,7 +833,7 @@ def _codex_step_cost(
         "reasoning_output_tokens": _delta("reasoning_output_tokens"),
     }
     model = _read_codex_default_model()
-    cost = cost_from_usage(delta_usage, model)
+    cost = cost_from_codex_usage_dict(delta_usage, model)
     prompt_tokens = delta_usage["input_tokens"]  # already includes cached
     completion_tokens = (
         delta_usage["output_tokens"] + delta_usage["reasoning_output_tokens"]

--- a/megaplan/workers/_impl.py
+++ b/megaplan/workers/_impl.py
@@ -1697,69 +1697,44 @@ def _build_mock_payload(step: str, state: dict[str, Any], plan_dir: Path, **over
     return _deep_merge(builder(state, plan_dir), overrides)
 
 
-def _mock_plan(state: PlanState, plan_dir: Path) -> WorkerResult:
-    return _mock_result(_build_mock_payload("plan", state, plan_dir))
-
-
-def _mock_prep(state: PlanState, plan_dir: Path) -> WorkerResult:
-    return _mock_result(_build_mock_payload("prep", state, plan_dir))
-
-
-def _mock_loop_plan(state: PlanState, plan_dir: Path) -> WorkerResult:
-    return _mock_result(_build_mock_payload("loop_plan", state, plan_dir))
-
-
-
-def _mock_critique(state: PlanState, plan_dir: Path) -> WorkerResult:
-    return _mock_result(_build_mock_payload("critique", state, plan_dir))
-
-
-def _mock_revise(state: PlanState, plan_dir: Path) -> WorkerResult:
-    return _mock_result(_build_mock_payload("revise", state, plan_dir))
-
-
-def _mock_gate(state: PlanState, plan_dir: Path) -> WorkerResult:
-    return _mock_result(_build_mock_payload("gate", state, plan_dir))
-
-
-def _mock_finalize(state: PlanState, plan_dir: Path) -> WorkerResult:
-    return _mock_result(_build_mock_payload("finalize", state, plan_dir))
-
-
-def _mock_execute(state: PlanState, plan_dir: Path, *, prompt_override: str | None = None) -> WorkerResult:
-    target = Path(state["config"]["project_dir"]) / "IMPLEMENTED_BY_MEGAPLAN.txt"
-    target.write_text("mock execution completed\n", encoding="utf-8")
-    return _mock_result(
-        _build_mock_payload("execute", state, plan_dir, prompt_override=prompt_override),
-        trace_output='{"event":"mock-execute"}\n',
-    )
-
-
-def _mock_loop_execute(state: PlanState, plan_dir: Path, *, prompt_override: str | None = None) -> WorkerResult:
-    return _mock_result(
-        _build_mock_payload("loop_execute", state, plan_dir, prompt_override=prompt_override),
-        trace_output='{"event":"mock-loop-execute"}\n',
-    )
-
-
-def _mock_review(state: PlanState, plan_dir: Path) -> WorkerResult:
-    return _mock_result(_build_mock_payload("review", state, plan_dir))
-
-
-_MockHandler = Callable[..., WorkerResult]
-
-_MOCK_DISPATCH: dict[str, _MockHandler] = {
-    "plan": _mock_plan,
-    "prep": _mock_prep,
-    "loop_plan": _mock_loop_plan,
-    "critique": _mock_critique,
-    "revise": _mock_revise,
-    "gate": _mock_gate,
-    "finalize": _mock_finalize,
-    "execute": _mock_execute,
-    "loop_execute": _mock_loop_execute,
-    "review": _mock_review,
+# Steps the mock worker supports, in declaration order. The trace stub
+# only fires for the two execute-shaped steps; everything else gets an
+# empty trace. Update both sets to add a new step.
+_MOCK_SUPPORTED_STEPS: tuple[str, ...] = (
+    "plan", "prep", "loop_plan",
+    "critique", "revise", "gate", "finalize",
+    "execute", "loop_execute", "review",
+)
+_MOCK_TRACE_OUTPUTS: dict[str, str] = {
+    "execute": '{"event":"mock-execute"}\n',
+    "loop_execute": '{"event":"mock-loop-execute"}\n',
 }
+
+
+def _mock_step(
+    step: str,
+    state: PlanState,
+    plan_dir: Path,
+    *,
+    prompt_override: str | None = None,
+) -> WorkerResult:
+    """Build the canonical mock WorkerResult for ``step``.
+
+    ``step == "execute"`` writes the IMPLEMENTED_BY_MEGAPLAN.txt sentinel
+    into the project directory — the only side effect any of the mock
+    handlers performed. Execute-shaped steps thread ``prompt_override``
+    through; the rest ignore it.
+    """
+    if step not in _MOCK_SUPPORTED_STEPS:
+        raise CliError("unsupported_step", f"Mock worker does not support '{step}'")
+    if step == "execute":
+        target = Path(state["config"]["project_dir"]) / "IMPLEMENTED_BY_MEGAPLAN.txt"
+        target.write_text("mock execution completed\n", encoding="utf-8")
+    if step in _EXECUTE_STEPS:
+        payload = _build_mock_payload(step, state, plan_dir, prompt_override=prompt_override)
+    else:
+        payload = _build_mock_payload(step, state, plan_dir)
+    return _mock_result(payload, trace_output=_MOCK_TRACE_OUTPUTS.get(step))
 
 
 def mock_worker_output(
@@ -1771,13 +1746,7 @@ def mock_worker_output(
     prompt_kwargs: dict[str, Any] | None = None,
 ) -> WorkerResult:
     del prompt_kwargs
-    handler = _MOCK_DISPATCH.get(step)
-    if handler is None:
-        raise CliError("unsupported_step", f"Mock worker does not support '{step}'")
-    if step in _EXECUTE_STEPS:
-        result = handler(state, plan_dir, prompt_override=prompt_override)
-    else:
-        result = handler(state, plan_dir)
+    result = _mock_step(step, state, plan_dir, prompt_override=prompt_override)
     try:
         root = _resolve_prompt_root(plan_dir, None)
         side_effect_paths = (

--- a/megaplan/workers/_impl.py
+++ b/megaplan/workers/_impl.py
@@ -2290,7 +2290,21 @@ def run_codex_step(
 def _is_agent_available(agent: str) -> bool:
     """Check if an agent is available (CLI binary or vendored for hermes)."""
     if agent == "hermes":
-        return (Path(__file__).resolve().parent / "agent" / "run_agent.py").is_file()
+        # The legacy filesystem probe pointed at megaplan/workers/agent/, which
+        # has never existed — run_agent.py lives one directory up at
+        # megaplan/agent/. The probe therefore always returned False on every
+        # install, and the downstream "pip install 'megaplan-harness[agent]'"
+        # error message fired even when the agent runtime was fully present.
+        # Importing megaplan.agent triggers the sys.path side effect at
+        # megaplan/agent/__init__.py that makes run_agent / hermes_state
+        # resolvable; we probe both so a partial install also fails closed.
+        try:
+            import megaplan.agent  # noqa: F401
+            from run_agent import AIAgent  # noqa: F401
+            from hermes_state import SessionDB  # noqa: F401
+        except ImportError:
+            return False
+        return True
     if agent in {"claude", "shannon"}:
         from megaplan._core.io import is_shannon_available
         return is_shannon_available()

--- a/megaplan/workers/shannon.py
+++ b/megaplan/workers/shannon.py
@@ -1030,7 +1030,30 @@ def run_shannon_step(
             if isinstance(file_payload, dict) and sentinel_key in file_payload:
                 # Prefer the on-disk file: even when the transcript parsed,
                 # the file is what the agent intended as the canonical artifact.
-                payload = file_payload
+                # BUT: if the on-disk file is still the unpopulated template
+                # (every check has zero findings) and the parsed transcript
+                # payload carries populated findings, prefer the transcript.
+                # Otherwise an agent that returned its JSON in the final
+                # result message instead of editing the file would have its
+                # work silently discarded.
+                def _has_populated_findings(p: Any) -> bool:
+                    if not isinstance(p, dict):
+                        return False
+                    checks = p.get(sentinel_key)
+                    if not isinstance(checks, list) or not checks:
+                        return False
+                    for check in checks:
+                        if not isinstance(check, dict):
+                            continue
+                        findings = check.get("findings")
+                        if isinstance(findings, list) and findings:
+                            return True
+                    return False
+
+                file_has_findings = _has_populated_findings(file_payload)
+                parsed_has_findings = _has_populated_findings(payload)
+                if file_has_findings or not parsed_has_findings:
+                    payload = file_payload
 
     # ── (g) normalize + validate ────────────────────────────────────────
     payload = _normalize_worker_payload(step, payload)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "megaplan-harness"
-version = "0.20.0"
+version = "0.21.0"
 description = "AI agent harness for coordinating Claude and GPT to make and execute extremely robust plans"
 requires-python = ">=3.11"
 license = { text = "OSNL-0.2" }
@@ -35,12 +35,10 @@ agent = [
     "fire",
     "httpx",
     "rich",
-    "tenacity",
     "requests",
     "jinja2",
     "prompt_toolkit",
     "firecrawl-py",
-    "parallel-web>=0.4.2",
     "fal-client",
     "edge-tts",
     "faster-whisper>=1.0.0",
@@ -69,3 +67,4 @@ exclude = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+python_files = ["test_*.py", "editorial_*.py"]

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -2822,6 +2822,7 @@ def test_codex_pricing_table() -> None:
     from megaplan.pricing.codex import (
         DEFAULT_MODEL,
         PRICING,
+        cost_from_codex_usage_dict,
         cost_from_usage,
     )
 
@@ -2837,18 +2838,31 @@ def test_codex_pricing_table() -> None:
         + 4864 * 0.50
         + (1089 + 230) * 30.00
     ) / 1_000_000
-    assert cost_from_usage(usage, "gpt-5.5") == pytest.approx(expected)
+    # Dict-form helper preserves the old API for callers with the raw blob.
+    assert cost_from_codex_usage_dict(usage, "gpt-5.5") == pytest.approx(expected)
     # Unknown model falls back to default rates.
-    assert cost_from_usage(usage, "totally-made-up") == pytest.approx(expected)
+    assert cost_from_codex_usage_dict(usage, "totally-made-up") == pytest.approx(expected)
     # Default model resolves the same way.
     assert DEFAULT_MODEL in PRICING
-    assert cost_from_usage(usage) == pytest.approx(expected)
+    assert cost_from_codex_usage_dict(usage) == pytest.approx(expected)
     # Empty / None usage -> 0.
-    assert cost_from_usage(None) == 0.0
-    assert cost_from_usage({}) == 0.0
+    assert cost_from_codex_usage_dict(None) == 0.0
+    assert cost_from_codex_usage_dict({}) == 0.0
     # gpt-5 cheaper rates apply.
-    cheap = cost_from_usage(usage, "gpt-5")
+    cheap = cost_from_codex_usage_dict(usage, "gpt-5")
     assert 0 < cheap < expected
+
+    # Unified signature matches claude/fireworks shape.
+    via_unified = cost_from_usage(
+        prompt_tokens=66607,
+        completion_tokens=1089 + 230,
+        model="gpt-5.5",
+        cached_prompt_tokens=4864,
+    )
+    assert via_unified == pytest.approx(expected)
+    # Defaults: no cached tokens, unknown model falls back to default rate.
+    assert cost_from_usage(0, 0, None) == 0.0
+    assert cost_from_usage(1_000_000, 0, "gpt-5.5") == pytest.approx(5.0)
 
 
 def test_codex_step_extracts_token_usage_from_session_jsonl(

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -3130,6 +3130,43 @@ def test_is_agent_available_claude_routes_through_shannon_deps() -> None:
         assert _is_agent_available("claude") is False
 
 
+def test_is_agent_available_hermes_when_runtime_importable() -> None:
+    """_is_agent_available('hermes') is True when megaplan.agent + run_agent + hermes_state import.
+
+    Regression for a path-mismatch bug where the legacy filesystem probe
+    pointed at megaplan/workers/agent/run_agent.py — which never existed
+    (run_agent.py lives at megaplan/agent/run_agent.py). The probe therefore
+    always returned False on every install and the downstream phase wrongly
+    raised agent_deps_missing even when the agent runtime was fully present.
+    """
+    from megaplan.workers import _is_agent_available
+
+    # The bundled agent runtime should import cleanly in the megaplan venv.
+    assert _is_agent_available("hermes") is True
+
+
+def test_is_agent_available_hermes_when_runtime_missing() -> None:
+    """_is_agent_available('hermes') is False if the runtime can't be imported.
+
+    Simulates the case where megaplan was installed without the agent runtime
+    (e.g. a slim wheel that excludes megaplan/agent/). Patches the import via
+    sys.modules to force ImportError on run_agent.
+    """
+    import sys
+
+    from megaplan.workers import _is_agent_available
+
+    saved_run_agent = sys.modules.pop("run_agent", None)
+    sys.modules["run_agent"] = None  # type: ignore[assignment]  # sentinel: forces ImportError
+    try:
+        assert _is_agent_available("hermes") is False
+    finally:
+        if saved_run_agent is not None:
+            sys.modules["run_agent"] = saved_run_agent
+        else:
+            sys.modules.pop("run_agent", None)
+
+
 # ---------------------------------------------------------------------------
 # Routing explicitness tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Seven commits landing post-decomp cleanup work, two real bug fixes, and four code-quality refactors recovered from a parked stash. **+41 tests pass on this branch** vs main (38 from newly-discovered editorial_ tests + 3 added pricing test cases); **1 fewer failure** (the shannon readiness probe flake is gone).

## Commits

### Bug fixes
1. **`fix(workers): probe hermes availability via import, not filesystem path`** — the filesystem probe checked `megaplan/workers/agent/run_agent.py` which has never existed (the path is `megaplan/agent/run_agent.py`). `_is_agent_available("hermes")` therefore always returned False, downstream phases raised a misleading "pip install 'megaplan-harness[agent]'" hint even on machines with a fully-present agent runtime. Bug surfaced when a `--profile thoughtful` run wedged at the gate phase. Replaces the filesystem probe with an import-based check + adds regression tests for both present-and-importable and runtime-missing cases.

2. **`fix(shannon): keep transcript findings when on-disk file is empty template`** — `run_shannon_step` preferred the on-disk file whenever both file_payload and a parsed-transcript payload were present. When an agent returned its structured JSON in the final result message *instead of* editing the template file, the still-template file silently overwrote the transcript's findings. Now: prefer the file only when it has findings, or the transcript has none either.

### Refactors (recovered from parked stash)
3. **`refactor(handlers/review): extract _finalize_review_outcome helper`** — `handle_review()` had two inline copies of the same ~100-line post-worker block (one returning early from the single-worker path, one falling through after the parallel-hermes path). Move to a single helper. -55 net lines.

4. **`refactor(workers/_impl): dedupe 10 _mock_<step> handlers into _mock_step`** — ten near-identical functions with a `_MOCK_DISPATCH` dict collapsed into one data-driven `_mock_step()` driven by `_MOCK_SUPPORTED_STEPS` + `_MOCK_TRACE_OUTPUTS`. -31 net lines.

5. **`refactor(pricing/codex): unify cost_from_usage signature with claude/fireworks`** — codex was the odd one out with `cost_from_usage(usage_dict, model)` while claude and fireworks both have `(prompt_tokens, completion_tokens, model, *, cached_*_tokens=0)`. Rename existing to `cost_from_codex_usage_dict()` for the single internal dict caller; rebuild `cost_from_usage()` with the unified shape.

6. **`refactor(prompts): unify create_<agent>_prompt into create_prompt(agent, ...)`** — three identical-body functions (only the builder dict and label differed) collapsed into one `create_prompt(agent, step, ...)` keyed off a new `_AGENT_REGISTRY`. The three per-agent functions remain as one-liner shims so the 80+ existing callers don't churn.

### Housekeeping
7. **`chore: bump 0.21.0, sync __version__, drop unused deps, discover editorial_ tests`**
   - Sync `megaplan/__init__.py:__version__` (was 0.8.1) with `pyproject.toml` (was 0.20.0) — 13 versions of drift. Both now 0.21.0.
   - Drop `tenacity` + `parallel-web` from `[agent]` extras — neither is imported anywhere in megaplan/.
   - Add `python_files = ["test_*.py", "editorial_*.py"]` to pytest config: **10 `editorial_*.py` files with 38 passing test functions were being silently skipped** by default discovery. Now wired in.

## Test plan

- [x] `pytest tests/` → **1955 passed, 5 failed, 23 skipped** in 165s.
- [x] The 5 failures are pre-existing main failures (`test_profile_smoke.py::test_profile_flag_matrix[*]` from commit `3ab996c1 Default DeepSeek profile slots to direct provider` — tests weren't updated when the default changed). **No regressions introduced by this branch.**
- [x] 99 review-related tests pass after the review refactor.
- [x] 159 workers/mock tests pass after the mock dedupe.
- [x] 24 pricing tests pass (claude + codex + fireworks).
- [x] 51 prompts/handler tests pass after the prompt unification.
- [x] 38 editorial tests pass post-discovery.
- [x] `import megaplan` still resolves to the main checkout; `megaplan.__version__ == "0.21.0"`.