### PR TITLE
feat(critique-evaluator): feed prep dossier + metrics into lens selection

### DIFF
--- a/megaplan/handlers/critique.py
+++ b/megaplan/handlers/critique.py
@@ -88,6 +88,24 @@ def handle_critique(root: Path, args: argparse.Namespace) -> StepResponse:
                 evaluator_model = _rank_input
                 evaluator_resolved = resolved
             _eval_prompt_kwargs: dict[str, Any] | None = None
+            # Prep context — feed the evaluator the prep research record (dossier +
+            # coverage metrics) so it selects lenses knowing what was investigated
+            # and where prep left gaps. Available from iteration 1 onward.
+            _prep_dossier_path = plan_dir / "prep_dossier.md"
+            _prep_metrics_path = plan_dir / "prep_metrics.json"
+            _prep_dossier_text = (
+                _prep_dossier_path.read_text(encoding="utf-8")
+                if _prep_dossier_path.exists()
+                else None
+            )
+            _prep_metrics = (
+                read_json(_prep_metrics_path) if _prep_metrics_path.exists() else None
+            )
+            if _prep_dossier_text or _prep_metrics:
+                _eval_prompt_kwargs = {
+                    "prep_dossier_text": _prep_dossier_text,
+                    "prep_metrics": _prep_metrics,
+                }
             if iteration >= 2:
                 from megaplan.audits.iteration import compute_iteration_pressure as _compute_iteration_pressure
                 from megaplan.prompts.critique import _plan_version_unified_diff
