### PR TITLE
fix(profiles): lock all-codex so it can't silently degrade to claude

### DIFF
--- a/megaplan/profiles/__init__.py
+++ b/megaplan/profiles/__init__.py
@@ -872,6 +872,43 @@ def _profile_has_premium_slots(profile: dict[str, str]) -> bool:
     return False
 
 
+# Profiles whose name asserts the vendor. If resolution drifts away from the
+# asserted vendor on any non-feedback phase, fail loudly: the resolved
+# phase_model is persisted into state.config and silently invalidates the
+# user's requested profile for the whole sprint.
+#
+# Only `all-codex` is in this list (not `all-claude`) because:
+#   - `all-claude` matches the harness-wide default vendor; when no
+#     `--vendor` is set it resolves to claude anyway, so the name is
+#     accurate even without locking. Locking it would also break the
+#     documented `--vendor codex --profile all-claude` flip.
+#   - `all-codex` is opinionated; without locking, the silent default-vendor
+#     fallback turned `--profile all-codex` into all-claude.
+_NAMED_VENDOR_PROFILES = {"all-codex": "codex"}
+
+
+def _validate_named_profile_invariants(
+    profile_name: str, resolved: dict[str, str]
+) -> None:
+    expected = _NAMED_VENDOR_PROFILES.get(profile_name)
+    if expected is None:
+        return
+    bad: list[str] = []
+    for phase, spec in resolved.items():
+        if phase == "feedback":
+            continue
+        agent, _model = parse_agent_spec(spec)
+        if agent != expected:
+            bad.append(f"{phase}={spec}")
+    if bad:
+        raise CliError(
+            "profile_resolution_mismatch",
+            f"profile={profile_name} expected {expected} on every non-feedback "
+            f"phase but resolved to: {', '.join(bad)}. "
+            f"Mark the profile vendor_locked=true or pass --vendor {expected} explicitly.",
+        )
+
+
 def apply_profile_expansion(
     args: argparse.Namespace,
     project_dir: Path | None,
@@ -976,6 +1013,8 @@ def apply_profile_expansion(
             resolved = apply_depth_rewrite(resolved, effective_depth_flag)
 
         resolved = apply_deepseek_provider_rewrite(resolved, effective_deepseek_provider_flag)
+
+        _validate_named_profile_invariants(profile_name, resolved)
 
         for pm in profile_to_phase_models(resolved):
             if "=" not in pm:

--- a/megaplan/profiles/all-codex.toml
+++ b/megaplan/profiles/all-codex.toml
@@ -1,5 +1,6 @@
 [profiles.all-codex]
 default = "partnered"
+vendor_locked = true
 plan = "codex"
 prep = "codex"
 critique = "codex"

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -748,6 +748,32 @@ def test_vendor_locked_profile_runs_without_flags(
     assert resolved["critique"] == "codex"
 
 
+def test_all_codex_resolves_to_codex_without_vendor_flag(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: `--profile all-codex` with no `--vendor` and no user
+    config must keep codex phases. Without vendor-locking, the silent
+    default-vendor fallback ("claude") rewrote every codex slot, turning
+    `all-codex` into all-claude across an entire sprint.
+    """
+    _isolate_user_config(tmp_path, monkeypatch)
+
+    args = _worker_args(profile="all-codex")
+    args.depth = "medium"
+    apply_profile_expansion(args, None)
+
+    resolved = _phase_models_to_map(args.phase_model)
+    for phase in ("plan", "prep", "critique", "revise", "gate", "finalize",
+                  "execute", "loop_plan", "loop_execute", "review",
+                  "tiebreaker_researcher", "tiebreaker_challenger"):
+        agent = resolved[phase].split(":", 1)[0]
+        assert agent == "codex", (
+            f"{phase} expected codex but got {resolved[phase]!r}"
+        )
+    assert resolved["feedback"] == "claude:low"
+
+
 def _write_medium_claude_profile(tmp_path: Path) -> None:
     """Write an inline claude:medium-author / codex:medium-critic profile
     used by the vendor/critic rewrite tests below."""


### PR DESCRIPTION
## Summary

`all-codex` was acting as a *template* profile, not a vendor invariant. With no `--vendor` flag and no `~/.config/megaplan/config.toml`, `_resolve_default_vendor()` silently returned `"claude"` and `apply_vendor_rewrite()` flipped every codex slot to claude. The resolved phase_model was then persisted into `state.config`, so the override stuck for the rest of the sprint.

Caught in the wild: a sprint launched with `--profile all-codex --depth medium` ran every phase on Claude. State file:

\`\`\`
"profile": "all-codex",
"phase_model": ["plan=claude:medium", "prep=claude", ...]
\`\`\`

Codex investigation: see thread context. Confidence: high. Reproduced via `apply_profile_expansion()` directly.

## Fix

- `megaplan/profiles/all-codex.toml`: `vendor_locked = true`. Per existing vendor-lock semantics, `--depth` still applies; `--vendor`/`--critic` are silently ignored.
- `megaplan/profiles/__init__.py`: `_validate_named_profile_invariants()` hard-fails at init if a named-vendor profile drifts off its asserted vendor. Defense in depth for future profiles.
- `tests/test_profiles.py`: regression test for the bug (`--profile all-codex` with no flags → codex phases).

## Design call: only `all-codex`, not `all-claude`

`all-claude` is intentionally left unlocked because:
- It matches the harness-wide default vendor, so its name is accurate even unlocked.
- The existing test `test_vendor_codex_flips_premium_slots_on_all_claude` documents that `--vendor codex --profile all-claude` is a supported flip path — locking would break it.
- `all-codex` is the opinionated one; without locking, the silent default-vendor fallback inverted its meaning.

If we later decide named profiles should be symmetric assertions (both locked), the validator already covers the path — just add `"all-claude": "claude"` to `_NAMED_VENDOR_PROFILES` and update the four flip-tests.

## Test plan

- [x] New regression test `test_all_codex_resolves_to_codex_without_vendor_flag` passes
- [x] All 59 existing profile tests still pass (`tests/test_profiles.py`)
- [x] Manual repro: `apply_profile_expansion(Namespace(profile='all-codex', depth='medium', ...))` now produces `plan=codex:medium, ..., feedback=claude:low` instead of all-claude
- [x] `--profile all-codex --vendor claude` correctly ignores `--vendor` (locked)
- [x] `--profile all-claude --vendor codex` still flips (unchanged)
- [x] Broader suite: 2146 passed, 23 skipped; 2 pre-existing failures on main unrelated to profiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)