### PR TITLE
feat(critique): layered defense against silent adaptive-critique fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ In subagent mode (the default for Claude Code and Codex) the agent drives the ph
 - **Database mode** — keep state in Supabase Postgres instead of `.megaplan/` for shared state across machines and cloud runs (`pip install 'megaplan-harness[db]'`, then set `MEGAPLAN_ACTOR_ID`).
 - **Observability** — `megaplan status --plan <name>` shows the active step, cost, execute progress, and next-step guidance.
 - **Configuration** — `megaplan config show | set <key> <value> | reset` tunes timeouts, critique concurrency, and per-phase agents.
+- **Adaptive critique defense** — `megaplan doctor --adaptive-critique` probes the adaptive critique wiring; `[execution] strict_adaptive_critique = true` refuses silent fallback to static lenses on production runs. See [docs/critique.md](docs/critique.md).
 
 ## Code health
 

--- a/docs/critique.md
+++ b/docs/critique.md
@@ -1,0 +1,118 @@
+# Adaptive critique — operational guide
+
+This page documents the layered defense added in PR #52 (May 2026) so the
+silent-fallback bug class that hid the original adaptive-critique
+regression cannot recur.
+
+## Background
+
+`partnered` / `premium` / `apex` profiles set `adaptive_critique = true`.
+On every iteration the critique handler asks the *evaluator* (an Opus-tier
+model) which lenses to apply, then farms the lenses out to cheaper critic
+models. The evaluator picks lenses with full knowledge of the plan,
+flag lifecycle, prep dossier, and prior critique results — adaptive,
+plan-shaped critique instead of a static 6-lens sweep.
+
+In May 2026 a missing `critique_evaluator` entry in
+`STEP_SCHEMA_FILENAMES` made every adaptive run KeyError at dispatch. A
+broad `except Exception` in `megaplan/handlers/critique.py` swallowed the
+error, wrote `fallback: true` to `evaluator_verdict.json`, and fell through
+to the same static lens list for every iteration of every plan. Static
+lenses produced reasonable-looking output, so the bug hid in plain sight
+across every adaptive profile.
+
+## Layered defense
+
+PR #52 adds four layers so the same bug class cannot silently disable
+adaptive critique again. Each layer catches the bug at a different stage:
+
+1. **Narrow except at the critique handler.**
+   `megaplan/handlers/critique.py` now only catches `(ValueError,
+   RuntimeError, OSError)` from the evaluator dispatch. Structural errors
+   (`KeyError` on missing step dispatch, `ImportError` on missing module,
+   `AttributeError` on misshapen payload) bubble up and fail the run loudly
+   instead of silently downgrading.
+
+2. **Loud stderr banner on fallback.** When the fallback path *does* fire
+   (legitimate LLM/IO failure), the handler now prints a clear banner to
+   stderr including the failing exception, the static lenses being used,
+   and the recommended diagnostic command (`megaplan doctor
+   --adaptive-critique`). Until PR #52 the only signal was a string buried
+   in `state.meta` that nobody reads interactively.
+
+3. **Startup validation at init.** `megaplan/handlers/init.py` calls
+   `assert_adaptive_critique_wired()` whenever `adaptive_critique`
+   resolves True. The probe checks that `STEP_SCHEMA_FILENAMES`,
+   `SCHEMAS`, the prompt template, and `_STEP_REQUIRED_KEYS` are all wired
+   for `critique_evaluator`. If any layer is broken, init raises
+   `AdaptiveCritiqueMisconfiguredError` *before* planning cost is paid —
+   the operator sees the misconfiguration immediately.
+
+4. **CI guard test.** `tests/test_adaptive_critique_wired.py` parametrizes
+   over every shipped profile with `adaptive_critique = true` and asserts
+   the wiring probe passes for each. A PR that re-introduces the original
+   bug (e.g. removes the `critique_evaluator` entry from
+   `STEP_SCHEMA_FILENAMES`) fails CI before merge.
+
+## Strict mode
+
+`execution.strict_adaptive_critique = true` opts a run into raising
+`AdaptiveCritiqueDegradedError` instead of writing `fallback: true` and
+proceeding with static lenses. Use this for:
+
+- production runs where adaptive critique is load-bearing,
+- CI runs that should fail if the evaluator can't be reached,
+- megaplan chain runs where downstream blocks depend on the adaptive
+  critique signal.
+
+Default is **off** for backward compatibility. The `partnered`,
+`premium`, and `apex` profiles do **not** set strict mode by default —
+turning it on at the profile level would break existing runs that
+sometimes recover from a transient evaluator failure via the static
+fallback. Strict mode is opt-in per run:
+
+```toml
+# ~/.config/megaplan/config.json (or project-level)
+[execution]
+strict_adaptive_critique = true
+```
+
+```bash
+megaplan init --adaptive-critique --strict-adaptive-critique --idea "..."
+```
+
+## The `megaplan doctor --adaptive-critique` subcommand
+
+```bash
+megaplan doctor --adaptive-critique
+```
+
+Probes every layer of the adaptive critique wiring and reports
+`[OK]` / `[FAIL]` per probe. Run it whenever you suspect adaptive
+critique is silently falling back. Exits 0 on healthy, 1 on any
+failure. Read-only — no LLM calls, no plan-dir state.
+
+Example output:
+
+```
+[OK]   critique_evaluator registered in STEP_SCHEMA_FILENAMES  (→ critique_evaluator.json)
+[OK]   critique_evaluator.json registered in SCHEMAS
+[OK]   critique_evaluator prompt template importable
+[OK]   _STEP_REQUIRED_KEYS covers selections/skipped/evaluator_model
+
+adaptive critique wiring is healthy.
+```
+
+## Error classes
+
+Both new errors live in `megaplan/types.py` and extend `RuntimeError`:
+
+- **`AdaptiveCritiqueMisconfiguredError`** — raised at `init` when the
+  wiring probe fails. Carries `missing: list[str]` with the failing
+  probe labels.
+- **`AdaptiveCritiqueDegradedError`** — raised at critique time when
+  `strict_adaptive_critique = true` and a runtime-recoverable failure
+  fires. Carries `reason: str` with the underlying exception text.
+
+Both are caught by the CLI runner's `(OSError, RuntimeError, ValueError)`
+catch tuple and surface as run failures with their messages intact.