@@ -105,6 +123,7 @@ def handle_critique(root: Path, args: argparse.Namespace) -> StepResponse:
                 ]
                 _diff = _plan_version_unified_diff(plan_dir, iteration)
                 _eval_prompt_kwargs = {
+                    **(_eval_prompt_kwargs or {}),
                     "flag_lifecycle": _registry,
                     "iteration_pressure": _compute_iteration_pressure(plan_dir, state),
                     "gate_signals": build_gate_signals(plan_dir, state, root),

--- a/megaplan/prompts/critique_evaluator.py
+++ b/megaplan/prompts/critique_evaluator.py
@@ -173,6 +173,59 @@ def _format_lens_catalog() -> str:
     return "\n".join(lines)
 
 
+def _render_prep_section(
+    prep_dossier_text: str | None, prep_metrics: dict | None
+) -> str:
+    """Render the "Prep that preceded this plan" section.
+
+    Surfaces the prep dossier plus the decision-relevant coverage signals from
+    ``prep_metrics.json`` (counts, gaps, contradictions) so the evaluator can
+    fire lenses with knowledge of where prep was thorough vs. where it left
+    holes. Returns ``""`` when no prep artifacts are available.
+    """
+    if not prep_dossier_text and not prep_metrics:
+        return ""
+    lines = [
+        "## Prep that preceded this plan",
+        "",
+        "This plan was produced after a multi-step prep phase (triage -> research",
+        "fan-out -> distill). Use the prep record below when deciding which lenses",
+        "to fire: areas prep researched thoroughly may need less scrutiny, while",
+        "areas prep flagged as gaps, contradictions, or timed-out research warrant",
+        "extra attention from the critics.",
+        "",
+    ]
+    if prep_metrics:
+        coverage_bits = [
+            f"{key}={prep_metrics[key]}"
+            for key in (
+                "area_count",
+                "fanout_count",
+                "completed_count",
+                "partial_count",
+                "timed_out_count",
+                "error_count",
+            )
+            if key in prep_metrics
+        ]
+        if coverage_bits:
+            lines.append("**Prep coverage:** " + ", ".join(coverage_bits))
+            lines.append("")
+        gap_notes = prep_metrics.get("gap_notes") or []
+        if gap_notes:
+            lines.append("**Gaps prep could not close:**")
+            lines += [f"- {note}" for note in gap_notes]
+            lines.append("")
+        contradiction_notes = prep_metrics.get("contradiction_notes") or []
+        if contradiction_notes:
+            lines.append("**Contradictions surfaced in research:**")
+            lines += [f"- {note}" for note in contradiction_notes]
+            lines.append("")
+    if prep_dossier_text:
+        lines += ["**Prep dossier:**", "", prep_dossier_text.strip(), ""]
+    return "\n".join(lines) + "\n\n"
+
+
 def _critique_evaluator_prompt(
     state: PlanState,
     plan_dir: Path,
@@ -182,12 +235,18 @@ def _critique_evaluator_prompt(
     gate_signals: dict | None = None,
     revise_resolutions: list[dict[str, Any]] | None = None,
     plan_diff: str | None = None,
+    prep_dossier_text: str | None = None,
+    prep_metrics: dict | None = None,
 ) -> str:
     """Assemble the critique evaluator prompt.
 
     Renders the finished plan + task graph, the intent/issue-hints/notes
     block, the 9-lens catalog, the ranked critic model roster, and the
     fire-by-default / justify-to-skip contract.
+
+    When prep_dossier_text / prep_metrics are supplied, a "Prep that preceded
+    this plan" section is rendered so the evaluator selects lenses with the
+    prep research record in view (gaps and contradictions warrant scrutiny).
 
     When iteration >= 2 and flag_lifecycle / iteration_pressure / gate_signals
     are supplied, a differential context section is prepended that guides
@@ -207,6 +266,8 @@ def _critique_evaluator_prompt(
 
     # Collect all known check ids for the contract
     all_check_ids = [check["id"] for check in CRITIQUE_CHECKS]
+
+    prep_section = _render_prep_section(prep_dossier_text, prep_metrics)
 
     iteration = state.get("iteration", 1)
     differential_section = ""
@@ -304,7 +365,7 @@ def _critique_evaluator_prompt(
 
         {intent_block}
 
-        {differential_section}{verify_section}## Critic Model Roster (rank 1 = strongest)
+        {prep_section}{differential_section}{verify_section}## Critic Model Roster (rank 1 = strongest)
 
         {roster_table}
 

--- a/tests/test_critique_evaluator.py
+++ b/tests/test_critique_evaluator.py
@@ -387,6 +387,49 @@ def test_differential_section_present_only_on_iteration_n(
     assert "race condition" in differential
 
 
+def test_prep_section_present_when_prep_artifacts_supplied(
+    plan_fixture: PlanFixture,
+) -> None:
+    """The evaluator prompt surfaces the prep dossier + coverage signals when
+    prep artifacts are passed, and omits the section when they are not."""
+    from megaplan._core import load_plan
+    from megaplan.prompts.critique_evaluator import _critique_evaluator_prompt
+
+    megaplan.handle_plan(plan_fixture.root, plan_fixture.make_args(plan=plan_fixture.plan_name))
+    _, state = load_plan(plan_fixture.root, plan_fixture.plan_name)
+
+    # Blind — no prep context passed.
+    blind = _critique_evaluator_prompt(state, plan_fixture.plan_dir, root=plan_fixture.root)
+    assert "Prep that preceded this plan" not in blind
+
+    # With prep dossier + metrics, the section renders and decision-relevant
+    # coverage signals (counts, gaps, contradictions) surface.
+    prep_metrics = {
+        "area_count": 4,
+        "fanout_count": 3,
+        "completed_count": 2,
+        "partial_count": 0,
+        "timed_out_count": 1,
+        "error_count": 0,
+        "gap_notes": ["auth token refresh path never researched"],
+        "contradiction_notes": ["two sources disagree on retry semantics"],
+    }
+    prep_dossier = "## Prep dossier\n\nTriaged 4 areas; fanned out 3 research units."
+    with_prep = _critique_evaluator_prompt(
+        state,
+        plan_fixture.plan_dir,
+        root=plan_fixture.root,
+        prep_dossier_text=prep_dossier,
+        prep_metrics=prep_metrics,
+    )
+    assert "Prep that preceded this plan" in with_prep
+    assert "timed_out_count=1" in with_prep
+    assert "auth token refresh path never researched" in with_prep
+    assert "two sources disagree on retry semantics" in with_prep
+    assert "fanned out 3 research units" in with_prep
+    assert with_prep != blind
+
+
 # ---------------------------------------------------------------------------
 # ROBUSTNESS_LEVELS purity
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What
The adaptive critique-evaluator (the optional stage that decides *which* critique lenses to fire) previously selected checks **blind to what prep researched**. This threads the prep record into its prompt.

## How
- `handlers/critique.py`: read `prep_dossier.md` + `prep_metrics.json` from the plan dir and pass them into the evaluator's `prompt_kwargs` — **from iteration 1 onward** (prep context matters most on the first, blind selection). Merges cleanly with the existing iteration≥2 differential kwargs.
- `prompts/critique_evaluator.py`: new `_render_prep_section()` renders a "Prep that preceded this plan" block — coverage counts, `gap_notes`, `contradiction_notes`, and the dossier — so the evaluator scrutinizes areas prep left thin.
- Test: asserts the section + gap/contradiction/coverage signals render when prep is supplied and are absent otherwise.

No state-schema changes; gated behind the existing `adaptive_critique` config knob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)