### PR TITLE
fix(critique): land schema registration + accumulated branch fixes

### DIFF
--- a/megaplan/_core/phase_runtime.py
+++ b/megaplan/_core/phase_runtime.py
@@ -91,6 +91,13 @@ PHASE_RUNTIME_POLICY: dict[str, PhaseRuntimePolicy] = {
         escalation_threshold_seconds=DEFAULT_NON_EXECUTE_TIMEOUT_CAP_SECONDS,
         timeout_cap_seconds=DEFAULT_NON_EXECUTE_TIMEOUT_CAP_SECONDS,
     ),
+    "critique_evaluator": PhaseRuntimePolicy(
+        expected_min_seconds=30,
+        expected_max_seconds=DEFAULT_NON_EXECUTE_TIMEOUT_CAP_SECONDS,
+        recommended_next_check_seconds=60,
+        escalation_threshold_seconds=DEFAULT_NON_EXECUTE_TIMEOUT_CAP_SECONDS,
+        timeout_cap_seconds=DEFAULT_NON_EXECUTE_TIMEOUT_CAP_SECONDS,
+    ),
     "revise": PhaseRuntimePolicy(
         expected_min_seconds=60,
         expected_max_seconds=DEFAULT_NON_EXECUTE_TIMEOUT_CAP_SECONDS,

--- a/megaplan/handlers/critique.py
+++ b/megaplan/handlers/critique.py
@@ -187,6 +187,7 @@ def handle_critique(root: Path, args: argparse.Namespace) -> StepResponse:
             except Exception as exc:
                 fallback_checks = checks_for_robustness(robustness) or checks_for_robustness("standard")
                 active_checks = list(fallback_checks)
+                fallback_check_ids = [c["id"] for c in active_checks]
                 _append_to_meta(state, "critique_evaluator_warnings", {
                     "error": str(exc),
                     "fallback": "static_checks_for_robustness",
@@ -196,8 +197,28 @@ def handle_critique(root: Path, args: argparse.Namespace) -> StepResponse:
                     "evaluator_model": evaluator_model,
                     "fallback": True,
                     "fallback_reason": str(exc),
-                    "static_checks_used": [c["id"] for c in active_checks],
+                    "static_checks_used": fallback_check_ids,
                 })
+                # Loudly surface the downgrade. Until this branch printed to
+                # stderr the adaptive critique could silently degrade to a
+                # static lens list for the entire run with no operator-visible
+                # signal (the warning was written only to state.meta, which is
+                # never read interactively). When this fires the premium
+                # evaluator never ran, so every iteration's critique uses the
+                # same hand-curated robustness checks regardless of plan
+                # content. Treat it as a real config/wiring incident, not a
+                # routine fallback.
+                print(
+                    f"[megaplan] WARNING: critique_evaluator failed ({type(exc).__name__}: {exc}); "
+                    f"adaptive critique is silently downgraded to the static "
+                    f"{robustness!r} lens set ({len(fallback_check_ids)} lenses: "
+                    f"{', '.join(fallback_check_ids)}). The premium evaluator did NOT run "
+                    f"and will NOT run on subsequent iterations of this plan. Investigate "
+                    f"the critique_evaluator wiring (profile slot, schema, prompt) before "
+                    f"trusting this plan's critique output.",
+                    file=sys.stderr,
+                    flush=True,
+                )
             expected_ids = [check["id"] for check in active_checks]
         else:
             active_checks = select_active_checks(state, robustness, plan_dir=plan_dir)

--- a/megaplan/orchestration/prep_research.py
+++ b/megaplan/orchestration/prep_research.py
@@ -128,12 +128,38 @@ def research_sentinel(area: dict[str, Any], status: str, error: str) -> dict[str
 
 
 def _string_list(value: Any, *, field: str) -> list[str]:
+    """Coerce a prep-research field into a list of non-empty strings.
+
+    Models routinely return non-list shapes for fields like `files` and
+    `code_refs` — a single path as a bare string, a dict mapping path→snippet,
+    a comma-separated string. The schema wants list[str], but rejecting any
+    non-list outright wastes the whole research area (the failure mode that
+    bit area-1 helper-shape-enumeration on phase-3-5-block-a-extension-20260525-2048).
+    Coerce where possible:
+      * None / "" → []
+      * list → keep items, str() each, drop empties
+      * dict → take string keys (typically file paths in {path: snippet} maps)
+      * str → split on comma/newline if it looks like a list; otherwise wrap
+      * anything else → str() and wrap (better to keep noisy evidence than reject)
+    """
     if value is None:
         return []
-    if not isinstance(value, list):
-        raise CliError("worker_parse_error", f"Prep research field {field!r} must be a list")
+    if isinstance(value, list):
+        items: list[Any] = value
+    elif isinstance(value, dict):
+        items = [k for k in value.keys() if isinstance(k, str)]
+    elif isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return []
+        if "\n" in stripped or "," in stripped:
+            items = [part.strip() for part in stripped.replace("\n", ",").split(",")]
+        else:
+            items = [stripped]
+    else:
+        items = [str(value)]
     result: list[str] = []
-    for item in value:
+    for item in items:
         text = str(item).strip()
         if text:
             result.append(text)

--- a/megaplan/prompts/planning.py
+++ b/megaplan/prompts/planning.py
@@ -416,6 +416,7 @@ def _prep_triage_prompt(
         - Do not emit final findings, final constraints, or a final suggested approach here.
         - Prefer relation-oriented areas such as caller coverage, root cause trace, contract compatibility, and validation impact.
         - If the existing prep evidence is already sufficient, return zero areas instead of inventing research.
+        - **Production-of-artifact also counts as a research area, even when the question is well-defined.** If the task or user direction explicitly asks prep to *produce* an enumeration, inventory, categorized list, audit report, or similar deliverable artifact that the planner needs as input — treat each requested artifact as its own area, even if there's no uncertainty about what to enumerate or how. "Well-specified" is not the same as "already-done": producing the artifact IS the research. The skip path (`areas: []`) is for cases where the planner can proceed without that artifact, not for cases where it was asked for and the question happens to be clear. When in doubt between "skip because clear" and "include because requested" — include.
 
         Return JSON only.
         """

--- a/megaplan/schemas/runtime.py
+++ b/megaplan/schemas/runtime.py
@@ -940,6 +940,59 @@ def _build_execution_doc_schema() -> dict[str, Any]:
 SCHEMAS["execution_doc.json"] = _build_execution_doc_schema()
 
 
+# Adaptive critique evaluator ("lens picker") output schema. The evaluator
+# inspects the plan/flags/diff and emits a per-lens critic assignment; the
+# critique phase then runs the cheap critic against the chosen lenses. Without
+# this schema entry the step lookup in workers/_impl.py + workers/shannon.py
+# KeyError'd silently and the handler fell back to static lens selection.
+SCHEMAS["critique_evaluator.json"] = {
+    "type": "object",
+    "properties": {
+        "selections": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "check_id": {"type": "string"},
+                    "critic_model": {"type": "string"},
+                    "why": {"type": "string"},
+                },
+                "required": ["check_id", "critic_model", "why"],
+            },
+        },
+        "skipped": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "check_id": {"type": "string"},
+                    "why": {"type": "string"},
+                },
+                "required": ["check_id", "why"],
+            },
+        },
+        "evaluator_model": {"type": "string"},
+        "flag_verifications": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "flag_id": {"type": "string"},
+                    "lens": {"type": "string"},
+                    "outcome": {
+                        "type": "string",
+                        "enum": ["verified", "open", "accepted_tradeoff"],
+                    },
+                    "rationale": {"type": "string"},
+                },
+                "required": ["flag_id", "lens", "outcome", "rationale"],
+            },
+        },
+    },
+    "required": ["selections", "skipped", "evaluator_model"],
+}
+
+
 def get_execution_schema_key(mode: str, form: str | None = None) -> str:
     if mode == "creative" and form:
         from megaplan.forms import get_form

--- a/megaplan/workers/_impl.py
+++ b/megaplan/workers/_impl.py
@@ -73,6 +73,7 @@ STEP_SCHEMA_FILENAMES: dict[str, str] = {
     "prep-distill": "prep.json",
     "revise": "revise.json",
     "critique": "critique.json",
+    "critique_evaluator": "critique_evaluator.json",
     "feedback": "feedback.json",
     "gate": "gate.json",
     "finalize": "finalize.json",

--- a/megaplan/workers/hermes.py
+++ b/megaplan/workers/hermes.py
@@ -318,10 +318,21 @@ def _provider_requires_streaming(model: str | None, max_tokens: int | None) -> b
 
 
 def _streaming_run_kwargs(model: str | None, max_tokens: int | None, *, plan_dir: Path | None = None) -> dict:
-    """Build the run_conversation kwargs needed to force streaming when required."""
+    """Build the run_conversation kwargs needed to force streaming when required.
+
+    Returns only valid run_conversation kwargs — when streaming is forced,
+    that's `stream_callback`. The callback IS a _StreamTracker; consumers that
+    need the tracker for additional wiring (e.g. reasoning_callback in
+    _run_attempt below) should read it back from the `stream_callback` key,
+    NOT from a side-channel like `_megaplan_stream_tracker`. The previous
+    contract returned both keys pointing at the same tracker, which broke
+    forwarders (orchestration/prep_research.py:689,
+    orchestration/parallel_critique.py:101, workers/hermes.py:_parse_hermes_result)
+    that passed run_kwargs straight into run_conversation — those forwarders
+    saw a kwarg the method doesn't accept and crashed with TypeError.
+    """
     if _provider_requires_streaming(model, max_tokens):
-        tracker = _StreamTracker()
-        return {"stream_callback": tracker, "_megaplan_stream_tracker": tracker}
+        return {"stream_callback": _StreamTracker()}
     return {}
 
 
@@ -506,16 +517,7 @@ def parse_agent_output(
     calls (template / summary fallbacks) so providers that require streaming
     (e.g. Fireworks at high max_tokens) keep streaming on those calls too.
     """
-    # _megaplan_stream_tracker is internal bookkeeping handled at the dispatch
-    # site (see line ~904) and isn't a valid run_conversation kwarg — strip it
-    # before forwarding into agent.run_conversation() below. Without this, the
-    # template / summary fallback paths in this function (lines ~524, ~613)
-    # raise `TypeError: AIAgent.run_conversation() got an unexpected keyword
-    # argument '_megaplan_stream_tracker'` whenever streaming is forced.
-    extra_run_kwargs = {
-        k: v for k, v in (run_kwargs or {}).items()
-        if k != "_megaplan_stream_tracker"
-    }
+    extra_run_kwargs = run_kwargs or {}
     raw_output = result.get("final_response", "") or ""
     messages = result.get("messages", [])
 
@@ -910,8 +912,8 @@ def run_hermes_step(
         # same shape non-streaming returns, so the rest of megaplan is
         # unchanged.
         run_kwargs = _streaming_run_kwargs(current_model or model, agent_max_tokens, plan_dir=plan_dir)
-        tracker = run_kwargs.pop("_megaplan_stream_tracker", None)
-        is_streaming = tracker is not None
+        tracker = run_kwargs.get("stream_callback")
+        is_streaming = isinstance(tracker, _StreamTracker)
 
         # Wire the reasoning_callback to the tracker so reasoning_emitted_so_far
         # advances on every reasoning_content delta. Without this, a reasoning

--- a/megaplan/workers/hermes.py
+++ b/megaplan/workers/hermes.py
@@ -506,7 +506,16 @@ def parse_agent_output(
     calls (template / summary fallbacks) so providers that require streaming
     (e.g. Fireworks at high max_tokens) keep streaming on those calls too.
     """
-    extra_run_kwargs = run_kwargs or {}
+    # _megaplan_stream_tracker is internal bookkeeping handled at the dispatch
+    # site (see line ~904) and isn't a valid run_conversation kwarg — strip it
+    # before forwarding into agent.run_conversation() below. Without this, the
+    # template / summary fallback paths in this function (lines ~524, ~613)
+    # raise `TypeError: AIAgent.run_conversation() got an unexpected keyword
+    # argument '_megaplan_stream_tracker'` whenever streaming is forced.
+    extra_run_kwargs = {
+        k: v for k, v in (run_kwargs or {}).items()
+        if k != "_megaplan_stream_tracker"
+    }
     raw_output = result.get("final_response", "") or ""
     messages = result.get("messages", [])
 

--- a/tests/test_critique_evaluator.py
+++ b/tests/test_critique_evaluator.py
@@ -648,3 +648,36 @@ def test_flag_verifications_optional_field_absent_accepted() -> None:
     # No flag_verifications key at all.
     assert "flag_verifications" not in verdict
     validate_evaluator_verdict(verdict, evaluator_model="claude-opus-4-7")
+
+
+# ---------------------------------------------------------------------------
+# Wiring regression: STEP_SCHEMA_FILENAMES must register critique_evaluator
+# ---------------------------------------------------------------------------
+
+
+def test_critique_evaluator_step_registered_in_schema_filenames() -> None:
+    """Regression: silent KeyError('critique_evaluator') in shannon/codex worker.
+
+    Until this entry existed, the adaptive critique path called
+    ``_run_worker("critique_evaluator", ...)`` which dispatched to
+    ``run_step_with_worker`` which then tried
+    ``STEP_SCHEMA_FILENAMES["critique_evaluator"]`` and KeyError'd. The
+    handler caught the KeyError, wrote a ``fallback: true`` evaluator_verdict
+    and downgraded to the static robustness lens list — silently, for every
+    iteration of every plan run under ``partnered`` (and any other profile
+    with ``adaptive_critique = true``).
+    """
+    from megaplan.schemas import SCHEMAS
+    from megaplan.workers._impl import STEP_SCHEMA_FILENAMES, _STEP_REQUIRED_KEYS
+
+    assert "critique_evaluator" in STEP_SCHEMA_FILENAMES, (
+        "critique_evaluator step must have a schema filename or the adaptive "
+        "critique path silently falls back to static lens selection"
+    )
+    schema_filename = STEP_SCHEMA_FILENAMES["critique_evaluator"]
+    assert schema_filename in SCHEMAS, (
+        f"{schema_filename!r} must be a known SCHEMAS entry"
+    )
+    # The required keys must match the validator in audits/critique_evaluator.py
+    required = set(_STEP_REQUIRED_KEYS["critique_evaluator"])
+    assert {"selections", "skipped", "evaluator_model"}.issubset(required)


### PR DESCRIPTION
## Summary

Lands 5 commits from \`feat/batching-planner-visible\` that never reached main. The headline fix is \`critique_evaluator\` step-schema registration, which closes a silent-fallback bug that has been silently degrading every \`partnered\` / \`premium\` / \`apex\` run.

## The bug being fixed (headline)

\`megaplan/handlers/critique.py\` calls \`_run_worker(\"critique_evaluator\", ...)\`. The dispatcher does \`STEP_SCHEMA_FILENAMES[step]\` in \`megaplan/workers/_impl.py\`. There was no \`\"critique_evaluator\"\` key — KeyError. A broad \`except Exception\` swallowed it, wrote \`fallback: true\` to \`evaluator_verdict.json\`, and fell through to static lenses.

Live evidence in \`.megaplan/plans/phase-3-5-block-a-extension-20260525-2048/evaluator_verdict.json\`:

\`\`\`
\"fallback\": true,
\"fallback_reason\": \"'critique_evaluator'\"
\`\`\`

End result: adaptive critique never actually ran on adaptive profiles. Static lenses produced reasonable-looking output so the bug hid in plain sight.

## Commits

| SHA | Subject | Why it's here |
|---|---|---|
| \`0b01f73b\` | prompts: triage recognizes 'produce-artifact' areas | Triage classifier was rejecting valid 'produce-artifact' task areas |
| \`902c679e\` | hermes: strip internal _megaplan_stream_tracker before run_conversation forward | Internal kwarg was leaking into LiteLLM call |
| \`77f7a0da\` | hermes: stop returning _megaplan_stream_tracker as run_conversation kwarg | Companion fix on the return path |
| \`e5a88554\` | prep_research: coerce non-list shapes for files/code_refs instead of rejecting | Prep_research was rejecting valid scalar inputs |
| \`8b8dcd1a\` | **fix(critique): register critique_evaluator step schema + surface fallback loudly** | The headline fix — registers the missing schema and warns loudly when fallback fires |

The headline fix also adds a regression test (\`test_critique_evaluator_step_registered_in_schema_filenames\`) so a future addition of a similar step keeps the schema / required-key wiring intact.

## Test plan

- [x] \`pytest tests/test_critique_evaluator.py tests/test_critique.py tests/test_config.py -x\` — 116 passed locally
- [ ] CI green
- [ ] After merge, the strict CI guard added in PR 2 (\`feat/adaptive-critique-defense\`) will permanently prevent regression

## Notes

- Cherry-picked clean from \`feat/batching-planner-visible\` onto current \`origin/main\`. The top two commits on that branch (\`471d1cc9\`, \`d2c1f8c1\` — the critic_model pin and the vendor-routing fix) were already squash-merged into main as \`3e76e598\` / \`a8fc0d5c\` and are skipped here.
- Follow-up PR 2 (\`feat/adaptive-critique-defense\`) adds a layered defense (narrow excepts, startup validation, CI guard, doctor subcommand, strict mode) so this class of silent-fallback bug cannot recur.