--- a/megaplan/audits/critique_evaluator.py
+++ b/megaplan/audits/critique_evaluator.py
@@ -405,3 +405,147 @@ def validate_evaluator_verdict(
                     f"flag_verification {idx}: duplicate flag_id {fid!r}."
                 )
             seen_fv.add(fid)
+
+
+# ---------------------------------------------------------------------------
+# Wiring probes — used by init-time startup validation and `megaplan doctor
+# --adaptive-critique`. Each probe returns a 3-tuple
+# (label, passed, detail) so callers can render either a green/red status
+# line (doctor) or assemble a structured AdaptiveCritiqueMisconfiguredError
+# (init). The probes are deliberately offline + read-only.
+# ---------------------------------------------------------------------------
+
+
+def probe_adaptive_critique_wiring() -> list[tuple[str, bool, str]]:
+    """Probe every load-bearing piece of the adaptive critique path.
+
+    Returns a list of ``(label, passed, detail)`` tuples. ``passed`` is the
+    only authoritative field; ``detail`` is for human surface and may be
+    empty on success. A failing probe means adaptive critique would
+    KeyError or otherwise fall back at runtime — the exact bug class the
+    layered defense is built to prevent.
+
+    Probes:
+
+    1. ``"critique_evaluator"`` is registered in ``STEP_SCHEMA_FILENAMES``.
+    2. The mapped schema filename is in the ``SCHEMAS`` dict.
+    3. The ``critique_evaluator`` prompt template loads (and is callable).
+    4. ``_STEP_REQUIRED_KEYS`` derives sensible keys for the step (the
+       required-keys table is built from the schema; a missing schema
+       silently produces an empty required-keys set).
+    """
+    results: list[tuple[str, bool, str]] = []
+
+    # Probe 1: step → schema filename dispatch
+    try:
+        from megaplan.workers._impl import STEP_SCHEMA_FILENAMES
+    except ImportError as exc:  # pragma: no cover — defensive
+        results.append((
+            "STEP_SCHEMA_FILENAMES importable",
+            False,
+            f"ImportError: {exc}",
+        ))
+        return results
+
+    if "critique_evaluator" not in STEP_SCHEMA_FILENAMES:
+        results.append((
+            "critique_evaluator registered in STEP_SCHEMA_FILENAMES",
+            False,
+            "missing key — adaptive critique will KeyError at dispatch and "
+            "fall back to static lenses",
+        ))
+        return results
+    schema_filename = STEP_SCHEMA_FILENAMES["critique_evaluator"]
+    results.append((
+        "critique_evaluator registered in STEP_SCHEMA_FILENAMES",
+        True,
+        f"→ {schema_filename}",
+    ))
+
+    # Probe 2: schema filename → SCHEMAS dict entry
+    try:
+        from megaplan.schemas import SCHEMAS
+    except ImportError as exc:  # pragma: no cover — defensive
+        results.append((
+            "SCHEMAS importable",
+            False,
+            f"ImportError: {exc}",
+        ))
+        return results
+
+    if schema_filename not in SCHEMAS:
+        results.append((
+            f"{schema_filename} registered in SCHEMAS",
+            False,
+            "schema is dispatched-to but not registered; "
+            "ensure_runtime_layout would not render it to disk",
+        ))
+    else:
+        results.append((
+            f"{schema_filename} registered in SCHEMAS",
+            True,
+            "",
+        ))
+
+    # Probe 3: prompt template
+    try:
+        from megaplan.prompts import create_prompt  # type: ignore
+        from megaplan.prompts.critique_evaluator import _critique_evaluator_prompt
+    except ImportError as exc:
+        results.append((
+            "critique_evaluator prompt template importable",
+            False,
+            f"ImportError: {exc}",
+        ))
+        return results
+    results.append((
+        "critique_evaluator prompt template importable",
+        bool(callable(_critique_evaluator_prompt)),
+        "",
+    ))
+
+    # Probe 4: required-keys table populated
+    try:
+        from megaplan.workers._impl import _STEP_REQUIRED_KEYS
+        required = set(_STEP_REQUIRED_KEYS.get("critique_evaluator", set()))
+    except ImportError as exc:  # pragma: no cover — defensive
+        results.append((
+            "_STEP_REQUIRED_KEYS importable",
+            False,
+            f"ImportError: {exc}",
+        ))
+        return results
+    expected = {"selections", "skipped", "evaluator_model"}
+    missing = expected - required
+    results.append((
+        "_STEP_REQUIRED_KEYS covers selections/skipped/evaluator_model",
+        not missing,
+        "" if not missing else f"missing: {sorted(missing)}",
+    ))
+
+    return results
+
+
+def assert_adaptive_critique_wired() -> None:
+    """Run :func:`probe_adaptive_critique_wiring` and raise
+    :class:`AdaptiveCritiqueMisconfiguredError` if any probe fails.
+
+    Called from ``handlers/init.py`` after ``adaptive_critique`` resolves
+    True so misconfigurations fail at init, not after planning cost.
+    """
+    from megaplan.types import AdaptiveCritiqueMisconfiguredError
+
+    results = probe_adaptive_critique_wiring()
+    failures = [(label, detail) for label, passed, detail in results if not passed]
+    if failures:
+        lines = ["adaptive critique is misconfigured:"]
+        for label, detail in failures:
+            lines.append(f"  - {label}: {detail}")
+        lines.append(
+            "Run `megaplan doctor --adaptive-critique` for a full status, "
+            "or set `[execution] adaptive_critique = false` to disable."
+        )
+        raise AdaptiveCritiqueMisconfiguredError(
+            "\n".join(lines),
+            missing=[label for label, _ in failures],
+        )

--- a/megaplan/cli.py
+++ b/megaplan/cli.py
@@ -3216,6 +3216,17 @@ def build_parser() -> argparse.ArgumentParser:
     init_parser.add_argument("--auto-approve", action="store_true", default=None)
     init_parser.add_argument("--adaptive-critique", action="store_true", default=None)
     init_parser.add_argument(
+        "--strict-adaptive-critique",
+        action="store_true",
+        default=None,
+        help=(
+            "Raise AdaptiveCritiqueDegradedError instead of silently falling back "
+            "to static lenses when the adaptive critique evaluator fails. "
+            "Recommended for production / CI / important runs. "
+            "Has no effect when --adaptive-critique is off."
+        ),
+    )
+    init_parser.add_argument(
         "--critic-model",
         default=None,
         choices=[c for c in CRITIC_MODEL_CHOICES if c],
@@ -4172,11 +4183,21 @@ def build_parser() -> argparse.ArgumentParser:
 
     doctor_parser = subparsers.add_parser(
         "doctor",
-        help="Diagnostic: plan-level or repo-level health checks",
+        help="Diagnostic: plan-level, repo-level, or adaptive-critique health checks",
     )
     doctor_group = doctor_parser.add_mutually_exclusive_group(required=True)
     doctor_group.add_argument("--plan", default=None, help="Plan name to check")
     doctor_group.add_argument("--repo", action="store_true", default=False, help="Check the repo")
+    doctor_group.add_argument(
+        "--adaptive-critique",
+        action="store_true",
+        default=False,
+        help=(
+            "Probe every load-bearing piece of the adaptive critique path "
+            "(step schema, schema dict entry, prompt template, required-keys "
+            "table). Exits non-zero if any probe fails."
+        ),
+    )
 
     record_tag_parser = subparsers.add_parser(
         "record-tag",

--- a/megaplan/handlers/critique.py
+++ b/megaplan/handlers/critique.py
@@ -13,6 +13,7 @@ from megaplan.orchestration.evaluation import build_gate_artifact, build_gate_si
 from megaplan.orchestration.parallel_critique import run_parallel_critique
 from megaplan.profiles import apply_profile_expansion
 from megaplan.types import (
+    AdaptiveCritiqueDegradedError,
     CliError,
     FLAG_BLOCKING_STATUSES,
     PlanState,
@@ -184,7 +185,34 @@ def handle_critique(root: Path, args: argparse.Namespace) -> StepResponse:
                     _verified_flag_ids_set = apply_flag_verifications(plan_dir, _fv_list)
                 # Build check_id->why map for per-lens targeting notes in the critic prompt.
                 _selection_why = {sel["check_id"]: sel.get("why", "") for sel in selections}
-            except Exception as exc:
+            # Narrow except: structural / wiring errors (KeyError on the step
+            # dispatch, ImportError on a missing module, AttributeError on a
+            # misshapen worker payload) MUST bubble — these are bugs, not
+            # runtime conditions, and they should fail the run loudly so the
+            # operator sees them. Swallowing them is exactly how the
+            # original silent-fallback bug hid for every adaptive run.
+            #
+            # Runtime-recoverable exceptions (ValueError from
+            # validate_evaluator_verdict against a well-formed schema,
+            # RuntimeError from a worker/LLM call, OSError from IO) are still
+            # caught here and downgraded to static lenses — those represent
+            # an LLM that produced bad output or a transient infra issue,
+            # not a config/wiring incident.
+            except (ValueError, RuntimeError, OSError) as exc:
+                # Strict mode: refuse the silent downgrade. Raise loudly so
+                # production / CI / important runs cannot quietly lose
+                # adaptive critique to a transient LLM glitch.
+                _strict = bool(state["config"].get("strict_adaptive_critique", False))
+                if _strict:
+                    raise AdaptiveCritiqueDegradedError(
+                        f"adaptive critique evaluator failed under strict mode "
+                        f"({type(exc).__name__}: {exc}); refusing to silently "
+                        f"downgrade to static lenses. Disable strict mode "
+                        f"(execution.strict_adaptive_critique = false) to allow "
+                        f"the fallback, or fix the underlying critique_evaluator "
+                        f"failure.",
+                        reason=str(exc),
+                    ) from exc
                 fallback_checks = checks_for_robustness(robustness) or checks_for_robustness("standard")
                 active_checks = list(fallback_checks)
                 fallback_check_ids = [c["id"] for c in active_checks]
@@ -209,13 +237,13 @@ def handle_critique(root: Path, args: argparse.Namespace) -> StepResponse:
                 # content. Treat it as a real config/wiring incident, not a
                 # routine fallback.
                 print(
-                    f"[megaplan] WARNING: critique_evaluator failed ({type(exc).__name__}: {exc}); "
-                    f"adaptive critique is silently downgraded to the static "
+                    f"[megaplan] ADAPTIVE CRITIQUE FALLBACK: critique_evaluator failed "
+                    f"({type(exc).__name__}: {exc}); falling back to static "
                     f"{robustness!r} lens set ({len(fallback_check_ids)} lenses: "
                     f"{', '.join(fallback_check_ids)}). The premium evaluator did NOT run "
-                    f"and will NOT run on subsequent iterations of this plan. Investigate "
-                    f"the critique_evaluator wiring (profile slot, schema, prompt) before "
-                    f"trusting this plan's critique output.",
+                    f"and will NOT run on subsequent iterations of this plan.\n"
+                    f"[megaplan] This usually indicates a misconfiguration. "
+                    f"Run: megaplan doctor --adaptive-critique",
                     file=sys.stderr,
                     flush=True,
                 )

--- a/megaplan/handlers/init.py
+++ b/megaplan/handlers/init.py
@@ -145,6 +145,16 @@ def _build_state_config(
                 adaptive_critique_value = get_effective("execution", "adaptive_critique")
     adaptive_critique = bool(adaptive_critique_value)
 
+    # Layered defense (May 2026 — see docs/critique.md): when adaptive critique
+    # resolves True, fail fast at init if the runtime wiring is incomplete.
+    # The original silent-fallback bug shipped because the missing schema only
+    # KeyError'd inside the critique handler under a broad except. Probing at
+    # init means a misconfigured profile is rejected before any planning cost.
+    if adaptive_critique:
+        from megaplan.audits.critique_evaluator import assert_adaptive_critique_wired
+
+        assert_adaptive_critique_wired()
+
     # Precedence mirrors adaptive_critique: explicit --critic-model CLI flag >
     # explicit user-config setting > profile-level `critic_model` field > global
     # default (""). When set, the adaptive evaluator still picks lenses, but the
@@ -174,6 +184,18 @@ def _build_state_config(
             strict_notes_arg = get_effective("execution", "strict_notes")
     strict_notes = bool(strict_notes_arg)
 
+    # Strict adaptive critique (PR #52, May 2026): when True AND
+    # adaptive_critique is True, the critique handler raises
+    # AdaptiveCritiqueDegradedError instead of silently falling back to static
+    # lenses on a runtime-recoverable failure. Off by default for backward
+    # compat. Recommended for production / CI / important runs (see
+    # docs/critique.md). Precedence mirrors other execution settings: CLI flag
+    # > explicit user config > global default.
+    strict_adaptive_critique_arg = getattr(args, "strict_adaptive_critique", None)
+    if strict_adaptive_critique_arg is None:
+        strict_adaptive_critique_arg = get_effective("execution", "strict_adaptive_critique")
+    strict_adaptive_critique = bool(strict_adaptive_critique_arg)
+
     max_tasks_per_batch_arg = getattr(args, "max_tasks_per_batch", None)
     if max_tasks_per_batch_arg is not None:
         max_tasks_per_batch = int(max_tasks_per_batch_arg)
@@ -192,6 +214,7 @@ def _build_state_config(
         "project_dir": str(project_dir),
         "auto_approve": auto_approve,
         "adaptive_critique": adaptive_critique,
+        "strict_adaptive_critique": strict_adaptive_critique,
         "critic_model": critic_model,
         "robustness": robustness,
         "mode": mode,

--- a/megaplan/observability/doctor.py
+++ b/megaplan/observability/doctor.py
@@ -640,10 +640,41 @@ def _doctor_repo(project_dir: Path) -> int:
     return 1 if has_error else 0
 
 
+def _doctor_adaptive_critique() -> int:
+    """Probe the adaptive critique wiring. Returns 0 if every probe passes,
+    1 otherwise. Pure read-only — no LLM calls, no plan-dir state.
+    """
+    from megaplan.audits.critique_evaluator import probe_adaptive_critique_wiring
+
+    results = probe_adaptive_critique_wiring()
+    has_failure = False
+    for label, passed, detail in results:
+        marker = "[OK]   " if passed else "[FAIL] "
+        suffix = f"  ({detail})" if detail else ""
+        print(f"{marker}{label}{suffix}", flush=True)
+        if not passed:
+            has_failure = True
+
+    if has_failure:
+        print(
+            "\nadaptive critique would fall back to static lenses at runtime.\n"
+            "  - to fix: investigate the failing probe(s) above\n"
+            "  - to suppress: set `[execution] adaptive_critique = false`\n"
+            "  - to refuse the silent fallback: "
+            "set `[execution] strict_adaptive_critique = true` (raises at run time)",
+            file=sys.stderr,
+            flush=True,
+        )
+        return 1
+    print("\nadaptive critique wiring is healthy.", flush=True)
+    return 0
+
+
 def handle_doctor(root: Path, args: argparse.Namespace) -> int:
     """``megaplan doctor`` entry point; returns exit code."""
     plan_name = getattr(args, "plan", None)
     repo_mode = getattr(args, "repo", False)
+    adaptive_critique_mode = getattr(args, "adaptive_critique", False)
 
     if plan_name:
         from megaplan._core import find_plan_dir
@@ -658,5 +689,8 @@ def handle_doctor(root: Path, args: argparse.Namespace) -> int:
     if repo_mode:
         return _doctor_repo(root)
 
-    print("doctor: specify --plan X or --repo", file=sys.stderr)
+    if adaptive_critique_mode:
+        return _doctor_adaptive_critique()
+
+    print("doctor: specify --plan X, --repo, or --adaptive-critique", file=sys.stderr)
     return 1

--- a/megaplan/types.py
+++ b/megaplan/types.py
@@ -624,6 +624,11 @@ DEFAULTS = {
     "orchestration.mode": "subagent",
     "execution.adaptive_critique": False,
     "execution.critic_model": "",
+    # When True AND adaptive_critique resolves True, the critique handler will
+    # raise AdaptiveCritiqueDegradedError instead of silently downgrading to
+    # static lenses. Default False for backward compatibility. Recommended for
+    # production / CI / important runs. See docs/critique.md.
+    "execution.strict_adaptive_critique": False,
 }
 
 # Valid pin values for execution.critic_model. Mirrors CRITIC_MODEL_ROSTER in
@@ -642,6 +647,7 @@ CRITIC_MODEL_CHOICES = (
 _SETTABLE_BOOL = {
     "execution.auto_approve",
     "execution.adaptive_critique",
+    "execution.strict_adaptive_critique",
     "execution.strict_notes",
 }
 
@@ -680,6 +686,37 @@ class CliError(Exception):
         self.valid_next = valid_next or []
         self.extra = extra or {}
         self.exit_code = exit_code
+
+
+class AdaptiveCritiqueMisconfiguredError(RuntimeError):
+    """Raised at ``init`` when adaptive_critique is requested but the runtime
+    wiring (step schema, schema dict entry, prompt template) is incomplete.
+
+    Fails fast so no execute-time cost is paid before the operator sees the
+    misconfiguration. The layered defense added in PR #52 (May 2026) checks
+    these probes at init so the silent KeyError fallback that hid the
+    original adaptive-critique bug for every ``partnered`` / ``premium`` /
+    ``apex`` run cannot recur.
+    """
+
+    def __init__(self, message: str, *, missing: list[str] | None = None) -> None:
+        super().__init__(message)
+        self.missing = list(missing or [])
+
+
+class AdaptiveCritiqueDegradedError(RuntimeError):
+    """Raised by the critique handler when adaptive critique would silently
+    fall back to static lenses AND ``execution.strict_adaptive_critique`` is
+    True.
+
+    The default (non-strict) behaviour is to log a loud stderr warning and
+    proceed with static lenses. Strict mode is the recommended setting for
+    production / CI / important runs — see docs/critique.md.
+    """
+
+    def __init__(self, message: str, *, reason: str | None = None) -> None:
+        super().__init__(message)
+        self.reason = reason
 
 
 # Re-export runtime exceptions for convenience (SD3).

--- a/tests/test_adaptive_critique_wired.py
+++ b/tests/test_adaptive_critique_wired.py
@@ -1,0 +1,261 @@
+"""CI guard: adaptive critique must stay wired end-to-end on every profile.
+
+Background
+----------
+A regression in May 2026 silently disabled adaptive critique on every
+``partnered`` / ``premium`` / ``apex`` run. The critique handler called
+``_run_worker("critique_evaluator", ...)`` which dispatched through
+``STEP_SCHEMA_FILENAMES[step]`` in ``megaplan/workers/_impl.py``. No
+``critique_evaluator`` key was registered — KeyError. A broad
+``except Exception`` in ``megaplan/handlers/critique.py`` swallowed it, wrote
+``fallback: true`` to ``evaluator_verdict.json``, and fell through to static
+lenses. The plan still shipped because static lenses produce reasonable
+output, but the adaptive design never ran.
+
+These tests fail loudly if the wiring ever regresses — at any of the
+schema-dispatch, schema-registration, prompt-template, or required-keys
+layers. They also assert that every shipped profile with
+``adaptive_critique = true`` passes the in-memory probe, and that the
+``handle_init`` path raises ``AdaptiveCritiqueMisconfiguredError`` if the
+wiring is broken when ``adaptive_critique`` resolves True (so the
+silent-fallback bug class cannot recur even with the swallow-except still
+nominally in place at the critique handler).
+
+These tests are deliberately offline — no LLM calls, no plan dirs, no
+disk schema rendering. They guard the static wiring that the original bug
+broke.
+"""
+
+from __future__ import annotations
+
+import json
+from argparse import Namespace
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import megaplan
+import megaplan.cli as cli_module
+import megaplan._core.io as io_module
+from megaplan.audits.critique_evaluator import (
+    assert_adaptive_critique_wired,
+    probe_adaptive_critique_wiring,
+)
+from megaplan.profiles import load_profile_metadata
+from megaplan.types import AdaptiveCritiqueMisconfiguredError
+
+
+@pytest.fixture
+def isolated_config_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Module-local copy of the fixture in tests/test_config.py — keeps the
+    test self-contained so a future move of test_config.py doesn't break the
+    CI guard."""
+    config_path = tmp_path / ".config" / "megaplan"
+
+    def fake_config_dir(home: Path | None = None) -> Path:
+        del home
+        return config_path
+
+    monkeypatch.setattr(io_module, "config_dir", fake_config_dir)
+    monkeypatch.setattr(cli_module, "config_dir", fake_config_dir)
+    return config_path
+
+
+# ---------------------------------------------------------------------------
+# Probe-level guard
+# ---------------------------------------------------------------------------
+
+
+def test_adaptive_critique_wiring_probe_passes_on_clean_install() -> None:
+    """Every wiring probe must pass on a clean checkout. This is the CI guard
+    that would have caught the original May 2026 KeyError bug.
+
+    If this fails: adaptive critique is silently disabled at runtime. Look at
+    the failing probe to see which layer regressed (step dispatch, schema
+    dict, prompt template, or required-keys table).
+    """
+    results = probe_adaptive_critique_wiring()
+    failures = [(label, detail) for label, passed, detail in results if not passed]
+    assert not failures, (
+        "adaptive critique wiring regression — these probes failed:\n"
+        + "\n".join(f"  - {label}: {detail}" for label, detail in failures)
+    )
+
+
+def test_assert_adaptive_critique_wired_is_a_noop_on_clean_install() -> None:
+    """The init-time gate must not raise on a healthy tree."""
+    assert_adaptive_critique_wired()  # must not raise
+
+
+def test_assert_adaptive_critique_wired_raises_when_step_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The init-time gate must raise AdaptiveCritiqueMisconfiguredError when
+    the ``critique_evaluator`` step is unregistered. Simulates the original
+    bug by popping the registration.
+
+    This test is the load-bearing one — if the original silent-fallback bug
+    recurs (someone removes the schema/dispatch entry), this test fires
+    immediately at PR time.
+    """
+    from megaplan.workers import _impl as worker_impl
+
+    patched = dict(worker_impl.STEP_SCHEMA_FILENAMES)
+    patched.pop("critique_evaluator", None)
+    monkeypatch.setattr(worker_impl, "STEP_SCHEMA_FILENAMES", patched)
+
+    with pytest.raises(AdaptiveCritiqueMisconfiguredError) as exc_info:
+        assert_adaptive_critique_wired()
+
+    assert "critique_evaluator" in str(exc_info.value)
+    assert "missing" in str(exc_info.value).lower() or "STEP_SCHEMA_FILENAMES" in str(exc_info.value)
+
+
+def test_assert_adaptive_critique_wired_raises_when_schema_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The gate must raise when the dispatch points at a schema filename that
+    isn't in the SCHEMAS dict. This catches the half-fixed case where someone
+    registers the step but forgets the schema entry."""
+    from megaplan import schemas as schemas_module
+
+    patched = dict(schemas_module.SCHEMAS)
+    patched.pop("critique_evaluator.json", None)
+    monkeypatch.setattr(schemas_module, "SCHEMAS", patched)
+
+    with pytest.raises(AdaptiveCritiqueMisconfiguredError) as exc_info:
+        assert_adaptive_critique_wired()
+
+    assert "critique_evaluator.json" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Profile-level guard: every shipped profile with adaptive_critique=true
+# ---------------------------------------------------------------------------
+
+
+def _adaptive_critique_profiles() -> list[str]:
+    """All built-in profiles that ship with adaptive_critique = true."""
+    metadata = load_profile_metadata()
+    return sorted(
+        name
+        for name, meta in metadata.items()
+        if meta.get("adaptive_critique") is True
+    )
+
+
+@pytest.mark.parametrize("profile_name", _adaptive_critique_profiles())
+def test_profile_with_adaptive_critique_passes_wiring_probe(profile_name: str) -> None:
+    """For every shipped profile that turns adaptive critique on by default,
+    the wiring must pass the probe. If a profile sets adaptive_critique=true
+    but the runtime cannot dispatch the step, every plan run on that profile
+    would silently degrade to static lenses.
+
+    Parametrized over the profile set so a newly-added adaptive profile is
+    automatically guarded.
+    """
+    results = probe_adaptive_critique_wiring()
+    failures = [(label, detail) for label, passed, detail in results if not passed]
+    assert not failures, (
+        f"profile {profile_name!r} sets adaptive_critique=true but the "
+        f"runtime wiring is broken:\n"
+        + "\n".join(f"  - {label}: {detail}" for label, detail in failures)
+    )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: handle_init refuses to seed adaptive critique on a broken tree
+# ---------------------------------------------------------------------------
+
+
+def _make_init_namespace(project_dir: Path, *, profile: str = "partnered") -> Namespace:
+    return Namespace(
+        project_dir=str(project_dir),
+        name="adaptive-wired-guard",
+        auto_approve=None,
+        robustness=None,
+        hermes=None,
+        phase_model=[],
+        idea="idea",
+        profile=profile,
+        adaptive_critique=True,
+        strict_adaptive_critique=None,
+        critic_model=None,
+        strict_notes=None,
+        max_tasks_per_batch=None,
+    )
+
+
+def test_handle_init_refuses_adaptive_critique_when_wiring_broken(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``handle_init`` must reject a request to enable adaptive critique when
+    the runtime wiring is broken. This is the layered defense against the
+    original silent-fallback bug: even with the swallow-except left at the
+    critique handler, no plan would survive ``init`` long enough to hit it
+    because init rejects misconfigured runs fast.
+
+    Without the init-time gate, the bug surfaces only at critique time —
+    after planning cost has been paid and after the plan looks committed.
+    """
+    from megaplan.workers import _impl as worker_impl
+
+    patched = dict(worker_impl.STEP_SCHEMA_FILENAMES)
+    patched.pop("critique_evaluator", None)
+    monkeypatch.setattr(worker_impl, "STEP_SCHEMA_FILENAMES", patched)
+
+    root = tmp_path / "root"
+    project_dir = tmp_path / "project"
+    root.mkdir()
+    project_dir.mkdir()
+
+    with pytest.raises(AdaptiveCritiqueMisconfiguredError):
+        megaplan.handle_init(root, _make_init_namespace(project_dir))
+
+
+def test_handle_init_succeeds_when_wiring_healthy(
+    isolated_config_dir: Path, tmp_path: Path
+) -> None:
+    """The init-time gate is a no-op on a healthy tree. Confirms the gate
+    doesn't introduce a false-positive regression for clean checkouts."""
+    isolated_config_dir.mkdir(parents=True, exist_ok=True)
+    (isolated_config_dir / "config.json").write_text(
+        json.dumps({"execution": {}}), encoding="utf-8"
+    )
+
+    root = tmp_path / "root"
+    project_dir = tmp_path / "project"
+    root.mkdir()
+    project_dir.mkdir()
+
+    response = megaplan.handle_init(root, _make_init_namespace(project_dir))
+    state_path = root / ".megaplan" / "plans" / response["plan"] / "state.json"
+    state: dict[str, Any] = json.loads(state_path.read_text(encoding="utf-8"))
+    assert state["config"]["adaptive_critique"] is True
+    # The strict-mode field also flows through (default False).
+    assert state["config"]["strict_adaptive_critique"] is False
+
+
+def test_handle_init_threads_strict_adaptive_critique_when_explicit(
+    isolated_config_dir: Path, tmp_path: Path
+) -> None:
+    """``--strict-adaptive-critique`` (or
+    ``[execution] strict_adaptive_critique = true``) must flow through to
+    ``state['config']['strict_adaptive_critique']`` so the critique handler
+    can refuse the silent fallback."""
+    isolated_config_dir.mkdir(parents=True, exist_ok=True)
+    (isolated_config_dir / "config.json").write_text(
+        json.dumps({"execution": {"strict_adaptive_critique": True}}),
+        encoding="utf-8",
+    )
+
+    root = tmp_path / "root"
+    project_dir = tmp_path / "project"
+    root.mkdir()
+    project_dir.mkdir()
+
+    response = megaplan.handle_init(root, _make_init_namespace(project_dir))
+    state_path = root / ".megaplan" / "plans" / response["plan"] / "state.json"
+    state: dict[str, Any] = json.loads(state_path.read_text(encoding="utf-8"))
+    assert state["config"]["strict_adaptive_critique"] is True

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -1113,6 +1113,7 @@ def test_execute_succeeds_with_user_approval(plan_fixture: PlanFixture) -> None:
 def test_execute_succeeds_in_auto_approve_mode(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     root = tmp_path / "root"
     project_dir = tmp_path / "project"
+    config_path = tmp_path / "config"
     root.mkdir()
     project_dir.mkdir()
     (project_dir / ".git").mkdir()
@@ -1122,6 +1123,20 @@ def test_execute_succeeds_in_auto_approve_mode(tmp_path: Path, monkeypatch: pyte
         "which",
         lambda name: "/usr/bin/mock" if name in {"claude", "codex"} else None,
     )
+
+    # Isolate the user-config dir so a global ``adaptive_critique = true`` in
+    # ~/.config/megaplan/config.json doesn't leak into the test and drive the
+    # critique handler down the adaptive-evaluator path (which the mock worker
+    # doesn't implement). Mirrors _make_plan_fixture_with_robustness.
+    import megaplan._core.io as _io_module
+
+    def _config_dir(home: Path | None = None) -> Path:
+        del home
+        return config_path
+
+    monkeypatch.setattr(_io_module, "config_dir", _config_dir)
+    monkeypatch.setattr(megaplan.cli, "config_dir", _config_dir)
+
     make_args = make_args_factory(project_dir)
     megaplan.handle_init(root, make_args(auto_approve=True))
     megaplan.handle_plan(root, make_args(plan="test-plan"))

--- a/tests/test_handle_review_robustness.py
+++ b/tests/test_handle_review_robustness.py
@@ -59,6 +59,7 @@ def _make_plan_fixture(
 ) -> PlanFixture:
     root = tmp_path / f"root-{robustness}"
     project_dir = tmp_path / f"project-{robustness}"
+    config_path = tmp_path / f"config-{robustness}"
     root.mkdir()
     project_dir.mkdir()
     (project_dir / ".git").mkdir()
@@ -69,6 +70,19 @@ def _make_plan_fixture(
         "which",
         lambda name: "/usr/bin/mock" if name in {"claude", "codex"} else None,
     )
+
+    # Isolate user config so a global ``adaptive_critique = true`` in
+    # ~/.config/megaplan/config.json doesn't leak into the test and drive
+    # the critique handler down the adaptive-evaluator path that the mock
+    # worker doesn't implement. See docs/critique.md.
+    import megaplan._core.io as _io_module
+
+    def _config_dir(home: Path | None = None) -> Path:
+        del home
+        return config_path
+
+    monkeypatch.setattr(_io_module, "config_dir", _config_dir)
+    monkeypatch.setattr(megaplan.cli, "config_dir", _config_dir)
 
     make_args = _make_args_factory(project_dir)
     response = megaplan.handle_init(root, make_args(name=f"{robustness}-plan", robustness=robustness))


### PR DESCRIPTION
## Summary

Follow-up to PR #51 (schema-registration fix). Adds a layered defense so the
silent-fallback bug class that hid the original adaptive-critique regression
for every \`partnered\` / \`premium\` / \`apex\` run cannot recur.

Five layers, each catching the bug at a different stage. Detailed walkthrough
in **\`docs/critique.md\`**.

## Five layers of defense

### A. Narrow except at the critique handler

\`megaplan/handlers/critique.py\` previously caught \`except Exception\` around
the evaluator dispatch — which is exactly how the original \`KeyError\` was
swallowed. Now narrowed to \`(ValueError, RuntimeError, OSError)\`:

- **Structural errors** (\`KeyError\`, \`ImportError\`, \`AttributeError\`,
  \`CliError\` from a mock-worker dispatch failure) **bubble up** and fail the
  run loudly.
- **Runtime-recoverable** exceptions (validation errors against well-formed
  schemas, transient worker / LLM / IO failures) are still caught and
  downgraded to static lenses — those represent real recoverable conditions,
  not config / wiring incidents.

The legitimate-failure path now prints a clearer \`ADAPTIVE CRITIQUE
FALLBACK:\` stderr banner with a \`megaplan doctor --adaptive-critique\`
pointer.

### B. Strict mode

New \`[execution] strict_adaptive_critique = false\` (default False,
backward-compatible). When True AND \`adaptive_critique\` resolves True, the
critique handler raises \`AdaptiveCritiqueDegradedError\` instead of writing
\`fallback: true\`. New \`--strict-adaptive-critique\` init flag.

Per the brief, the shipped \`partnered\` / \`premium\` / \`apex\` profiles do
**NOT** set strict mode by default — that's an opt-in for production / CI /
important runs. See \`docs/critique.md\`.

### C. Startup validation at init

\`megaplan/handlers/init.py\` calls \`assert_adaptive_critique_wired()\` when
\`adaptive_critique\` resolves True. The probe (in
\`megaplan/audits/critique_evaluator.py\`) checks:

1. \`\"critique_evaluator\"\` is registered in \`STEP_SCHEMA_FILENAMES\`
2. The mapped schema filename is in the \`SCHEMAS\` dict
3. The \`critique_evaluator\` prompt template loads
4. \`_STEP_REQUIRED_KEYS\` covers the expected keys

Failure raises \`AdaptiveCritiqueMisconfiguredError\` with the failing probe
labels — **before** any planning cost is paid.

### D. \`megaplan doctor --adaptive-critique\`

New subcommand. Runs every probe and prints \`[OK]\` / \`[FAIL]\`. Read-only
— no LLM calls, no plan-dir state.

\`\`\`
\$ megaplan doctor --adaptive-critique
[OK]   critique_evaluator registered in STEP_SCHEMA_FILENAMES  (→ critique_evaluator.json)
[OK]   critique_evaluator.json registered in SCHEMAS
[OK]   critique_evaluator prompt template importable
[OK]   _STEP_REQUIRED_KEYS covers selections/skipped/evaluator_model

adaptive critique wiring is healthy.
\`\`\`

### E. CI guard test

New \`tests/test_adaptive_critique_wired.py\` parametrizes over every shipped
profile with \`adaptive_critique = true\` and asserts the wiring probe passes
for each. A PR that re-introduces the original bug fails CI before merge.

**Verification of acceptance criterion #4** — the new probe assertion was
checked-out against pre-PR-51 main (the bug state) and confirmed to FAIL
there. On post-PR-51 main it PASSES. The CI guard would have caught the
original silent-fallback bug at PR review time.

## New error classes

Both in \`megaplan/types.py\`, extending \`RuntimeError\`:

- \`AdaptiveCritiqueMisconfiguredError\` — init-time gate; carries
  \`missing: list[str]\`.
- \`AdaptiveCritiqueDegradedError\` — critique-time strict-mode raise;
  carries \`reason: str\`.

Both surface through the CLI runner's existing \`(OSError, RuntimeError,
ValueError)\` catch tuple.

## Test-isolation fixes

\`tests/test_execute.py::test_execute_succeeds_in_auto_approve_mode\` and
\`tests/test_handle_review_robustness.py::_make_plan_fixture\` previously
let the real user config bleed in. Before this commit they accidentally
relied on the broad except swallowing the mock worker's \`CliError\` after
the user's global \`adaptive_critique = true\` drove the test down the
adaptive-evaluator path. The narrow except (layer A) makes that bleed
surface as a hard failure, so the tests need to isolate config — which is
the right behaviour anyway.

## Anti-scope (per brief)

- The \`partnered\` / \`premium\` / \`apex\` profiles do NOT enable strict mode
  by default — that's a follow-up the user decides.
- Existing \`critique_evaluator\` prompt template and schema content
  unchanged beyond probe wiring.
- No force-pushes, no amended commits, no hook bypass.

## Test plan

- [x] \`pytest tests/test_critique_evaluator.py tests/test_critique.py tests/test_config.py tests/test_adaptive_critique_wired.py tests/test_execute.py tests/test_tiny_robustness.py tests/test_handle_review_robustness.py tests/test_parallel_critique.py tests/test_parallel_review.py tests/test_receipts_review.py tests/test_hermes_worker_fireworks_streaming.py\` — 245 passed locally
- [x] \`python -m megaplan doctor --adaptive-critique\` — green
- [x] CI guard fails on pre-PR-51 main (verifies it would have caught the original bug)
- [ ] Full suite green on this PR's CI
- [ ] Awaiting human review (do not auto-merge per brief)