### PR TITLE
m2 plan-all-first: contracts + review.md + reground (interim WIP snapshot)

### DIFF
--- a/megaplan/_core/io.py
+++ b/megaplan/_core/io.py
@@ -644,6 +644,8 @@ def load_finalize_snapshot(plan_dir: Path) -> dict[str, Any]:
 
 
 def render_final_md(finalize_data: dict[str, Any], *, phase: str = "finalize") -> str:
+    from megaplan.orchestration.plan_contracts import render_contract_markdown
+
     show_execution_gaps = phase in ("execute", "review")
     show_review_gaps = phase == "review"
     tasks = finalize_data.get("tasks", [])
@@ -684,6 +686,10 @@ def render_final_md(finalize_data: dict[str, Any], *, phase: str = "finalize") -
             lines.append("  Reviewer verdict: [PENDING]")
             gap_counts["Reviewer verdicts pending"] = gap_counts.get("Reviewer verdicts pending", 0) + 1
         lines.append("")
+
+    contract_markdown = render_contract_markdown(finalize_data)
+    if contract_markdown:
+        lines.extend([contract_markdown, ""])
 
     lines.extend(["## Watch Items", ""])
     watch_items = finalize_data.get("watch_items", [])

--- a/megaplan/chain/__init__.py
+++ b/megaplan/chain/__init__.py
@@ -52,6 +52,7 @@ import subprocess
 import sys
 import time
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Callable, Literal
 
@@ -616,6 +617,7 @@ class ChainState:
     # ``profile_bumps`` / ``robustness_bumps`` / ``depth_bumps`` persist the
     # escalated tier overrides applied for the next re-init.
     retry_counts: dict[str, int] = field(default_factory=dict)
+    reground_decisions: dict[str, Any] = field(default_factory=dict)
     ladder_stage: dict[str, str] = field(default_factory=dict)
     profile_bumps: dict[str, str] = field(default_factory=dict)
     robustness_bumps: dict[str, str] = field(default_factory=dict)
@@ -640,6 +642,7 @@ class ChainState:
             "extra_repo_sync": list(self.extra_repo_sync),
             "completion_contract_mode": self.completion_contract_mode,
             "retry_counts": dict(self.retry_counts),
+            "reground_decisions": dict(self.reground_decisions),
             "ladder_stage": dict(self.ladder_stage),
             "profile_bumps": dict(self.profile_bumps),
             "robustness_bumps": dict(self.robustness_bumps),
@@ -701,6 +704,11 @@ class ChainState:
                 if isinstance(key, str) and isinstance(val, str)
             }
 
+        def _str_any_map(value: Any) -> dict[str, Any]:
+            if not isinstance(value, dict):
+                return {}
+            return {key: val for key, val in value.items() if isinstance(key, str)}
+
         return cls(
             current_milestone_index=int(raw.get("current_milestone_index", -1)),
             current_plan_name=raw.get("current_plan_name"),
@@ -719,6 +727,7 @@ class ChainState:
             extra_repo_sync=extra_repo_sync,
             completion_contract_mode=completion_contract_mode,
             retry_counts=_str_int_map(raw.get("retry_counts")),
+            reground_decisions=_str_any_map(raw.get("reground_decisions")),
             ladder_stage=_str_str_map(raw.get("ladder_stage")),
             profile_bumps=_str_str_map(raw.get("profile_bumps")),
             robustness_bumps=_str_str_map(raw.get("robustness_bumps")),
@@ -797,6 +806,348 @@ def _upsert_completed_record(state: ChainState, record: dict[str, Any]) -> None:
 
 def _completed_record_for_label(state: ChainState, label: str) -> dict[str, Any] | None:
     return _completed_records_by_label(state).get(label)
+
+
+def _load_contract_for_completed_record(root: Path, record: dict[str, Any]) -> dict[str, Any] | None:
+    """Load the plan contract for a completed record.
+
+    Prefers the current ``contract.json`` in the plan directory. When that
+    file is missing, falls back to reading it from the git commit stored in
+    ``artifact_commit_sha`` via ``read_plan_artifact_from_commit``.  The
+    loaded payload is normalized through ``normalize_contract_payload``.
+
+    Returns ``None`` when the record has no usable plan name or the contract
+    cannot be found through either path.
+    """
+    from megaplan.chain.git_ops import read_plan_artifact_from_commit
+    from megaplan.orchestration.plan_contracts import normalize_contract_payload
+
+    plan_name = record.get("plan")
+    if not isinstance(plan_name, str) or not plan_name.strip():
+        return None
+
+    plan_dir = root / ".megaplan" / "plans" / plan_name
+    contract_path = plan_dir / "contract.json"
+
+    # Prefer the current artifact on disk.
+    if contract_path.exists():
+        try:
+            payload = json.loads(contract_path.read_text(encoding="utf-8"))
+            return normalize_contract_payload(payload)
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    # Fall back to the commit artifact.
+    commit_sha = record.get("artifact_commit_sha")
+    if isinstance(commit_sha, str) and commit_sha.strip():
+        rel_path = f".megaplan/plans/{plan_name}/contract.json"
+        try:
+            content = read_plan_artifact_from_commit(root, commit_sha.strip(), rel_path)
+            if content is not None:
+                payload = json.loads(content)
+                return normalize_contract_payload(payload)
+        except (json.JSONDecodeError, CliError):
+            pass
+
+    return None
+
+
+def _contract_context_for_plan_only_milestone(
+    root: Path,
+    milestone: MilestoneSpec,
+    state: ChainState,
+) -> dict[str, Any]:
+    from megaplan.orchestration.plan_contracts import provided_paths_by_milestone
+
+    records = _completed_records_by_label(state)
+    upstream_contracts: list[dict[str, Any]] = []
+    dependency_labels: list[str] = []
+    for label in milestone.depends_on:
+        record = records.get(label)
+        if not isinstance(record, dict) or record.get("status") not in {"finalized", "done"}:
+            continue
+        contract = _load_contract_for_completed_record(root, record)
+        if contract is None:
+            continue
+        dependency_labels.append(label)
+        upstream_contracts.append(
+            {
+                "milestone_label": label,
+                "provides": list(contract.get("provides", [])),
+                "assumes": list(contract.get("assumes", [])),
+            }
+        )
+    return {
+        "plan_only": True,
+        "milestone_label": milestone.label,
+        "dependency_labels": dependency_labels,
+        "upstream_contracts": upstream_contracts,
+        "provided_paths": provided_paths_by_milestone(upstream_contracts),
+    }
+
+
+def _chain_review_path(spec_path: Path) -> Path:
+    return spec_path.resolve().parent / ".megaplan" / "plans" / ".chains" / f"{spec_path.stem}.review.md"
+
+
+def _markdown_cell(value: Any) -> str:
+    text = "" if value is None else str(value)
+    return text.replace("\\", "\\\\").replace("|", "\\|").replace("\n", "<br>")
+
+
+def _write_chain_review(
+    root: Path,
+    spec_path: Path,
+    spec: ChainSpec,
+    state: ChainState,
+    *,
+    partial_reason: str | None = None,
+) -> Path:
+    from megaplan.orchestration.plan_contracts import diff_assumes_against_provides
+
+    records = _completed_records_by_label(state)
+    loaded_contracts: dict[str, dict[str, Any]] = {}
+    for label, record in records.items():
+        if not isinstance(record, dict) or record.get("status") not in {"finalized", "done"}:
+            continue
+        contract = _load_contract_for_completed_record(root, record)
+        if contract is not None:
+            loaded_contracts[label] = contract
+
+    rows: list[dict[str, str]] = []
+    for milestone in spec.milestones:
+        downstream_contract = loaded_contracts.get(milestone.label)
+        if downstream_contract is None or not downstream_contract.get("assumes"):
+            continue
+        upstream_contracts = [
+            {
+                "milestone_label": label,
+                "provides": list(loaded_contracts[label].get("provides", [])),
+                "assumes": list(loaded_contracts[label].get("assumes", [])),
+            }
+            for label in milestone.depends_on
+            if label in loaded_contracts
+        ]
+        rows.extend(
+            diff_assumes_against_provides(
+                downstream_contract,
+                upstream_contracts,
+                downstream_label=milestone.label,
+            )
+        )
+
+    status_counts = {status: 0 for status in ("OK", "MISSING_UPSTREAM", "MISMATCH")}
+    for row in rows:
+        status = row.get("status")
+        if status in status_counts:
+            status_counts[status] += 1
+
+    lines = [
+        f"# Chain Review: {spec_path.stem}",
+        "",
+        f"- Status: {'partial' if partial_reason else 'complete'}",
+        f"- Partial reason: {partial_reason or ''}",
+        f"- Completed records considered: {len(records)}",
+        f"- Contracts loaded: {len(loaded_contracts)}",
+        f"- OK: {status_counts['OK']}",
+        f"- MISSING_UPSTREAM: {status_counts['MISSING_UPSTREAM']}",
+        f"- MISMATCH: {status_counts['MISMATCH']}",
+        "",
+        "| Downstream | Upstream | Symbol | Expected Path | Actual Path | Expected Signature | Actual Signature | Status | Note |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    if rows:
+        for row in rows:
+            lines.append(
+                "| "
+                + " | ".join(
+                    _markdown_cell(row.get(key, ""))
+                    for key in (
+                        "downstream_label",
+                        "upstream_label",
+                        "symbol",
+                        "expected_path",
+                        "actual_path",
+                        "expected_signature",
+                        "actual_signature",
+                        "status",
+                        "note",
+                    )
+                )
+                + " |"
+            )
+    else:
+        lines.append("|  |  |  |  |  |  |  | OK | No Provides-to-Assumes rows. |")
+
+    path = _chain_review_path(spec_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+    return path
+
+
+def _read_plan_state_payload(root: Path, plan_name: str) -> dict[str, Any] | None:
+    try:
+        plan_dir = resolve_plan_dir(root, plan_name)
+    except CliError:
+        plan_dir = root / ".megaplan" / "plans" / plan_name
+    state_path = plan_dir / "state.json"
+    try:
+        raw = json.loads(state_path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError, UnicodeDecodeError):
+        return None
+    return raw if isinstance(raw, dict) else None
+
+
+def _plan_current_state_from_payload(root: Path, plan_name: str) -> str | None:
+    raw = _read_plan_state_payload(root, plan_name)
+    current = raw.get("current_state") if isinstance(raw, dict) else None
+    return current if isinstance(current, str) else None
+
+
+def _apply_reground_replan(
+    root: Path,
+    plan_name: str,
+    decision: dict[str, Any],
+) -> None:
+    from megaplan.handlers.override import apply_override_replan
+
+    try:
+        plan_dir = resolve_plan_dir(root, plan_name)
+    except CliError:
+        plan_dir = root / ".megaplan" / "plans" / plan_name
+    raw_state = _read_plan_state_payload(root, plan_name)
+    if not isinstance(raw_state, dict):
+        raise CliError(
+            "missing_reground_plan_state",
+            f"cannot apply reground replan: plan {plan_name!r} has no readable state.json",
+        )
+    summary = _reground_diff_summary(decision)
+    apply_override_replan(
+        root,
+        plan_dir,
+        raw_state,
+        reason=f"Contract drift detected before execute. {summary}",
+        note=summary,
+    )
+
+
+def _reground_skip_decision(milestone: MilestoneSpec, reason: str) -> dict[str, Any]:
+    return {
+        "status": "skipped",
+        "milestone_label": milestone.label,
+        "reason": reason,
+        "checked_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+    }
+
+
+def _record_execute_reground_decision(
+    root: Path,
+    state: ChainState,
+    milestone: MilestoneSpec,
+    plan_name: str,
+    downstream_record: dict[str, Any] | None,
+) -> dict[str, Any]:
+    from megaplan.orchestration.plan_contracts import (
+        MATERIAL_CONTRACT_STATUSES,
+        contract_diff_fingerprint,
+        diff_assumes_against_provides,
+    )
+
+    if not milestone.depends_on:
+        decision = _reground_skip_decision(milestone, "no_dependencies")
+        state.reground_decisions[milestone.label] = decision
+        return decision
+    if not isinstance(downstream_record, dict) or downstream_record.get("status") != "finalized":
+        decision = _reground_skip_decision(milestone, "downstream_not_finalized")
+        state.reground_decisions[milestone.label] = decision
+        return decision
+
+    plan_state = _read_plan_state_payload(root, plan_name)
+    meta = (plan_state or {}).get("meta")
+    chain_policy = meta.get("chain_policy") if isinstance(meta, dict) else None
+    contract_context = chain_policy.get("contract_context") if isinstance(chain_policy, dict) else None
+    if not isinstance(contract_context, dict) or contract_context.get("plan_only") is not True:
+        decision = _reground_skip_decision(milestone, "not_plan_only")
+        state.reground_decisions[milestone.label] = decision
+        return decision
+
+    downstream_contract = _load_contract_for_completed_record(root, downstream_record)
+    if downstream_contract is None:
+        decision = _reground_skip_decision(milestone, "downstream_contract_unavailable")
+        state.reground_decisions[milestone.label] = decision
+        return decision
+    if not downstream_contract.get("assumes"):
+        decision = _reground_skip_decision(milestone, "downstream_assumes_empty")
+        state.reground_decisions[milestone.label] = decision
+        return decision
+
+    records = _completed_records_by_label(state)
+    upstream_contracts: list[dict[str, Any]] = []
+    unavailable: list[str] = []
+    for label in milestone.depends_on:
+        record = records.get(label)
+        contract = _load_contract_for_completed_record(root, record) if isinstance(record, dict) else None
+        if contract is None:
+            unavailable.append(label)
+            continue
+        upstream_contracts.append(
+            {
+                "milestone_label": label,
+                "provides": list(contract.get("provides", [])),
+                "assumes": list(contract.get("assumes", [])),
+            }
+        )
+    if unavailable:
+        decision = _reground_skip_decision(
+            milestone,
+            "upstream_contract_unavailable:" + ",".join(sorted(unavailable)),
+        )
+        state.reground_decisions[milestone.label] = decision
+        return decision
+    if not any(contract.get("provides") for contract in upstream_contracts):
+        decision = _reground_skip_decision(milestone, "upstream_provides_empty")
+        state.reground_decisions[milestone.label] = decision
+        return decision
+
+    diff_rows = diff_assumes_against_provides(
+        downstream_contract,
+        upstream_contracts,
+        downstream_label=milestone.label,
+    )
+    material_rows = [
+        row for row in diff_rows if row.get("status") in MATERIAL_CONTRACT_STATUSES
+    ]
+    decision = {
+        "status": "drift" if material_rows else "pass",
+        "milestone_label": milestone.label,
+        "dependency_labels": list(milestone.depends_on),
+        "checked_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "diff_row_count": len(diff_rows),
+        "material_diff_count": len(material_rows),
+        "material_fingerprint": contract_diff_fingerprint(material_rows),
+        "material_diffs": material_rows,
+    }
+    state.reground_decisions[milestone.label] = decision
+    return decision
+
+
+def _reground_diff_summary(decision: dict[str, Any]) -> str:
+    rows = decision.get("material_diffs")
+    if not isinstance(rows, list) or not rows:
+        return "No material contract drift rows."
+    parts: list[str] = []
+    for row in rows[:5]:
+        if not isinstance(row, dict):
+            continue
+        upstream = row.get("upstream_label") or "<unknown>"
+        symbol = row.get("symbol") or "<unknown>"
+        status = row.get("status") or "MISMATCH"
+        note = row.get("note") or ""
+        parts.append(f"{status} {upstream}:{symbol}" + (f" ({note})" if note else ""))
+    suffix = ""
+    if len(rows) > len(parts):
+        suffix = f"; +{len(rows) - len(parts)} more"
+    return "; ".join(parts) + suffix
 
 
 def _load_finalized_record_state(
@@ -959,6 +1310,7 @@ def _plan_artifact_paths_for_milestone(
         plan_dir / "final.md",
         plan_dir / "finalize.json",
         plan_dir / "state.json",
+        plan_dir / "contract.json",
     ]
     idea_path = Path(milestone.idea)
     if idea_path.exists():
@@ -1059,6 +1411,9 @@ def _write_chain_policy_into_plan_meta(
     spec: ChainSpec,
     spec_path: Path,
     milestone_label: str,
+    *,
+    plan_only: bool = False,
+    contract_context: dict[str, Any] | None = None,
 ) -> None:
     """Record effective chain policy in the plan's ``state.json`` metadata.
 
@@ -1109,7 +1464,13 @@ def _write_chain_policy_into_plan_meta(
         "review_policy": effective["review_policy"],
         "source": effective["source"],
         "milestone_label": milestone_label,
+        "plan_only": plan_only,
     }
+    if contract_context is not None:
+        chain_policy["dependency_labels"] = list(contract_context.get("dependency_labels", []))
+        chain_policy["upstream_contracts"] = list(contract_context.get("upstream_contracts", []))
+        chain_policy["provided_paths"] = dict(contract_context.get("provided_paths", {}))
+        chain_policy["contract_context"] = contract_context
 
     def _patch_chain_policy(current: dict[str, Any]) -> bool:
         meta = current.setdefault("meta", {})
@@ -1927,6 +2288,14 @@ def run_chain(
             save_chain_state(spec_path, state)
             decision = _handle_outcome(outcome, spec=spec, writer=writer)
             if decision == "stop":
+                if planning_pass:
+                    _write_chain_review(
+                        root,
+                        spec_path,
+                        spec,
+                        state,
+                        partial_reason=f"seed plan {outcome.status}",
+                    )
                 return _result("stopped", state, events, spec=spec, reason=f"seed plan {outcome.status}")
             if decision == "retry":
                 # Recursive retry kept simple: re-drive seed once.
@@ -1940,6 +2309,14 @@ def run_chain(
                 state.last_state = outcome.status
                 save_chain_state(spec_path, state)
                 if outcome.status != "done":
+                    if planning_pass:
+                        _write_chain_review(
+                            root,
+                            spec_path,
+                            spec,
+                            state,
+                            partial_reason="seed retry failed",
+                        )
                     return _result("stopped", state, events, spec=spec, reason="seed retry failed")
             # skip / advance both proceed to milestones
         _upsert_completed_record(
@@ -2122,10 +2499,21 @@ def run_chain(
                 phase_model=milestone.phase_model,
                 writer=writer,
             )
+            contract_context = (
+                _contract_context_for_plan_only_milestone(root, milestone, state)
+                if planning_pass
+                else None
+            )
             # Record effective chain policy in the newly initialized plan's
             # state.json metadata so downstream consumers can introspect it.
             _write_chain_policy_into_plan_meta(
-                root, plan_name, spec, spec_path, milestone.label
+                root,
+                plan_name,
+                spec,
+                spec_path,
+                milestone.label,
+                plan_only=planning_pass,
+                contract_context=contract_context,
             )
             state.current_milestone_index = idx
             state.current_plan_name = plan_name
@@ -2165,6 +2553,61 @@ def run_chain(
                     root, spec_path, branch=milestone.branch, pr_number=state.pr_number
                 )
 
+        if execution_pass:
+            previous_reground_decision = state.reground_decisions.get(milestone.label)
+            current_plan_state = _plan_current_state_from_payload(root, plan_name)
+            if current_plan_state != STATE_FINALIZED:
+                reground_decision = _reground_skip_decision(milestone, "plan_not_finalized")
+                if not (
+                    isinstance(previous_reground_decision, dict)
+                    and previous_reground_decision.get("status") == "replanned"
+                ):
+                    state.reground_decisions[milestone.label] = reground_decision
+                    save_chain_state(spec_path, state)
+            else:
+                reground_decision = _record_execute_reground_decision(
+                    root,
+                    state,
+                    milestone,
+                    plan_name,
+                    _completed_record_for_status(state, milestone),
+                )
+                if reground_decision.get("status") == "drift":
+                    fingerprint = reground_decision.get("material_fingerprint")
+                    if (
+                        isinstance(previous_reground_decision, dict)
+                        and previous_reground_decision.get("material_fingerprint") == fingerprint
+                        and previous_reground_decision.get("status") in {"drift", "replanned"}
+                    ):
+                        save_chain_state(spec_path, state)
+                        summary = _reground_diff_summary(reground_decision)
+                        log(f"reground {milestone.label}: repeated drift; stopping")
+                        return _result(
+                            "stopped",
+                            state,
+                            events,
+                            spec=spec,
+                            reason=f"repeated contract drift for {milestone.label}: {summary}",
+                        )
+                    _apply_reground_replan(root, plan_name, reground_decision)
+                    replanned_decision = dict(reground_decision)
+                    replanned_decision["status"] = "replanned"
+                    replanned_decision["replan_reason"] = _reground_diff_summary(reground_decision)
+                    replanned_decision["replanned_at"] = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+                    state.reground_decisions[milestone.label] = replanned_decision
+                    save_chain_state(spec_path, state)
+                    log(f"reground {milestone.label}: drift; replanning same milestone")
+                    continue
+                save_chain_state(spec_path, state)
+            log(
+                f"reground {milestone.label}: {reground_decision['status']}"
+                + (
+                    f" ({reground_decision['reason']})"
+                    if reground_decision.get("reason")
+                    else ""
+                )
+            )
+
         outcome = _drive_plan_with_blocked_execute_recovery(
             root,
             plan_name,
@@ -2184,6 +2627,14 @@ def run_chain(
                 root, spec_path, milestone, outcome, state, writer=writer
             )
             save_chain_state(spec_path, state)
+            if planning_pass:
+                _write_chain_review(
+                    root,
+                    spec_path,
+                    spec,
+                    state,
+                    partial_reason=f"milestone {milestone.label} ended {outcome.status}",
+                )
             return _result(
                 "stopped",
                 state,
@@ -2288,6 +2739,14 @@ def run_chain(
         save_chain_state(spec_path, state)
         if one:
             log(f"paused after milestone {milestone.label}")
+            if planning_pass:
+                _write_chain_review(
+                    root,
+                    spec_path,
+                    spec,
+                    state,
+                    partial_reason=f"completed one milestone: {milestone.label}",
+                )
             return _result(
                 "paused",
                 state,
@@ -2297,6 +2756,8 @@ def run_chain(
             )
 
     log("all milestones complete")
+    if planning_pass:
+        _write_chain_review(root, spec_path, spec, state)
     return _result("done", state, events, spec=spec)
 
 

--- a/megaplan/chain/git_ops.py
+++ b/megaplan/chain/git_ops.py
@@ -522,6 +522,54 @@ def _porcelain_paths(root: Path) -> set[str]:
     return paths
 
 
+def read_plan_artifact_from_commit(root: Path, commit_sha: str, rel_path: str) -> str | None:
+    """Read a file's content from a git commit, returning None only for missing files.
+
+    Uses ``git show <commit_sha>:<rel_path>``. Returns the file content as a
+    string when the file exists in the commit. Returns ``None`` when git
+    reports the path does not exist in the given tree-ish (e.g. "does not
+    exist", "exists on disk, but not in", "bad revision"). Raises
+    ``CliError`` for real git failures (non-zero exit for other reasons).
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "show", f"{commit_sha}:{rel_path}"],
+            cwd=str(root),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+        raise CliError(
+            "git_artifact_read_failed",
+            f"git show {commit_sha}:{rel_path} failed with {exc}",
+        ) from exc
+
+    if proc.returncode == 0:
+        return proc.stdout
+
+    # Distinguish "file missing from this commit" (None) from real git errors.
+    stderr_lower = (proc.stderr or "").lower()
+    if (
+        "does not exist" in stderr_lower
+        or "exists on disk" in stderr_lower
+        or "bad revision" in stderr_lower
+    ):
+        return None
+
+    raise CliError(
+        "git_artifact_read_failed",
+        f"git show {commit_sha}:{rel_path} exited {proc.returncode}",
+        extra={
+            "command": ["git", "show", f"{commit_sha}:{rel_path}"],
+            "returncode": proc.returncode,
+            "stdout": proc.stdout,
+            "stderr": proc.stderr,
+        },
+    )
+
+
 def _artifact_relpath(root: Path, path: Path) -> str:
     candidate = path if path.is_absolute() else root / path
     try:

--- a/megaplan/handlers/finalize.py
+++ b/megaplan/handlers/finalize.py
@@ -21,6 +21,7 @@ from megaplan._core import (
     require_state,
     sha256_file,
 )
+from megaplan.orchestration.plan_contracts import normalize_contract_payload
 
 from .shared import _finish_step, _raise_step_validation_error, _run_worker, shutil, subprocess
 
@@ -594,6 +595,12 @@ def _normalize_task_complexity(payload: dict[str, Any]) -> None:
 
 
 def _write_finalize_artifacts(plan_dir: Path, payload: dict[str, Any], state: PlanState) -> str:
+    contract_payload = normalize_contract_payload(
+        {"provides": payload.get("provides", []), "assumes": payload.get("assumes", [])},
+        root=Path(state["config"]["project_dir"]),
+    )
+    payload["provides"] = contract_payload["provides"]
+    payload["assumes"] = contract_payload["assumes"]
     if state["config"].get("mode") in {"doc", "joke"}:
         payload["baseline_test_failures"] = None
         payload["baseline_test_command"] = None
@@ -607,6 +614,7 @@ def _write_finalize_artifacts(plan_dir: Path, payload: dict[str, Any], state: Pl
     _apply_programmatic_coverage(payload, plan_dir, state)
     _normalize_task_complexity(payload)
     _reconcile_validation_after_mutation(payload)
+    atomic_write_json(plan_dir / "contract.json", contract_payload)
     atomic_write_json(plan_dir / "finalize.json", payload)
     atomic_write_json(plan_dir / "finalize_snapshot.json", payload)
     atomic_write_text(plan_dir / "user_actions.md", _render_user_actions_md(payload))
@@ -629,7 +637,7 @@ def handle_finalize(root: Path, args: argparse.Namespace) -> StepResponse:
             step="finalize",
             worker=worker, agent=agent, mode=mode, refreshed=refreshed,
             summary=f"Finalized plan with {len(worker.payload['tasks'])} tasks and {len(worker.payload['watch_items'])} watch items.",
-            artifacts=["final.md", "finalize.json", "user_actions.md"],
+            artifacts=["contract.json", "final.md", "finalize.json", "user_actions.md"],
             output_file="finalize.json",
             artifact_hash=artifact_hash,
             next_step="execute",

--- a/megaplan/handlers/override.py
+++ b/megaplan/handlers/override.py
@@ -350,8 +350,13 @@ def _override_force_proceed(
     return response
 
 
-def _override_replan(
-    root: Path, plan_dir: Path, state: PlanState, args: argparse.Namespace
+def apply_override_replan(
+    root: Path,
+    plan_dir: Path,
+    state: PlanState,
+    *,
+    reason: str,
+    note: str | None = None,
 ) -> StepResponse:
     allowed = {STATE_GATED, STATE_FINALIZED, STATE_CRITIQUED, STATE_FAILED}
     if state["current_state"] not in allowed:
@@ -360,7 +365,7 @@ def _override_replan(
             f"replan requires state {', '.join(sorted(allowed))}, got '{state['current_state']}'",
             valid_next=infer_next_steps(state),
         )
-    reason = args.reason or args.note or "Re-entering planning loop"
+    reason = reason or note or "Re-entering planning loop"
     plan_file = latest_plan_path(plan_dir, state)
     state["current_state"] = STATE_PLANNED
     state["last_gate"] = {}
@@ -369,8 +374,8 @@ def _override_replan(
         "overrides",
         {"action": "replan", "timestamp": now_utc(), "reason": reason},
     )
-    if args.note:
-        _append_to_meta(state, "notes", {"timestamp": now_utc(), "note": args.note})
+    if note:
+        _append_to_meta(state, "notes", {"timestamp": now_utc(), "note": note})
     save_state_merge_meta(plan_dir, state)
     try:
         from megaplan.observability.events import emit, EventKind
@@ -394,6 +399,18 @@ def _override_replan(
     }
     _attach_next_step_runtime(response)
     return response
+
+
+def _override_replan(
+    root: Path, plan_dir: Path, state: PlanState, args: argparse.Namespace
+) -> StepResponse:
+    return apply_override_replan(
+        root,
+        plan_dir,
+        state,
+        reason=args.reason or args.note or "Re-entering planning loop",
+        note=args.note,
+    )
 
 
 _BLOCKED_RECOVERY_STATES: dict[str, str] = {

--- a/megaplan/orchestration/plan_contracts.py
+++ b/megaplan/orchestration/plan_contracts.py
@@ -1,0 +1,299 @@
+"""Helpers for plan-stage Provides/Assumes contracts.
+
+These helpers intentionally stay narrow: they normalize the contract schema
+used by finalize/chain planning, render it for markdown surfaces, collect
+provided paths for prep cross-reference, and compare downstream Assumes
+against upstream Provides without introducing semantic analysis.
+"""
+
+from __future__ import annotations
+
+import json
+import posixpath
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+
+MATERIAL_CONTRACT_STATUSES = frozenset({"MISSING_UPSTREAM", "MISMATCH"})
+
+
+def _trim_string(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _normalize_signature(value: Any) -> str:
+    return _trim_string(value)
+
+
+def _normalize_path(value: Any, *, root: Path) -> str:
+    raw = _trim_string(value)
+    if not raw:
+        return ""
+    if raw.startswith("~"):
+        raw = str(Path(raw).expanduser())
+    candidate = Path(raw)
+    if candidate.is_absolute():
+        try:
+            raw = candidate.resolve().relative_to(root.resolve()).as_posix()
+        except ValueError:
+            raw = candidate.resolve().as_posix()
+    else:
+        raw = raw.replace("\\", "/")
+    normalized = posixpath.normpath(raw.replace("\\", "/"))
+    return "" if normalized == "." else normalized
+
+
+def _normalize_interfaces(value: Any, *, root: Path) -> list[dict[str, str]]:
+    if not isinstance(value, list):
+        return []
+    interfaces: list[dict[str, str]] = []
+    for item in value:
+        if not isinstance(item, Mapping):
+            continue
+        interfaces.append(
+            {
+                "symbol": _trim_string(item.get("symbol")),
+                "signature": _normalize_signature(item.get("signature")),
+                "path": _normalize_path(item.get("path"), root=root),
+            }
+        )
+    return interfaces
+
+
+def normalize_contract_payload(
+    payload: Any,
+    *,
+    root: Path | str | None = None,
+) -> dict[str, list[dict[str, Any]]]:
+    """Normalize the narrow Provides/Assumes schema for plan contracts."""
+
+    root_path = Path(root).resolve() if root is not None else Path.cwd().resolve()
+    raw = payload if isinstance(payload, Mapping) else {}
+
+    provides: list[dict[str, Any]] = []
+    for item in raw.get("provides", []):
+        if not isinstance(item, Mapping):
+            continue
+        provides.append(
+            {
+                "name": _trim_string(item.get("name")),
+                "description": _trim_string(item.get("description")),
+                "interfaces": _normalize_interfaces(item.get("interfaces"), root=root_path),
+            }
+        )
+
+    assumes: list[dict[str, Any]] = []
+    for item in raw.get("assumes", []):
+        if not isinstance(item, Mapping):
+            continue
+        assumes.append(
+            {
+                "name": _trim_string(item.get("name")),
+                "upstream_milestone": _trim_string(item.get("upstream_milestone")),
+                "interfaces": _normalize_interfaces(item.get("interfaces"), root=root_path),
+            }
+        )
+
+    return {"provides": provides, "assumes": assumes}
+
+
+def render_contract_markdown(contract: Any) -> str:
+    """Render additive Provides/Assumes markdown sections for final.md."""
+
+    normalized = normalize_contract_payload(contract)
+    lines: list[str] = []
+
+    if normalized["provides"]:
+        lines.append("## Provides")
+        lines.append("")
+        for provide in normalized["provides"]:
+            heading = f"- `{provide['name']}`" if provide["name"] else "- Unnamed provide"
+            if provide["description"]:
+                heading = f"{heading}: {provide['description']}"
+            lines.append(heading)
+            for interface in provide["interfaces"]:
+                details = [
+                    f"`{interface['symbol']}`" if interface["symbol"] else "`<unnamed>`",
+                    f"path `{interface['path']}`" if interface["path"] else "path `<unknown>`",
+                ]
+                if interface["signature"]:
+                    details.append(f"signature `{interface['signature']}`")
+                lines.append(f"  - {', '.join(details)}")
+        lines.append("")
+
+    if normalized["assumes"]:
+        lines.append("## Assumes")
+        lines.append("")
+        for assume in normalized["assumes"]:
+            upstream = assume["upstream_milestone"] or "<unknown upstream>"
+            heading = f"- `{assume['name']}` from `{upstream}`" if assume["name"] else f"- From `{upstream}`"
+            lines.append(heading)
+            for interface in assume["interfaces"]:
+                details = [
+                    f"`{interface['symbol']}`" if interface["symbol"] else "`<unnamed>`",
+                    f"path `{interface['path']}`" if interface["path"] else "path `<unknown>`",
+                ]
+                if interface["signature"]:
+                    details.append(f"signature `{interface['signature']}`")
+                lines.append(f"  - {', '.join(details)}")
+        lines.append("")
+
+    return "\n".join(lines).rstrip()
+
+
+def provided_paths_by_milestone(contracts: Iterable[Mapping[str, Any]]) -> dict[str, list[str]]:
+    """Collect unique provided paths keyed by milestone label."""
+
+    paths: dict[str, set[str]] = {}
+    for item in contracts:
+        if not isinstance(item, Mapping):
+            continue
+        label = (
+            _trim_string(item.get("milestone_label"))
+            or _trim_string(item.get("label"))
+            or _trim_string(item.get("upstream_milestone"))
+        )
+        if not label:
+            continue
+        contract_payload = item.get("contract")
+        if not isinstance(contract_payload, Mapping):
+            contract_payload = {"provides": item.get("provides", [])}
+        normalized = normalize_contract_payload(contract_payload)
+        bucket = paths.setdefault(label, set())
+        for provide in normalized["provides"]:
+            for interface in provide["interfaces"]:
+                if interface["path"]:
+                    bucket.add(interface["path"])
+    return {label: sorted(values) for label, values in sorted(paths.items())}
+
+
+def _normalize_upstream_contracts(
+    upstream_contracts: Any,
+) -> dict[str, dict[str, list[dict[str, Any]]]]:
+    if isinstance(upstream_contracts, Mapping):
+        normalized: dict[str, dict[str, list[dict[str, Any]]]] = {}
+        for label, contract in upstream_contracts.items():
+            if isinstance(label, str):
+                normalized[label] = normalize_contract_payload(contract)
+        return normalized
+    if not isinstance(upstream_contracts, Iterable) or isinstance(upstream_contracts, (str, bytes)):
+        return {}
+
+    normalized = {}
+    for item in upstream_contracts:
+        if not isinstance(item, Mapping):
+            continue
+        label = _trim_string(item.get("milestone_label")) or _trim_string(item.get("label"))
+        if not label:
+            continue
+        contract_payload = item.get("contract")
+        if not isinstance(contract_payload, Mapping):
+            contract_payload = {"provides": item.get("provides", [])}
+        normalized[label] = normalize_contract_payload(contract_payload)
+    return normalized
+
+
+def diff_assumes_against_provides(
+    downstream_contract: Any,
+    upstream_contracts: Any,
+    *,
+    downstream_label: str = "",
+) -> list[dict[str, str]]:
+    """Compare downstream Assumes to upstream Provides row-by-row."""
+
+    downstream = normalize_contract_payload(downstream_contract)
+    upstream = _normalize_upstream_contracts(upstream_contracts)
+    rows: list[dict[str, str]] = []
+
+    for assume in downstream["assumes"]:
+        upstream_label = assume["upstream_milestone"]
+        upstream_contract = upstream.get(upstream_label)
+        upstream_index: dict[str, dict[str, str]] = {}
+        if upstream_contract is not None:
+            for provide in upstream_contract["provides"]:
+                for interface in provide["interfaces"]:
+                    symbol = interface["symbol"]
+                    if symbol and symbol not in upstream_index:
+                        upstream_index[symbol] = interface
+
+        for interface in assume["interfaces"]:
+            symbol = interface["symbol"]
+            actual = upstream_index.get(symbol, {})
+            status = "OK"
+            note = ""
+            if upstream_contract is None or not actual:
+                status = "MISSING_UPSTREAM"
+                note = (
+                    f"upstream contract `{upstream_label}` missing"
+                    if upstream_contract is None
+                    else f"symbol `{symbol}` missing upstream"
+                )
+            else:
+                path_changed = actual.get("path", "") != interface["path"]
+                signature_changed = actual.get("signature", "") != interface["signature"]
+                if path_changed or signature_changed:
+                    status = "MISMATCH"
+                    if path_changed and signature_changed:
+                        note = "path and signature changed"
+                    elif path_changed:
+                        note = "path changed"
+                    else:
+                        note = "signature changed"
+            rows.append(
+                {
+                    "downstream_label": downstream_label,
+                    "downstream_name": assume["name"],
+                    "upstream_label": upstream_label,
+                    "symbol": symbol,
+                    "assumes_interface": symbol,
+                    "provides_interface": actual.get("symbol", symbol),
+                    "expected_path": interface["path"],
+                    "actual_path": actual.get("path", ""),
+                    "path": interface["path"],
+                    "expected_signature": interface["signature"],
+                    "actual_signature": actual.get("signature", ""),
+                    "signature": interface["signature"],
+                    "status": status,
+                    "note": note,
+                }
+            )
+    return rows
+
+
+def contract_diff_fingerprint(diff_rows: Iterable[Mapping[str, Any]]) -> str:
+    """Return a deterministic canonical fingerprint for material diff rows."""
+
+    canonical_rows: list[dict[str, str]] = []
+    for row in diff_rows:
+        if not isinstance(row, Mapping):
+            continue
+        status = _trim_string(row.get("status"))
+        if status not in MATERIAL_CONTRACT_STATUSES:
+            continue
+        canonical_rows.append(
+            {
+                "actual_path": _trim_string(row.get("actual_path")),
+                "actual_signature": _normalize_signature(row.get("actual_signature")),
+                "downstream_label": _trim_string(row.get("downstream_label")),
+                "expected_path": _trim_string(row.get("expected_path")),
+                "expected_signature": _normalize_signature(row.get("expected_signature")),
+                "note": _trim_string(row.get("note")),
+                "status": status,
+                "symbol": _trim_string(row.get("symbol")),
+                "upstream_label": _trim_string(row.get("upstream_label")),
+            }
+        )
+    canonical_rows.sort(
+        key=lambda row: (
+            row["downstream_label"],
+            row["upstream_label"],
+            row["symbol"],
+            row["status"],
+            row["expected_path"],
+            row["actual_path"],
+            row["expected_signature"],
+            row["actual_signature"],
+            row["note"],
+        )
+    )
+    return json.dumps(canonical_rows, sort_keys=True, separators=(",", ":"), ensure_ascii=True)

--- a/megaplan/orchestration/prep_research.py
+++ b/megaplan/orchestration/prep_research.py
@@ -79,6 +79,7 @@ def minimal_prep_metrics() -> dict[str, Any]:
     return {
         "area_count": 0,
         "fanout_count": 0,
+        "forced_count": 0,
         "completed_count": 0,
         "partial_count": 0,
         "timed_out_count": 0,
@@ -101,6 +102,7 @@ def minimal_prep_metrics() -> dict[str, Any]:
             "existing_files": [],
             "missing_files": [],
             "shared_files": [],
+            "to_be_built_files": [],
         },
         "stage_metrics": {
             "triage": _stage_metrics(),
@@ -288,13 +290,118 @@ def _artifact_text(plan_dir: Path, filename: str, text: str) -> str:
     return _hash_file(plan_dir / filename)
 
 
-def _cap_research_areas(state: PlanState, areas: list[Any]) -> tuple[list[dict[str, Any]], int]:
+def _forced_upstream_areas(state: PlanState) -> list[dict[str, Any]]:
+    """Derive one forced prep research area per upstream dependency label.
+
+    Reads ``state.meta.chain_policy.contract_context`` and creates an area
+    for each ``dependency_label`` with a brief covering the upstream planned
+    interfaces so downstream prep research accounts for the contract surface.
+    """
+    meta = state.get("meta")
+    if not isinstance(meta, dict):
+        return []
+    chain_policy = meta.get("chain_policy")
+    if not isinstance(chain_policy, dict):
+        return []
+    contract_context = chain_policy.get("contract_context")
+    if not isinstance(contract_context, dict):
+        return []
+    if contract_context.get("plan_only") is not True:
+        return []
+    dep_labels = contract_context.get("dependency_labels")
+    if not isinstance(dep_labels, list) or not dep_labels:
+        return []
+    upstream_contracts = contract_context.get("upstream_contracts")
+    if not isinstance(upstream_contracts, list):
+        upstream_contracts = []
+
+    # Build a label→paths index from upstream contracts
+    label_paths: dict[str, set[str]] = {}
+    for item in upstream_contracts:
+        if not isinstance(item, dict):
+            continue
+        label = str(item.get("milestone_label") or item.get("label") or "").strip()
+        if not label:
+            continue
+        provides = item.get("provides", [])
+        if not isinstance(provides, list):
+            provides = []
+        paths = label_paths.setdefault(label, set())
+        for provide in provides:
+            if not isinstance(provide, dict):
+                continue
+            for interface in provide.get("interfaces", []) or []:
+                if isinstance(interface, dict):
+                    path = str(interface.get("path", "")).strip()
+                    if path:
+                        paths.add(path)
+
+    forced: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    for label in dep_labels:
+        if not isinstance(label, str):
+            continue
+        label = label.strip()
+        if not label or label in seen_ids:
+            continue
+        seen_ids.add(label)
+        paths = sorted(label_paths.get(label, []))
+        suggested_files = paths[:10]  # keep the area focused
+        forced.append({
+            "id": f"upstream-{label}",
+            "area": f"Upstream contract: {label}",
+            "brief": (
+                f"Research planned upstream interfaces provided by milestone `{label}` "
+                f"so prep can account for contract-surface shape, path expectations, "
+                f"and signature constraints during downstream planning."
+            ),
+            "suggested_files": suggested_files,
+        })
+    return forced
+
+
+def _deduplicate_areas(
+    forced: list[dict[str, Any]],
+    triage_areas: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Insert forced areas before triage areas, keeping the first seen ID.
+
+    Returns a list where forced areas appear first (preserving insertion order)
+    and triage areas that share an ``id`` with a forced area are dropped.
+    """
+    seen: set[str] = set()
+    merged: list[dict[str, Any]] = []
+    for area in forced:
+        aid = str(area.get("id") or area.get("area") or "").strip()
+        if aid and aid not in seen:
+            seen.add(aid)
+            merged.append(area)
+    for area in triage_areas:
+        aid = str(area.get("id") or area.get("area") or "").strip()
+        if aid and aid not in seen:
+            seen.add(aid)
+            merged.append(area)
+    return merged
+
+
+def _cap_research_areas(
+    state: PlanState,
+    areas: list[Any],
+    *,
+    forced_count: int = 0,
+) -> tuple[list[dict[str, Any]], int]:
     cap = prep_area_cap(state)
     normalized: list[dict[str, Any]] = []
     for index, area in enumerate(areas):
         if not isinstance(area, dict):
             raise CliError("parse_error", f"prep triage area at index {index} must be an object")
         normalized.append(dict(area))
+
+    # Always retain forced areas even when forced_count > cap.
+    if forced_count >= cap:
+        # All slots go to forced areas; triage areas are culled.
+        return normalized[:forced_count], cap
+
     return normalized[:cap], cap
 
 
@@ -302,6 +409,7 @@ def _prep_metrics(
     *,
     original_area_count: int,
     capped_area_count: int,
+    forced_count: int = 0,
     findings: list[dict[str, Any]],
     fanout: GenericScatterResult,
     triage_worker: WorkerResult,
@@ -334,6 +442,7 @@ def _prep_metrics(
     return {
         "area_count": original_area_count,
         "fanout_count": capped_area_count,
+        "forced_count": forced_count,
         "completed_count": sum(1 for item in findings if item.get("status") == "complete"),
         "partial_count": sum(1 for item in findings if item.get("status") == "partial"),
         "timed_out_count": sum(1 for item in findings if item.get("status") == "timed_out"),
@@ -368,6 +477,7 @@ def _prep_metrics(
             "existing_files": [],
             "missing_files": [],
             "shared_files": [],
+            "to_be_built_files": [],
         },
         "stage_metrics": {
             "triage": triage_stage,
@@ -446,7 +556,69 @@ def _gap_notes(
     missing_files = cross_reference.get("missing_files", [])
     if missing_files:
         notes.append("Referenced files missing during bounded cross-reference: " + ", ".join(missing_files))
+    to_be_built = cross_reference.get("to_be_built_files", [])
+    if to_be_built:
+        labels = sorted(set(
+            str(item["upstream_milestone"])
+            for item in to_be_built
+            if isinstance(item, dict) and item.get("upstream_milestone")
+        ))
+        paths = sorted(set(
+            str(item["path"])
+            for item in to_be_built
+            if isinstance(item, dict) and item.get("path")
+        ))
+        notes.append(
+            "Files expected from upstream milestone(s) "
+            + ", ".join(labels)
+            + " (not yet built locally): "
+            + ", ".join(paths)
+        )
     return notes
+
+
+def _collect_upstream_provided_paths(state: PlanState) -> dict[str, str]:
+    """Return a mapping of provided path → upstream milestone label.
+
+    Reads ``state.meta.chain_policy.contract_context.upstream_contracts``
+    and extracts interface paths keyed by their upstream milestone so
+    ``_cross_reference_prep_output`` can classify them as to-be-built files.
+    """
+    meta = state.get("meta")
+    if not isinstance(meta, dict):
+        return {}
+    chain_policy = meta.get("chain_policy")
+    if not isinstance(chain_policy, dict):
+        return {}
+    contract_context = chain_policy.get("contract_context")
+    if not isinstance(contract_context, dict):
+        return {}
+    if contract_context.get("plan_only") is not True:
+        return {}
+    upstream_contracts = contract_context.get("upstream_contracts")
+    if not isinstance(upstream_contracts, list):
+        return {}
+
+    path_map: dict[str, str] = {}
+    for item in upstream_contracts:
+        if not isinstance(item, dict):
+            continue
+        label = str(item.get("milestone_label") or item.get("label") or "").strip()
+        if not label:
+            continue
+        provides = item.get("provides")
+        if not isinstance(provides, list):
+            provides = []
+        for provide in provides:
+            if not isinstance(provide, dict):
+                continue
+            for interface in provide.get("interfaces", []) or []:
+                if not isinstance(interface, dict):
+                    continue
+                path = str(interface.get("path", "")).strip()
+                if path and path not in path_map:
+                    path_map[path] = label
+    return path_map
 
 
 def _cross_reference_prep_output(
@@ -454,6 +626,7 @@ def _cross_reference_prep_output(
     root: Path,
     findings: list[dict[str, Any]],
     prep_payload: dict[str, Any],
+    upstream_provided_paths: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     finding_files = {
         str(path).strip()
@@ -467,11 +640,24 @@ def _cross_reference_prep_output(
         if isinstance(item, dict) and str(item.get("file_path") or "").strip()
     }
     checked_files = sorted(finding_files | prep_files)
+
+    # Classify upstream-provided paths as to-be-built before filesystem checks.
+    provided = upstream_provided_paths or {}
+    to_be_built_files: list[dict[str, Any]] = []
+    for path in checked_files:
+        label = provided.get(path)
+        if label:
+            to_be_built_files.append({"path": path, "upstream_milestone": label})
+
+    # Only report a file as missing when it is NOT an upstream-provided path
+    # (those are expected to not exist locally yet).
+    upstream_path_set = set(provided.keys())
     existing_files = sorted(
         path for path in checked_files if (root / path).exists()
     )
     missing_files = sorted(
-        path for path in checked_files if not (root / path).exists()
+        path for path in checked_files
+        if not (root / path).exists() and path not in upstream_path_set
     )
     return {
         "performed": bool(checked_files),
@@ -479,6 +665,7 @@ def _cross_reference_prep_output(
         "existing_files": existing_files,
         "missing_files": missing_files,
         "shared_files": sorted(finding_files & prep_files),
+        "to_be_built_files": to_be_built_files,
     }
 
 
@@ -490,9 +677,15 @@ def _assemble_prep_outputs(
     findings: list[dict[str, Any]],
     metrics: dict[str, Any],
     prep_payload: dict[str, Any],
+    upstream_provided_paths: dict[str, str] | None = None,
 ) -> tuple[dict[str, Any], str]:
     overlaps = _research_overlap_groups(findings)
-    cross_reference = _cross_reference_prep_output(root=root, findings=findings, prep_payload=prep_payload)
+    cross_reference = _cross_reference_prep_output(
+        root=root,
+        findings=findings,
+        prep_payload=prep_payload,
+        upstream_provided_paths=upstream_provided_paths,
+    )
     contradiction_notes = _contradiction_notes(findings, overlaps)
     gap_notes = _gap_notes(findings, prep_payload, cross_reference)
     metrics["overlap_groups"] = overlaps
@@ -584,6 +777,14 @@ def _prep_dossier_text(
     else:
         lines.append("- (none)")
     cross_reference = metrics.get("cross_reference", {})
+    to_be_built = cross_reference.get("to_be_built_files", [])
+    to_be_built_lines: list[str] = []
+    if to_be_built:
+        for item in to_be_built:
+            if isinstance(item, dict):
+                to_be_built_lines.append(
+                    f"- {item.get('path', '?')} (from {item.get('upstream_milestone', '?')})"
+                )
     lines.extend(
         [
             "",
@@ -592,6 +793,13 @@ def _prep_dossier_text(
             f"- Performed: {'yes' if cross_reference.get('performed') else 'no'}",
             f"- Shared files: {', '.join(cross_reference.get('shared_files', [])) or '(none)'}",
             f"- Missing files: {', '.join(cross_reference.get('missing_files', [])) or '(none)'}",
+        ]
+    )
+    if to_be_built_lines:
+        lines.append(f"- Expected from upstream (not yet built):")
+        lines.extend(to_be_built_lines)
+    lines.extend(
+        [
             "",
             "## Metrics",
             "",
@@ -997,7 +1205,12 @@ def run_prep_orchestration(
     areas = triage.get("areas", [])
     if not isinstance(areas, list):
         raise CliError("parse_error", "prep triage output field 'areas' must be a list")
-    capped_areas, _area_cap = _cap_research_areas(state, areas)
+    forced_areas = _forced_upstream_areas(state)
+    upstream_provided_paths = _collect_upstream_provided_paths(state)
+    merged_areas = _deduplicate_areas(forced_areas, areas)
+    capped_areas, _area_cap = _cap_research_areas(
+        state, merged_areas, forced_count=len(forced_areas),
+    )
 
     if not capped_areas:
         payload = write_skip_prep_artifacts(plan_dir)
@@ -1039,6 +1252,7 @@ def run_prep_orchestration(
     metrics = _prep_metrics(
         original_area_count=len(areas),
         capped_area_count=len(capped_areas),
+        forced_count=len(forced_areas),
         findings=findings,
         fanout=fanout,
         triage_worker=triage_worker,
@@ -1051,6 +1265,7 @@ def run_prep_orchestration(
         findings=findings,
         metrics=metrics,
         prep_payload=compatible_payload,
+        upstream_provided_paths=upstream_provided_paths,
     )
     _artifact_json(plan_dir, "research.json", {"findings": findings})
     metrics_hash = _artifact_json(plan_dir, "prep_metrics.json", metrics)

--- a/megaplan/pipelines/creative/prompts/critique_creative.py
+++ b/megaplan/pipelines/creative/prompts/critique_creative.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import textwrap
 from pathlib import Path
+from typing import Any, Mapping
 from typing import Any
 
 from megaplan._core import configured_robustness, creative_form_id, read_json
@@ -105,7 +106,9 @@ def _critique_creative_prompt(
     root: Path | None = None,
     *,
     form: Form | None = None,
+    contract_context: Mapping[str, Any] | None = None,
 ) -> str:
+    del contract_context
     context = _critique_context(state, plan_dir, root)
     active_form = form or get_form(creative_form_id(state) or "joke")
     robustness = configured_robustness(state)

--- a/megaplan/pipelines/creative/prompts/prep_joke.py
+++ b/megaplan/pipelines/creative/prompts/prep_joke.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import textwrap
 from pathlib import Path
+from typing import Mapping
 
 from megaplan.types import PlanState
 
@@ -15,7 +16,13 @@ def _declared_primary_criterion(state: PlanState) -> str:
     return ""
 
 
-def _prep_joke_prompt(state: PlanState, plan_dir: Path, root: Path | None = None) -> str:
+def _prep_joke_prompt(
+    state: PlanState,
+    plan_dir: Path,
+    root: Path | None = None,
+    contract_context: Mapping[str, object] | None = None,
+) -> str:
+    del contract_context
     del root
     project_dir = Path(state["config"]["project_dir"])
     output_path = plan_dir / "prep.json"

--- a/megaplan/prompts/__init__.py
+++ b/megaplan/prompts/__init__.py
@@ -16,6 +16,7 @@ from ._shared import (
     _finalize_debt_block,
     _gate_debt_block,
     _grouped_debt_for_prompt,
+    _render_contracts_block,
     _planning_debt_block,
     _render_prep_block,
     _resolve_prompt_root,
@@ -243,11 +244,30 @@ def create_prompt(
             f"expected one of {sorted(_AGENT_REGISTRY)}",
         ) from exc
     builder = _resolve_builder(builders, step, state, label)
+    contract_context = prompt_kwargs.pop("contract_context", None)
     if step == "review":
         return _prepend_harness_guard(builder(state, plan_dir, **prompt_kwargs))
+    if step == "plan":
+        return _prepend_harness_guard(builder(state, plan_dir, contract_context=contract_context))
+    if step == "prep":
+        return _prepend_harness_guard(builder(state, plan_dir, root=root, contract_context=contract_context))
+    if step == "prep-triage":
+        return _prepend_harness_guard(builder(state, plan_dir, root=root, contract_context=contract_context))
+    if step == "prep-distill":
+        allowed = {}
+        for key in ("triage", "findings", "output_path", "dossier_path", "metrics_path"):
+            if key in prompt_kwargs:
+                allowed[key] = prompt_kwargs.pop(key)
+        return _prepend_harness_guard(
+            builder(state, plan_dir, root=root, contract_context=contract_context, **allowed)
+        )
+    if step in ("critique", "critique_evaluator"):
+        return _prepend_harness_guard(
+            builder(state, plan_dir, root=root, contract_context=contract_context, **prompt_kwargs)
+        )
+    if step == "gate":
+        return _prepend_harness_guard(builder(state, plan_dir, root=root, contract_context=contract_context))
     if step in _ROOT_BEARING_STEPS:
-        if step in ("critique", "critique_evaluator") and prompt_kwargs:
-            return _prepend_harness_guard(builder(state, plan_dir, root=root, **prompt_kwargs))
         return _prepend_harness_guard(builder(state, plan_dir, root=root))
     return _prepend_harness_guard(builder(state, plan_dir))
 
@@ -307,6 +327,7 @@ __all__ = [
     "_prep_prompt",
     "_prep_research_prompt",
     "_prep_triage_prompt",
+    "_render_contracts_block",
     "_review_doc_prompt",
     "_review_joke_prompt",
     "_write_critique_template",

--- a/megaplan/prompts/_shared.py
+++ b/megaplan/prompts/_shared.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import textwrap
 from pathlib import Path
+from typing import Any, Mapping
 
 from megaplan._core import (
     debt_by_subsystem,
@@ -182,6 +183,125 @@ def _finalize_debt_block(plan_dir: Path, root: Path | None) -> str:
         {json_dump(watch_lines).strip()}
         """
     ).strip()
+
+
+def _resolve_contract_context(
+    state: Mapping[str, Any],
+    contract_context: Mapping[str, Any] | None = None,
+) -> Mapping[str, Any] | None:
+    if contract_context is not None:
+        return contract_context
+    meta = state.get("meta")
+    if not isinstance(meta, Mapping):
+        return None
+    chain_policy = meta.get("chain_policy")
+    if not isinstance(chain_policy, Mapping):
+        return None
+    resolved = chain_policy.get("contract_context")
+    return resolved if isinstance(resolved, Mapping) else None
+
+
+def _render_contracts_block(
+    contract_context: Mapping[str, Any] | None,
+    *,
+    audience: str,
+) -> str:
+    if not isinstance(contract_context, Mapping):
+        return ""
+    if contract_context.get("plan_only") is not True:
+        return ""
+
+    upstream_contracts = contract_context.get("upstream_contracts")
+    if isinstance(upstream_contracts, Mapping):
+        contracts = [
+            {"milestone_label": label, **(value if isinstance(value, Mapping) else {})}
+            for label, value in upstream_contracts.items()
+            if isinstance(label, str)
+        ]
+    elif isinstance(upstream_contracts, list):
+        contracts = [item for item in upstream_contracts if isinstance(item, Mapping)]
+    else:
+        contracts = []
+    if not contracts:
+        return ""
+
+    intro_map = {
+        "plan": (
+            "Planning-pass upstream contract context. These interfaces are planned upstream surfaces, "
+            "not executed evidence; plan against them without assuming they already exist in the repo."
+        ),
+        "prep": (
+            "Planning-pass upstream contract context. Use these planned upstream interfaces to guide prep "
+            "and cross-reference work; they are expected future surfaces, not missing-file defects."
+        ),
+        "prep-triage": (
+            "Planning-pass upstream contract context. Factor these upstream planned interfaces into the "
+            "research-area split when they materially shape what the downstream milestone must investigate."
+        ),
+        "prep-distill": (
+            "Planning-pass upstream contract context. Preserve these upstream planned interfaces in the "
+            "final prep view only when they materially affect the downstream implementation plan."
+        ),
+        "critique": (
+            "Deferred-verification planning-pass contract context. These upstream-provided interfaces are "
+            "planned dependency surfaces, not executed code. Do NOT flag missing files, missing symbols, "
+            "or unresolved references to these interfaces as defects — verification is deferred until the "
+            "upstream milestone executes. Treat these as interface contracts the plan should honor, "
+            "not as missing-code gaps."
+        ),
+        "critique_evaluator": (
+            "Deferred-verification planning-pass contract context. These upstream interfaces are planned "
+            "surfaces from dependency milestones that have not yet executed. When assigning critique lenses, "
+            "do not route existence/availability checks against these interfaces — verification is deferred. "
+            "The plan is a contract consumer, not an implementer of these surfaces."
+        ),
+        "gate": (
+            "Deferred-verification planning-pass contract context. These upstream-provided interfaces are "
+            "commitments from dependency milestones, not executed artifacts. Do not treat missing upstream "
+            "files, symbols, or artifacts as blocking defects — the gate decision is about THIS milestone's "
+            "plan quality, not upstream completion status."
+        ),
+        "generic": (
+            "Planning-pass upstream contract context. These interfaces are planned dependency surfaces, "
+            "not executed evidence."
+        ),
+    }
+    intro = intro_map.get(audience, intro_map["generic"])
+    lines = ["Planning-pass upstream contract context:", intro, ""]
+
+    for item in contracts:
+        label = str(item.get("milestone_label") or item.get("label") or "?").strip() or "?"
+        lines.append(f"- Milestone `{label}`")
+        provides = item.get("provides", [])
+        if not provides and isinstance(item.get("contract"), Mapping):
+            provides = item["contract"].get("provides", [])
+        if not isinstance(provides, list):
+            provides = []
+        emitted = False
+        for provide in provides:
+            if not isinstance(provide, Mapping):
+                continue
+            name = str(provide.get("name", "")).strip() or "Unnamed provide"
+            description = str(provide.get("description", "")).strip()
+            details = f": {description}" if description else ""
+            lines.append(f"  - `{name}`{details}")
+            interfaces = provide.get("interfaces", [])
+            if not isinstance(interfaces, list):
+                interfaces = []
+            for interface in interfaces:
+                if not isinstance(interface, Mapping):
+                    continue
+                symbol = str(interface.get("symbol", "")).strip() or "<unnamed>"
+                path = str(interface.get("path", "")).strip() or "<unknown path>"
+                signature = str(interface.get("signature", "")).strip()
+                rendered = f"    - `{symbol}` at `{path}`"
+                if signature:
+                    rendered += f" with signature `{signature}`"
+                lines.append(rendered)
+                emitted = True
+        if not emitted:
+            lines.append("  - No upstream interfaces recorded.")
+    return "\n".join(lines)
 
 
 

--- a/megaplan/prompts/critique.py
+++ b/megaplan/prompts/critique.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import difflib
 import textwrap
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 
 from megaplan.forms.provocations import select_active_checks
 from megaplan._core import (
@@ -271,6 +271,7 @@ def _build_critique_prompt(
     critique_review_block: str,
     revise_context: str = "",
     selection_why: dict[str, str] | None = None,
+    contracts_block: str = "",
 ) -> str:
     revise_block = ""
     if revise_context:
@@ -290,6 +291,7 @@ def _build_critique_prompt(
         f"""
         You are an independent reviewer. Critique the plan against the actual repository.
 
+        {contracts_block}
         Project directory:
         {context["project_dir"]}
 
@@ -378,7 +380,14 @@ def _critique_prompt(
     expected_ids: list[str] | None = None,
     revise_context: str = "",
     selection_why: dict[str, str] | None = None,
+    contract_context: Mapping[str, Any] | None = None,
 ) -> str:
+    from ._shared import _render_contracts_block, _resolve_contract_context
+
+    contracts_block = _render_contracts_block(
+        _resolve_contract_context(state, contract_context),
+        audience="critique",
+    )
     context = _critique_context(state, plan_dir, root)
     if active_checks is None:
         active_checks = select_active_checks(state, context["robustness"], plan_dir=plan_dir)
@@ -435,7 +444,11 @@ def _critique_prompt(
             Workflow: read the file → investigate → read file again → add findings → write file back.
         """
         ).strip()
-    return _build_critique_prompt(state, context, critique_review_block, revise_context=revise_context, selection_why=selection_why)
+    return _build_critique_prompt(
+        state, context, critique_review_block,
+        revise_context=revise_context, selection_why=selection_why,
+        contracts_block=contracts_block,
+    )
 
 
 def single_check_critique_prompt(

--- a/megaplan/prompts/critique_evaluator.py
+++ b/megaplan/prompts/critique_evaluator.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import textwrap
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 
 from megaplan._core import (
     intent_and_notes_block,
@@ -238,6 +238,7 @@ def _critique_evaluator_prompt(
     plan_diff: str | None = None,
     prep_dossier_text: str | None = None,
     prep_metrics: dict | None = None,
+    contract_context: Mapping[str, Any] | None = None,
 ) -> str:
     """Assemble the critique evaluator prompt.
 
@@ -257,6 +258,12 @@ def _critique_evaluator_prompt(
     verify block is rendered that asks the evaluator to adjudicate each
     resolution claim against the plan diff.
     """
+    from ._shared import _render_contracts_block, _resolve_contract_context
+
+    contracts_block = _render_contracts_block(
+        _resolve_contract_context(state, contract_context),
+        audience="critique_evaluator",
+    )
     project_dir = Path(state["config"]["project_dir"])
     latest_plan = latest_plan_path(plan_dir, state).read_text(encoding="utf-8")
     latest_meta = read_json(latest_plan_meta_path(plan_dir, state))
@@ -354,6 +361,7 @@ def _critique_evaluator_prompt(
         You are the Critique Evaluator. Your job is to decide which critic models
         will apply which critique lenses for this plan.
 
+        {contracts_block}
         Project directory:
         {project_dir}
 

--- a/megaplan/prompts/gate.py
+++ b/megaplan/prompts/gate.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import textwrap
 from pathlib import Path
+from typing import Any, Mapping
 
 from megaplan._core import (
     configured_robustness,
@@ -30,7 +31,18 @@ def _iteration_pressure_block(state: PlanState, plan_dir: Path) -> str:
     return render_pressure_table(entries)
 
 
-def _gate_prompt(state: PlanState, plan_dir: Path, root: Path | None = None) -> str:
+def _gate_prompt(
+    state: PlanState,
+    plan_dir: Path,
+    root: Path | None = None,
+    contract_context: Mapping[str, Any] | None = None,
+) -> str:
+    from ._shared import _render_contracts_block, _resolve_contract_context
+
+    contracts_block = _render_contracts_block(
+        _resolve_contract_context(state, contract_context),
+        audience="gate",
+    )
     project_dir = Path(state["config"]["project_dir"])
     latest_plan = latest_plan_path(plan_dir, state).read_text(encoding="utf-8")
     latest_meta = read_json(latest_plan_meta_path(plan_dir, state))
@@ -76,6 +88,7 @@ def _gate_prompt(state: PlanState, plan_dir: Path, root: Path | None = None) -> 
         f"""
         You are the gatekeeper for the megaplan workflow. Make the continuation decision directly.
 
+        {contracts_block}
         Project directory:
         {project_dir}
 

--- a/megaplan/prompts/planning.py
+++ b/megaplan/prompts/planning.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import textwrap
 from pathlib import Path
+from typing import Any, Mapping
 
 from megaplan._core import (
     creative_form_id,
@@ -17,7 +18,7 @@ from megaplan._core import (
 from megaplan.forms import get_form
 from megaplan.types import PlanState
 
-from ._shared import _render_prep_block
+from ._shared import _render_contracts_block, _render_prep_block, _resolve_contract_context
 
 
 def _render_open_tickets(state: PlanState, plan_dir: Path) -> str:
@@ -186,9 +187,17 @@ def _prep_context_sections(state: PlanState, plan_dir: Path) -> tuple[Path, Path
     return project_dir, prep_path, direction_block, notes_block
 
 
-def _plan_prompt(state: PlanState, plan_dir: Path) -> str:
+def _plan_prompt(
+    state: PlanState,
+    plan_dir: Path,
+    contract_context: Mapping[str, Any] | None = None,
+) -> str:
     project_dir = Path(state["config"]["project_dir"])
     prep_block, prep_instruction = _render_prep_block(plan_dir)
+    contracts_block = _render_contracts_block(
+        _resolve_contract_context(state, contract_context),
+        audience="plan",
+    )
     if prep_instruction:
         prep_instruction += (
             " Open questions in the brief are candidate concerns, not mandates —"
@@ -280,6 +289,8 @@ def _plan_prompt(state: PlanState, plan_dir: Path) -> str:
 
         {intent_and_notes_block(state)}
 
+        {contracts_block}
+
         Project directory:
         {project_dir}
 
@@ -324,10 +335,19 @@ def _plan_prompt(state: PlanState, plan_dir: Path) -> str:
     ).strip()
 
 
-def _prep_prompt(state: PlanState, plan_dir: Path, root: Path | None = None) -> str:
+def _prep_prompt(
+    state: PlanState,
+    plan_dir: Path,
+    root: Path | None = None,
+    contract_context: Mapping[str, Any] | None = None,
+) -> str:
     del root
     project_dir, output_path, direction_block, notes_block = _prep_context_sections(
         state, plan_dir
+    )
+    contracts_block = _render_contracts_block(
+        _resolve_contract_context(state, contract_context),
+        audience="prep",
     )
 
     return textwrap.dedent(
@@ -343,6 +363,8 @@ def _prep_prompt(state: PlanState, plan_dir: Path, root: Path | None = None) -> 
         {direction_block}
 
         {notes_block}
+
+        {contracts_block}
 
         First, assess: does this task need codebase investigation?
 
@@ -387,11 +409,18 @@ def _prep_prompt(state: PlanState, plan_dir: Path, root: Path | None = None) -> 
 
 
 def _prep_triage_prompt(
-    state: PlanState, plan_dir: Path, root: Path | None = None
+    state: PlanState,
+    plan_dir: Path,
+    root: Path | None = None,
+    contract_context: Mapping[str, Any] | None = None,
 ) -> str:
     del root
     project_dir, _prep_path, direction_block, notes_block = _prep_context_sections(
         state, plan_dir
+    )
+    contracts_block = _render_contracts_block(
+        _resolve_contract_context(state, contract_context),
+        audience="prep-triage",
     )
     output_path = plan_dir / "prep_triage.json"
     return textwrap.dedent(
@@ -407,6 +436,8 @@ def _prep_triage_prompt(
         {direction_block}
 
         {notes_block}
+
+        {contracts_block}
 
         Goals:
         - Decide whether prep can skip research entirely.
@@ -490,10 +521,15 @@ def _prep_distill_prompt(
     dossier_path: Path | None = None,
     metrics_path: Path | None = None,
     root: Path | None = None,
+    contract_context: Mapping[str, Any] | None = None,
 ) -> str:
     del root
     project_dir, prep_path, direction_block, notes_block = _prep_context_sections(
         state, plan_dir
+    )
+    contracts_block = _render_contracts_block(
+        _resolve_contract_context(state, contract_context),
+        audience="prep-distill",
     )
     target_path = output_path or prep_path
     dossier_target = dossier_path or (plan_dir / "prep_dossier.md")
@@ -513,6 +549,8 @@ def _prep_distill_prompt(
         {direction_block}
 
         {notes_block}
+
+        {contracts_block}
 
         Triage framing:
         {json_dump(triage).strip()}

--- a/megaplan/prompts/prep_doc.py
+++ b/megaplan/prompts/prep_doc.py
@@ -4,11 +4,18 @@ from __future__ import annotations
 
 import textwrap
 from pathlib import Path
+from typing import Mapping
 
 from megaplan.types import PlanState
 
 
-def _prep_doc_prompt(state: PlanState, plan_dir: Path, root: Path | None = None) -> str:
+def _prep_doc_prompt(
+    state: PlanState,
+    plan_dir: Path,
+    root: Path | None = None,
+    contract_context: Mapping[str, Any] | None = None,
+) -> str:
+    del contract_context
     del root
     project_dir = Path(state["config"]["project_dir"])
     output_path = plan_dir / "prep.json"

--- a/megaplan/schemas/sprint1.py
+++ b/megaplan/schemas/sprint1.py
@@ -42,6 +42,7 @@ PlanArtifactRole = Literal[
     "gate_signals",
     "finalize",
     "finalize_snapshot",
+    "contract",
     "execution_batch",
     "execution",
     "execution_audit",

--- a/megaplan/store/plan_repository.py
+++ b/megaplan/store/plan_repository.py
@@ -248,6 +248,8 @@ class PlanRepository:
             return "raw_worker_output"
         if name == "finalize.json" or name == "finalize_snapshot.json":
             return "finalize_snapshot" if name == "finalize_snapshot.json" else "finalize"
+        if name == "contract.json":
+            return "contract"
         if name.startswith("critique"):
             return "critique"
         if name == "faults.json":

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -33,6 +33,7 @@ from megaplan.chain import (
     save_chain_state,
 )
 from megaplan.chain.git_ops import CommitResult
+from megaplan.handlers.finalize import _write_finalize_artifacts
 from megaplan.types import CliError, STATE_FINALIZED
 
 
@@ -745,14 +746,16 @@ def test_commit_plan_artifacts_force_adds_ignored_files_on_base_and_restores_bra
     plan_dir.mkdir(parents=True)
     state_path = plan_dir / "state.json"
     final_path = plan_dir / "final.md"
+    contract_path = plan_dir / "contract.json"
     state_path.write_text('{"current_state":"finalized"}\n', encoding="utf-8")
     final_path.write_text("final review\n", encoding="utf-8")
+    contract_path.write_text('{"provides":[],"assumes":[]}\n', encoding="utf-8")
 
     result = commit_plan_artifacts_to_base(
         tmp_path,
         "main",
         "plan-m1",
-        [state_path, final_path, plan_dir / "optional.json"],
+        [state_path, final_path, contract_path, plan_dir / "optional.json"],
         push_enabled=False,
     )
 
@@ -763,6 +766,7 @@ def test_commit_plan_artifacts_force_adds_ignored_files_on_base_and_restores_bra
     tracked_on_main = _git(tmp_path, "ls-tree", "-r", "--name-only", "main").stdout.splitlines()
     assert ".megaplan/plans/plan-m1/state.json" in tracked_on_main
     assert ".megaplan/plans/plan-m1/final.md" in tracked_on_main
+    assert ".megaplan/plans/plan-m1/contract.json" in tracked_on_main
 
 
 def test_commit_plan_artifacts_rejects_unrelated_dirty_worktree(tmp_path: Path) -> None:
@@ -1001,6 +1005,36 @@ def test_chain_state_to_dict_and_from_dict_roundtrip_with_sync() -> None:
     assert reloaded.last_pushed_commit == "abc123"
     assert reloaded.dirty_flag is False
     assert reloaded.sync_state == "clean"
+
+
+def test_chain_state_from_dict_defaults_reground_decisions_for_old_json() -> None:
+    state = ChainState.from_dict({"current_milestone_index": 1, "retry_counts": {"m1": 2}})
+
+    assert state.reground_decisions == {}
+    assert state.retry_counts == {"m1": 2}
+
+
+def test_chain_state_roundtrips_reground_decisions() -> None:
+    state = ChainState(
+        current_milestone_index=1,
+        current_plan_name="plan-m2",
+        reground_decisions={
+            "m2": {
+                "last_fingerprint": "abc123",
+                "consecutive_count": 2,
+                "decision": "stop",
+                "timestamp": "2026-05-30T10:00:00Z",
+                "summary": "signature changed",
+                "rows": [{"symbol": "Runtime.status", "status": "MISMATCH"}],
+            }
+        },
+    )
+
+    raw = state.to_dict()
+    assert raw["reground_decisions"] == state.reground_decisions
+
+    reloaded = ChainState.from_dict(raw)
+    assert reloaded.reground_decisions == state.reground_decisions
 
 
 def test_format_chain_status_pretty(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
@@ -2301,6 +2335,7 @@ def test_run_chain_plan_mode_records_finalized_only_after_artifact_durability(tm
         assert ".megaplan/plans/plan-m1/final.md" in relpaths
         assert ".megaplan/plans/plan-m1/finalize.json" in relpaths
         assert ".megaplan/plans/plan-m1/state.json" in relpaths
+        assert ".megaplan/plans/plan-m1/contract.json" in relpaths
         assert idea.relative_to(tmp_path).as_posix() in relpaths
         assert load_chain_state(spec_path).completed == []
         return CommitResult(
@@ -2407,8 +2442,8 @@ def test_run_chain_two_pass_modes_finalize_then_execute_milestones_in_order(tmp_
     ensure_pr.assert_not_called()
     commit_push.assert_not_called()
     assert planned_commits == [
-        ("setup/cloud", "plan-m1", ["final.md", "finalize.json", "m1.txt", "state.json"]),
-        ("setup/cloud", "plan-m2", ["final.md", "finalize.json", "m2.txt", "state.json"]),
+        ("setup/cloud", "plan-m1", ["contract.json", "final.md", "finalize.json", "m1.txt", "state.json"]),
+        ("setup/cloud", "plan-m2", ["contract.json", "final.md", "finalize.json", "m2.txt", "state.json"]),
     ]
     saved = load_chain_state(spec_path)
     assert [(entry["label"], entry["status"], entry["plan_branch"]) for entry in saved.completed] == [
@@ -3319,6 +3354,1014 @@ def test_load_runtime_policy_logs_corrupt_json(
     caplog.set_level("WARNING", logger="megaplan")
     assert chain_module.load_runtime_policy(spec_path) == {}
     assert any("M3A_WARN_CHAIN_POLICY_READ" in record.getMessage() for record in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# T9/T10/T12/T13: contract metadata, review, and execute reground decisions
+# ---------------------------------------------------------------------------
+
+
+def _write_contract(root: Path, plan: str, contract: dict[str, object]) -> None:
+    plan_dir = root / ".megaplan" / "plans" / plan
+    plan_dir.mkdir(parents=True, exist_ok=True)
+    (plan_dir / "contract.json").write_text(json.dumps(contract), encoding="utf-8")
+
+
+def _contract_finalize_payload(
+    *,
+    provides: list[dict[str, object]],
+    assumes: list[dict[str, object]],
+    meta_commentary: str,
+) -> dict[str, object]:
+    return {
+        "tasks": [],
+        "watch_items": [],
+        "sense_checks": [],
+        "meta_commentary": meta_commentary,
+        "validation": {
+            "plan_steps_covered": [],
+            "orphan_tasks": [],
+            "completeness_notes": "ok",
+            "coverage_complete": True,
+        },
+        "provides": provides,
+        "assumes": assumes,
+    }
+
+
+def _write_finalized_contract_artifacts(
+    root: Path,
+    plan: str,
+    *,
+    payload: dict[str, object],
+) -> Path:
+    plan_dir = root / ".megaplan" / "plans" / plan
+    plan_dir.mkdir(parents=True, exist_ok=True)
+    state_path = plan_dir / "state.json"
+    if state_path.exists():
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+    else:
+        state = {"name": plan, "config": {}}
+    state["name"] = plan
+    state["current_state"] = STATE_FINALIZED
+    state["iteration"] = state.get("iteration", 1) or 1
+    config = state.setdefault("config", {})
+    if not isinstance(config, dict):
+        state["config"] = config = {}
+    config["project_dir"] = str(root)
+    config["mode"] = "doc"
+    state.setdefault("plan_versions", [{"version": 1, "file": "plan_v1.md"}])
+    (plan_dir / "plan_v1.md").write_text("# Plan\n", encoding="utf-8")
+    _write_finalize_artifacts(plan_dir, payload, state)
+    state_path.write_text(json.dumps(state) + "\n", encoding="utf-8")
+    return plan_dir
+
+
+def _write_plan_only_finalized_state(root: Path, plan: str, *, plan_only: bool = True) -> Path:
+    plan_dir = root / ".megaplan" / "plans" / plan
+    plan_dir.mkdir(parents=True, exist_ok=True)
+    state = {
+        "name": plan,
+        "current_state": STATE_FINALIZED,
+        "iteration": 1,
+        "plan_versions": [{"version": 1, "file": "plan_v1.md"}],
+        "config": {"project_dir": str(root)},
+        "meta": {
+            "chain_policy": {
+                "plan_only": plan_only,
+                "contract_context": {"plan_only": plan_only},
+            }
+        },
+    }
+    (plan_dir / "plan_v1.md").write_text("# Plan\n", encoding="utf-8")
+    (plan_dir / "state.json").write_text(json.dumps(state) + "\n", encoding="utf-8")
+    return plan_dir
+
+
+def test_run_chain_plan_mode_injects_dependency_provides_metadata_and_preserves_prep_direction(
+    tmp_path: Path,
+) -> None:
+    i1 = _touch_idea(tmp_path, "m-a.txt")
+    i2 = _touch_idea(tmp_path, "m-b.txt")
+    spec_path = _write_spec(
+        tmp_path,
+        {
+            "milestones": [
+                {"label": "M-a", "idea": str(i1)},
+                {
+                    "label": "M-b",
+                    "idea": str(i2),
+                    "depends_on": ["M-a"],
+                    "prep_direction": "keep the user's prep direction",
+                },
+            ]
+        },
+    )
+    plan_names = iter(["plan-ma", "plan-mb"])
+    prep_directions: list[str | None] = []
+
+    def fake_init(root, idea_path, **kwargs):
+        del idea_path
+        plan = next(plan_names)
+        prep_directions.append(kwargs["prep_direction"])
+        _write_plan_state(root, plan, "initialized")
+        return plan
+
+    def fake_drive(root, plan, spec, *, stop_at_finalized=False, on_phase_complete=None, writer):
+        del spec, on_phase_complete, writer
+        assert stop_at_finalized is True
+        state_path = root / ".megaplan" / "plans" / plan / "state.json"
+        raw_state = json.loads(state_path.read_text(encoding="utf-8"))
+        raw_state["current_state"] = STATE_FINALIZED
+        state_path.write_text(json.dumps(raw_state) + "\n", encoding="utf-8")
+        if plan == "plan-ma":
+            _write_contract(
+                root,
+                plan,
+                {
+                    "provides": [
+                        {
+                            "name": "Planner surface",
+                            "interfaces": [
+                                {
+                                    "symbol": "Planner.run",
+                                    "path": "megaplan/planner.py",
+                                    "signature": "Planner.run(config) -> None",
+                                }
+                            ],
+                        }
+                    ],
+                    "assumes": [],
+                },
+            )
+        else:
+            _write_contract(root, plan, {"provides": [], "assumes": []})
+        return _fake_outcome(plan, "finalized")
+
+    with patch("megaplan.chain._refresh_base_branch", lambda *a, **k: None), \
+         patch("megaplan.chain._init_plan", side_effect=fake_init), \
+         patch("megaplan.chain._drive_plan", side_effect=fake_drive), \
+         patch(
+             "megaplan.chain.commit_plan_artifacts_to_base",
+             side_effect=lambda root, base, plan, paths, push, dry_run=False: CommitResult(
+                 committed=True, pushed=False, commit_sha=f"sha-{plan}", base_branch=base
+             ),
+         ):
+        result = run_chain(spec_path, tmp_path, writer=lambda _m: None, mode="plan")
+
+    assert result["status"] == "done"
+    assert prep_directions == [None, "keep the user's prep direction"]
+    mb_state = json.loads((tmp_path / ".megaplan" / "plans" / "plan-mb" / "state.json").read_text(encoding="utf-8"))
+    policy = mb_state["meta"]["chain_policy"]
+    assert policy["plan_only"] is True
+    assert policy["dependency_labels"] == ["M-a"]
+    assert policy["provided_paths"] == {"M-a": ["megaplan/planner.py"]}
+    context = policy["contract_context"]
+    assert context["plan_only"] is True
+    assert context["milestone_label"] == "M-b"
+    assert context["upstream_contracts"][0]["milestone_label"] == "M-a"
+    assert context["upstream_contracts"][0]["provides"][0]["interfaces"][0]["symbol"] == "Planner.run"
+
+
+def test_run_chain_start_mode_leaves_dependency_contract_prompts_inert(tmp_path: Path) -> None:
+    i1 = _touch_idea(tmp_path, "m-a.txt")
+    i2 = _touch_idea(tmp_path, "m-b.txt")
+    spec_path = _write_spec(
+        tmp_path,
+        {
+            "milestones": [
+                {"label": "M-a", "idea": str(i1)},
+                {"label": "M-b", "idea": str(i2), "depends_on": ["M-a"]},
+            ]
+        },
+    )
+    plan_names = iter(["plan-ma", "plan-mb"])
+
+    def fake_init(root, idea_path, **_kwargs):
+        del idea_path
+        plan = next(plan_names)
+        _write_plan_state(root, plan, "initialized")
+        return plan
+
+    def fake_drive(root, plan, spec, *, stop_at_finalized=False, on_phase_complete=None, writer):
+        del spec, stop_at_finalized, on_phase_complete, writer
+        state_path = root / ".megaplan" / "plans" / plan / "state.json"
+        raw_state = json.loads(state_path.read_text(encoding="utf-8"))
+        raw_state["current_state"] = "done"
+        state_path.write_text(json.dumps(raw_state) + "\n", encoding="utf-8")
+        _write_contract(
+            root,
+            plan,
+            {
+                "provides": [
+                    {
+                        "name": "Start-mode provide",
+                        "interfaces": [{"symbol": "S.run", "path": "s.py", "signature": "S.run()"}],
+                    }
+                ],
+                "assumes": [],
+            },
+        )
+        return _fake_outcome(plan, "done")
+
+    with patch("megaplan.chain._refresh_base_branch", lambda *a, **k: None), \
+         patch("megaplan.chain._init_plan", side_effect=fake_init), \
+         patch("megaplan.chain._drive_plan", side_effect=fake_drive):
+        result = run_chain(spec_path, tmp_path, writer=lambda _m: None)
+
+    assert result["status"] == "done"
+    mb_state = json.loads((tmp_path / ".megaplan" / "plans" / "plan-mb" / "state.json").read_text(encoding="utf-8"))
+    policy = mb_state["meta"]["chain_policy"]
+    assert policy["plan_only"] is False
+    assert "contract_context" not in policy
+
+
+def test_run_chain_execute_reground_records_skip_when_contract_unavailable(tmp_path: Path) -> None:
+    i1 = _touch_idea(tmp_path, "m-a.txt")
+    i2 = _touch_idea(tmp_path, "m-b.txt")
+    spec_path = _write_spec(
+        tmp_path,
+        {
+            "milestones": [
+                {"label": "M-a", "idea": str(i1)},
+                {"label": "M-b", "idea": str(i2), "depends_on": ["M-a"]},
+            ]
+        },
+    )
+    _write_plan_only_finalized_state(tmp_path, "plan-mb")
+    save_chain_state(
+        spec_path,
+        ChainState(
+            current_milestone_index=2,
+            completed=[
+                {"label": "M-a", "plan": "plan-ma", "status": "done"},
+                {"label": "M-b", "plan": "plan-mb", "status": "finalized"},
+            ],
+        ),
+    )
+
+    with patch("megaplan.chain._init_plan") as init_plan, \
+         patch("megaplan.chain._drive_plan", return_value=_fake_outcome("plan-mb", "done")):
+        result = run_chain(spec_path, tmp_path, writer=lambda _m: None, mode="execute")
+
+    assert result["status"] == "done"
+    init_plan.assert_not_called()
+    saved = load_chain_state(spec_path)
+    assert saved.reground_decisions["M-b"]["status"] == "skipped"
+    assert saved.reground_decisions["M-b"]["reason"] == "downstream_contract_unavailable"
+
+
+def test_run_chain_execute_reground_records_pass_before_driver(tmp_path: Path) -> None:
+    i1 = _touch_idea(tmp_path, "m-a.txt")
+    i2 = _touch_idea(tmp_path, "m-b.txt")
+    spec_path = _write_spec(
+        tmp_path,
+        {
+            "milestones": [
+                {"label": "M-a", "idea": str(i1)},
+                {"label": "M-b", "idea": str(i2), "depends_on": ["M-a"]},
+            ]
+        },
+    )
+    _write_plan_only_finalized_state(tmp_path, "plan-mb")
+    _write_contract(
+        tmp_path,
+        "plan-ma",
+        {
+            "provides": [
+                {
+                    "name": "Planner",
+                    "interfaces": [{"symbol": "Planner.run", "path": "planner.py", "signature": "run()"}],
+                }
+            ],
+            "assumes": [],
+        },
+    )
+    _write_contract(
+        tmp_path,
+        "plan-mb",
+        {
+            "provides": [],
+            "assumes": [
+                {
+                    "name": "Planner",
+                    "upstream_milestone": "M-a",
+                    "interfaces": [{"symbol": "Planner.run", "path": "planner.py", "signature": "run()"}],
+                }
+            ],
+        },
+    )
+    save_chain_state(
+        spec_path,
+        ChainState(
+            current_milestone_index=2,
+            completed=[
+                {"label": "M-a", "plan": "plan-ma", "status": "done"},
+                {"label": "M-b", "plan": "plan-mb", "status": "finalized"},
+            ],
+        ),
+    )
+
+    def fake_drive(root, plan, spec, *, stop_at_finalized=False, on_phase_complete=None, writer):
+        del root, plan, spec, stop_at_finalized, on_phase_complete, writer
+        assert load_chain_state(spec_path).reground_decisions["M-b"]["status"] == "pass"
+        return _fake_outcome("plan-mb", "done")
+
+    with patch("megaplan.chain._drive_plan", side_effect=fake_drive):
+        result = run_chain(spec_path, tmp_path, writer=lambda _m: None, mode="execute")
+
+    assert result["status"] == "done"
+    saved = load_chain_state(spec_path)
+    assert saved.reground_decisions["M-b"]["material_diff_count"] == 0
+    assert saved.reground_decisions["M-b"]["diff_row_count"] == 1
+
+
+def test_run_chain_execute_reground_records_drift_fingerprint(tmp_path: Path) -> None:
+    i1 = _touch_idea(tmp_path, "m-a.txt")
+    i2 = _touch_idea(tmp_path, "m-b.txt")
+    spec_path = _write_spec(
+        tmp_path,
+        {
+            "milestones": [
+                {"label": "M-a", "idea": str(i1)},
+                {"label": "M-b", "idea": str(i2), "depends_on": ["M-a"]},
+            ]
+        },
+    )
+    _write_plan_only_finalized_state(tmp_path, "plan-mb")
+    _write_contract(
+        tmp_path,
+        "plan-ma",
+        {
+            "provides": [
+                {
+                    "name": "Planner",
+                    "interfaces": [{"symbol": "Planner.run", "path": "planner.py", "signature": "run(new)"}],
+                }
+            ],
+            "assumes": [],
+        },
+    )
+    _write_contract(
+        tmp_path,
+        "plan-mb",
+        {
+            "provides": [],
+            "assumes": [
+                {
+                    "name": "Planner",
+                    "upstream_milestone": "M-a",
+                    "interfaces": [{"symbol": "Planner.run", "path": "planner.py", "signature": "run(old)"}],
+                }
+            ],
+        },
+    )
+    save_chain_state(
+        spec_path,
+        ChainState(
+            current_milestone_index=2,
+            completed=[
+                {"label": "M-a", "plan": "plan-ma", "status": "done"},
+                {"label": "M-b", "plan": "plan-mb", "status": "finalized"},
+            ],
+        ),
+    )
+
+    with patch("megaplan.chain._drive_plan", return_value=_fake_outcome("plan-mb", "done")):
+        result = run_chain(spec_path, tmp_path, writer=lambda _m: None, mode="execute")
+
+    assert result["status"] == "done"
+    decision = load_chain_state(spec_path).reground_decisions["M-b"]
+    assert decision["status"] == "replanned"
+    assert decision["material_diff_count"] == 1
+    assert decision["material_diffs"][0]["status"] == "MISMATCH"
+    assert decision["material_fingerprint"] != "[]"
+
+
+def test_run_chain_plan_mode_writes_chain_review_with_contract_statuses(tmp_path: Path) -> None:
+    ideas = [_touch_idea(tmp_path, f"m-{label}.txt") for label in ("a", "b", "z", "c", "d")]
+    spec_path = _write_spec(
+        tmp_path,
+        {
+            "milestones": [
+                {"label": "M-a", "idea": str(ideas[0])},
+                {"label": "M-b", "idea": str(ideas[1]), "depends_on": ["M-a"]},
+                {"label": "M-z", "idea": str(ideas[2])},
+                {"label": "M-c", "idea": str(ideas[3]), "depends_on": ["M-z"]},
+                {"label": "M-d", "idea": str(ideas[4]), "depends_on": ["M-a"]},
+            ]
+        },
+    )
+    plan_by_label = {
+        "M-a": "plan-ma",
+        "M-b": "plan-mb",
+        "M-z": "plan-mz",
+        "M-c": "plan-mc",
+        "M-d": "plan-md",
+    }
+    labels = iter(plan_by_label)
+
+    def fake_init(root, idea_path, **_kwargs):
+        del root, idea_path
+        label = next(labels)
+        plan = plan_by_label[label]
+        _write_plan_state(tmp_path, plan, "initialized")
+        return plan
+
+    def fake_drive(root, plan, spec, *, stop_at_finalized=False, on_phase_complete=None, writer):
+        del spec, stop_at_finalized, on_phase_complete, writer
+        contracts = {
+            "plan-ma": {
+                "provides": [
+                    {
+                        "name": "A",
+                        "interfaces": [{"symbol": "A.run", "path": "a.py", "signature": "run(new)"}],
+                    }
+                ],
+                "assumes": [],
+            },
+            "plan-mb": {
+                "provides": [],
+                "assumes": [
+                    {
+                        "name": "A",
+                        "upstream_milestone": "M-a",
+                        "interfaces": [{"symbol": "A.run", "path": "a.py", "signature": "run(new)"}],
+                    }
+                ],
+            },
+            "plan-mz": {"provides": [], "assumes": []},
+            "plan-mc": {
+                "provides": [],
+                "assumes": [
+                    {
+                        "name": "Z",
+                        "upstream_milestone": "M-z",
+                        "interfaces": [{"symbol": "Z.run", "path": "z.py", "signature": "run()"}],
+                    }
+                ],
+            },
+            "plan-md": {
+                "provides": [],
+                "assumes": [
+                    {
+                        "name": "A",
+                        "upstream_milestone": "M-a",
+                        "interfaces": [{"symbol": "A.run", "path": "a.py", "signature": "run(old)"}],
+                    }
+                ],
+            },
+        }
+        _write_plan_state(root, plan, STATE_FINALIZED)
+        _write_contract(root, plan, contracts[plan])
+        return _fake_outcome(plan, "finalized")
+
+    with patch("megaplan.chain._refresh_base_branch", lambda *a, **k: None), \
+         patch("megaplan.chain._init_plan", side_effect=fake_init), \
+         patch("megaplan.chain._drive_plan", side_effect=fake_drive), \
+         patch(
+             "megaplan.chain.commit_plan_artifacts_to_base",
+             side_effect=lambda root, base, plan, paths, push, dry_run=False: CommitResult(
+                 committed=True, pushed=False, commit_sha=f"sha-{plan}", base_branch=base
+             ),
+         ):
+        result = run_chain(spec_path, tmp_path, writer=lambda _m: None, mode="plan")
+
+    assert result["status"] == "done"
+    review = chain_module._chain_review_path(spec_path).read_text(encoding="utf-8")
+    assert "- Status: complete" in review
+    assert "| M-b | M-a | A.run | a.py | a.py | run(new) | run(new) | OK |  |" in review
+    assert "| M-c | M-z | Z.run | z.py |  | run() |  | MISSING_UPSTREAM | symbol `Z.run` missing upstream |" in review
+    assert "| M-d | M-a | A.run | a.py | a.py | run(old) | run(new) | MISMATCH | signature changed |" in review
+
+
+def test_run_chain_three_milestone_contract_fixture_covers_artifacts_review_and_reground(
+    tmp_path: Path,
+) -> None:
+    ideas = [_touch_idea(tmp_path, f"m-{label}.txt") for label in ("a", "b", "c")]
+    spec_path = _write_spec(
+        tmp_path,
+        {
+            "milestones": [
+                {"label": "M-a", "idea": str(ideas[0])},
+                {"label": "M-b", "idea": str(ideas[1]), "depends_on": ["M-a"]},
+                {"label": "M-c", "idea": str(ideas[2])},
+            ]
+        },
+    )
+    plan_by_label = {"M-a": "plan-ma", "M-b": "plan-mb", "M-c": "plan-mc"}
+    labels = iter(plan_by_label)
+    contract_payloads = {
+        "plan-ma": _contract_finalize_payload(
+            provides=[
+                {
+                    "name": "Planner surface",
+                    "interfaces": [
+                        {
+                            "symbol": "Planner.run",
+                            "path": "planner.py",
+                            "signature": "run()",
+                        }
+                    ],
+                }
+            ],
+            assumes=[],
+            meta_commentary="M-a publishes the planner surface.",
+        ),
+        "plan-mb": _contract_finalize_payload(
+            provides=[],
+            assumes=[
+                {
+                    "name": "Planner surface",
+                    "upstream_milestone": "M-a",
+                    "interfaces": [
+                        {
+                            "symbol": "Planner.run",
+                            "path": "planner.py",
+                            "signature": "run()",
+                        }
+                    ],
+                }
+            ],
+            meta_commentary="M-b consumes M-a's planner surface.",
+        ),
+        "plan-mc": _contract_finalize_payload(
+            provides=[],
+            assumes=[
+                {
+                    "name": "Sibling-only surface",
+                    "upstream_milestone": "M-b",
+                    "interfaces": [
+                        {
+                            "symbol": "Builder.run",
+                            "path": "builder.py",
+                            "signature": "run()",
+                        }
+                    ],
+                }
+            ],
+            meta_commentary="M-c references a sibling surface without a declared dependency.",
+        ),
+    }
+
+    def fake_init(root, idea_path, **_kwargs):
+        del root, idea_path
+        label = next(labels)
+        plan = plan_by_label[label]
+        _write_plan_state(tmp_path, plan, "initialized")
+        return plan
+
+    def fake_drive(root, plan, spec, *, stop_at_finalized=False, on_phase_complete=None, writer):
+        del spec, stop_at_finalized, on_phase_complete, writer
+        _write_finalized_contract_artifacts(root, plan, payload=contract_payloads[plan])
+        return _fake_outcome(plan, "finalized")
+
+    with patch("megaplan.chain._refresh_base_branch", lambda *a, **k: None), \
+         patch("megaplan.chain._init_plan", side_effect=fake_init), \
+         patch("megaplan.chain._drive_plan", side_effect=fake_drive), \
+         patch(
+             "megaplan.chain.commit_plan_artifacts_to_base",
+             side_effect=lambda root, base, plan, paths, push, dry_run=False: CommitResult(
+                 committed=True, pushed=False, commit_sha=f"sha-{plan}", base_branch=base
+             ),
+         ):
+        plan_result = run_chain(spec_path, tmp_path, writer=lambda _m: None, mode="plan")
+
+    assert plan_result["status"] == "done"
+    plan_state_mb = json.loads(
+        (tmp_path / ".megaplan" / "plans" / "plan-mb" / "state.json").read_text(encoding="utf-8")
+    )
+    plan_state_mc = json.loads(
+        (tmp_path / ".megaplan" / "plans" / "plan-mc" / "state.json").read_text(encoding="utf-8")
+    )
+    mb_context = plan_state_mb["meta"]["chain_policy"]["contract_context"]
+    mc_context = plan_state_mc["meta"]["chain_policy"]["contract_context"]
+    assert mb_context["dependency_labels"] == ["M-a"]
+    assert mb_context["upstream_contracts"][0]["milestone_label"] == "M-a"
+    assert mc_context["dependency_labels"] == []
+    assert mc_context["upstream_contracts"] == []
+
+    for plan_name in ("plan-ma", "plan-mb", "plan-mc"):
+        plan_dir = tmp_path / ".megaplan" / "plans" / plan_name
+        assert (plan_dir / "contract.json").exists()
+
+    ma_final = (tmp_path / ".megaplan" / "plans" / "plan-ma" / "final.md").read_text(encoding="utf-8")
+    mb_final = (tmp_path / ".megaplan" / "plans" / "plan-mb" / "final.md").read_text(encoding="utf-8")
+    mc_final = (tmp_path / ".megaplan" / "plans" / "plan-mc" / "final.md").read_text(encoding="utf-8")
+    assert "## Provides" in ma_final
+    assert "## Assumes" not in ma_final
+    assert "## Assumes" in mb_final
+    assert "from `M-a`" in mb_final
+    assert "## Assumes" in mc_final
+    assert "from `M-b`" in mc_final
+
+    review = chain_module._chain_review_path(spec_path).read_text(encoding="utf-8")
+    assert "| M-b | M-a | Planner.run | planner.py | planner.py | run() | run() | OK |  |" in review
+    assert (
+        "| M-c | M-b | Builder.run | builder.py |  | run() |  | MISSING_UPSTREAM | "
+        "upstream contract `M-b` missing |"
+    ) in review
+
+    saved = load_chain_state(spec_path)
+    completed_by_label = {record["label"]: record for record in saved.completed}
+    assert completed_by_label["M-a"]["artifact_commit_sha"] == "sha-plan-ma"
+    assert completed_by_label["M-b"]["artifact_commit_sha"] == "sha-plan-mb"
+    assert completed_by_label["M-c"]["artifact_commit_sha"] == "sha-plan-mc"
+
+    _write_contract(
+        tmp_path,
+        "plan-ma",
+        {
+            "provides": [
+                {
+                    "name": "Planner surface",
+                    "interfaces": [
+                        {
+                            "symbol": "Planner.run",
+                            "path": "planner.py",
+                            "signature": "run(updated)",
+                        }
+                    ],
+                }
+            ],
+            "assumes": [],
+        },
+    )
+    saved.current_milestone_index = len(load_spec(spec_path).milestones)
+    save_chain_state(spec_path, saved)
+
+    def fake_execute_drive(root, plan, spec, *, stop_at_finalized=False, on_phase_complete=None, writer):
+        del root, spec, stop_at_finalized, on_phase_complete, writer
+        current = load_chain_state(spec_path)
+        if plan == "plan-mb":
+            assert current.reground_decisions["M-b"]["status"] == "replanned"
+            assert current.reground_decisions["M-b"]["material_diffs"][0]["status"] == "MISMATCH"
+            return _fake_outcome(plan, "done")
+        if plan == "plan-mc":
+            assert current.reground_decisions["M-c"]["status"] == "skipped"
+            assert current.reground_decisions["M-c"]["reason"] == "no_dependencies"
+            return _fake_outcome(plan, "done")
+        return _fake_outcome(plan, "done")
+
+    with patch("megaplan.chain._drive_plan", side_effect=fake_execute_drive):
+        execute_result = run_chain(spec_path, tmp_path, writer=lambda _m: None, mode="execute")
+
+    assert execute_result["status"] == "done"
+    execute_state = load_chain_state(spec_path)
+    assert execute_state.reground_decisions["M-b"]["status"] == "replanned"
+    assert execute_state.reground_decisions["M-b"]["material_diffs"][0]["status"] == "MISMATCH"
+    assert execute_state.reground_decisions["M-c"]["status"] == "skipped"
+    assert execute_state.reground_decisions["M-c"]["reason"] == "no_dependencies"
+
+
+def test_run_chain_plan_mode_writes_partial_chain_review_on_one_exit(tmp_path: Path) -> None:
+    i1 = _touch_idea(tmp_path, "m-a.txt")
+    i2 = _touch_idea(tmp_path, "m-b.txt")
+    spec_path = _write_spec(
+        tmp_path,
+        {"milestones": [{"label": "M-a", "idea": str(i1)}, {"label": "M-b", "idea": str(i2)}]},
+    )
+
+    def fake_init(root, idea_path, **_kwargs):
+        del idea_path
+        _write_plan_state(root, "plan-ma", "initialized")
+        return "plan-ma"
+
+    def fake_drive(root, plan, spec, *, stop_at_finalized=False, on_phase_complete=None, writer):
+        del spec, stop_at_finalized, on_phase_complete, writer
+        _write_plan_state(root, plan, STATE_FINALIZED)
+        _write_contract(root, plan, {"provides": [], "assumes": []})
+        return _fake_outcome(plan, "finalized")
+
+    with patch("megaplan.chain._refresh_base_branch", lambda *a, **k: None), \
+         patch("megaplan.chain._init_plan", side_effect=fake_init), \
+         patch("megaplan.chain._drive_plan", side_effect=fake_drive), \
+         patch(
+             "megaplan.chain.commit_plan_artifacts_to_base",
+             return_value=CommitResult(committed=True, pushed=False, commit_sha="sha", base_branch="main"),
+         ):
+        result = run_chain(spec_path, tmp_path, writer=lambda _m: None, mode="plan", one=True)
+
+    assert result["status"] == "paused"
+    review = chain_module._chain_review_path(spec_path).read_text(encoding="utf-8")
+    assert "- Status: partial" in review
+    assert "- Partial reason: completed one milestone: M-a" in review
+
+
+def test_write_chain_review_uses_latest_completed_record_for_duplicate_labels(tmp_path: Path) -> None:
+    i1 = _touch_idea(tmp_path, "m-a.txt")
+    i2 = _touch_idea(tmp_path, "m-b.txt")
+    spec_path = _write_spec(
+        tmp_path,
+        {
+            "milestones": [
+                {"label": "M-a", "idea": str(i1)},
+                {"label": "M-b", "idea": str(i2), "depends_on": ["M-a"]},
+            ]
+        },
+    )
+    _write_contract(
+        tmp_path,
+        "old-a",
+        {
+            "provides": [
+                {"name": "A", "interfaces": [{"symbol": "A.run", "path": "a.py", "signature": "old()"}]}
+            ],
+            "assumes": [],
+        },
+    )
+    _write_contract(
+        tmp_path,
+        "new-a",
+        {
+            "provides": [
+                {"name": "A", "interfaces": [{"symbol": "A.run", "path": "a.py", "signature": "new()"}]}
+            ],
+            "assumes": [],
+        },
+    )
+    _write_contract(
+        tmp_path,
+        "plan-b",
+        {
+            "provides": [],
+            "assumes": [
+                {
+                    "name": "A",
+                    "upstream_milestone": "M-a",
+                    "interfaces": [{"symbol": "A.run", "path": "a.py", "signature": "new()"}],
+                }
+            ],
+        },
+    )
+    state = ChainState(
+        completed=[
+            {"label": "M-a", "plan": "old-a", "status": "finalized"},
+            {"label": "M-a", "plan": "new-a", "status": "finalized"},
+            {"label": "M-b", "plan": "plan-b", "status": "finalized"},
+        ]
+    )
+
+    chain_module._write_chain_review(tmp_path, spec_path, load_spec(spec_path), state)
+    review = chain_module._chain_review_path(spec_path).read_text(encoding="utf-8")
+    assert "new()" in review
+    assert "old()" not in review
+
+
+def test_run_chain_execute_first_drift_replans_and_continues_same_plan(tmp_path: Path) -> None:
+    i1 = _touch_idea(tmp_path, "m-a.txt")
+    i2 = _touch_idea(tmp_path, "m-b.txt")
+    spec_path = _write_spec(
+        tmp_path,
+        {
+            "milestones": [
+                {"label": "M-a", "idea": str(i1)},
+                {"label": "M-b", "idea": str(i2), "depends_on": ["M-a"]},
+            ]
+        },
+    )
+    _write_plan_only_finalized_state(tmp_path, "plan-mb")
+    _write_contract(
+        tmp_path,
+        "plan-ma",
+        {
+            "provides": [
+                {"name": "Planner", "interfaces": [{"symbol": "Planner.run", "path": "planner.py", "signature": "run(new)"}]}
+            ],
+            "assumes": [],
+        },
+    )
+    _write_contract(
+        tmp_path,
+        "plan-mb",
+        {
+            "provides": [],
+            "assumes": [
+                {
+                    "name": "Planner",
+                    "upstream_milestone": "M-a",
+                    "interfaces": [{"symbol": "Planner.run", "path": "planner.py", "signature": "run(old)"}],
+                }
+            ],
+        },
+    )
+    save_chain_state(
+        spec_path,
+        ChainState(
+            current_milestone_index=2,
+            completed=[
+                {"label": "M-a", "plan": "plan-ma", "status": "done"},
+                {"label": "M-b", "plan": "plan-mb", "status": "finalized"},
+            ],
+        ),
+    )
+
+    def fake_drive(root, plan, spec, *, stop_at_finalized=False, on_phase_complete=None, writer):
+        del root, spec, stop_at_finalized, on_phase_complete, writer
+        saved = load_chain_state(spec_path)
+        assert plan == "plan-mb"
+        assert saved.current_milestone_index == 1
+        assert saved.current_plan_name == "plan-mb"
+        assert saved.reground_decisions["M-b"]["status"] == "replanned"
+        plan_state = json.loads((tmp_path / ".megaplan" / "plans" / "plan-mb" / "state.json").read_text(encoding="utf-8"))
+        assert plan_state["current_state"] == "planned"
+        assert any(item.get("action") == "replan" for item in plan_state["meta"]["overrides"])
+        return _fake_outcome("plan-mb", "done")
+
+    with patch("megaplan.chain._drive_plan", side_effect=fake_drive) as drive:
+        result = run_chain(spec_path, tmp_path, writer=lambda _m: None, mode="execute")
+
+    assert result["status"] == "done"
+    assert drive.call_count == 1
+    saved = load_chain_state(spec_path)
+    assert saved.current_milestone_index == 2
+    assert saved.completed[-1]["label"] == "M-b"
+    assert saved.completed[-1]["status"] == "done"
+
+
+def test_run_chain_execute_repeated_identical_drift_stops_before_driver(tmp_path: Path) -> None:
+    from megaplan.orchestration.plan_contracts import (
+        contract_diff_fingerprint,
+        diff_assumes_against_provides,
+    )
+
+    i1 = _touch_idea(tmp_path, "m-a.txt")
+    i2 = _touch_idea(tmp_path, "m-b.txt")
+    spec_path = _write_spec(
+        tmp_path,
+        {
+            "milestones": [
+                {"label": "M-a", "idea": str(i1)},
+                {"label": "M-b", "idea": str(i2), "depends_on": ["M-a"]},
+            ]
+        },
+    )
+    upstream = {
+        "provides": [
+            {"name": "Planner", "interfaces": [{"symbol": "Planner.run", "path": "planner.py", "signature": "run(new)"}]}
+        ],
+        "assumes": [],
+    }
+    downstream = {
+        "provides": [],
+        "assumes": [
+            {
+                "name": "Planner",
+                "upstream_milestone": "M-a",
+                "interfaces": [{"symbol": "Planner.run", "path": "planner.py", "signature": "run(old)"}],
+            }
+        ],
+    }
+    _write_plan_only_finalized_state(tmp_path, "plan-mb")
+    _write_contract(tmp_path, "plan-ma", upstream)
+    _write_contract(tmp_path, "plan-mb", downstream)
+    rows = diff_assumes_against_provides(
+        downstream,
+        [{"milestone_label": "M-a", "provides": upstream["provides"], "assumes": []}],
+        downstream_label="M-b",
+    )
+    fingerprint = contract_diff_fingerprint(rows)
+    save_chain_state(
+        spec_path,
+        ChainState(
+            current_milestone_index=2,
+            completed=[
+                {"label": "M-a", "plan": "plan-ma", "status": "done"},
+                {"label": "M-b", "plan": "plan-mb", "status": "finalized"},
+            ],
+            reground_decisions={
+                "M-b": {
+                    "status": "replanned",
+                    "material_fingerprint": fingerprint,
+                    "material_diffs": rows,
+                }
+            },
+        ),
+    )
+
+    with patch("megaplan.chain._drive_plan") as drive:
+        result = run_chain(spec_path, tmp_path, writer=lambda _m: None, mode="execute")
+
+    assert result["status"] == "stopped"
+    assert "repeated contract drift for M-b" in result["reason"]
+    drive.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# T8: git commit artifact loading and contract fallback
+# ---------------------------------------------------------------------------
+
+
+def test_read_plan_artifact_from_commit_returns_content() -> None:
+    """git show success returns file content as string."""
+    from megaplan.chain.git_ops import read_plan_artifact_from_commit
+
+    fake_proc = subprocess.CompletedProcess(
+        args=["git", "show", "abc123:.megaplan/plans/p/contract.json"],
+        returncode=0,
+        stdout='{"provides":[],"assumes":[]}\n',
+        stderr="",
+    )
+    with patch.object(chain_module.subprocess, "run", return_value=fake_proc):
+        result = read_plan_artifact_from_commit(Path("/fake"), "abc123", ".megaplan/plans/p/contract.json")
+    assert result == '{"provides":[],"assumes":[]}\n'
+
+
+def test_read_plan_artifact_from_commit_returns_none_for_missing_file() -> None:
+    """git show for missing file returns None."""
+    from megaplan.chain.git_ops import read_plan_artifact_from_commit
+
+    for stderr in (
+        "fatal: path '.megaplan/plans/p/contract.json' does not exist in 'abc123'",
+        "fatal: Path 'contract.json' exists on disk, but not in 'abc123'",
+        "fatal: bad revision 'abc123'",
+    ):
+        fake_proc = subprocess.CompletedProcess(
+            args=["git", "show", "abc123:.megaplan/plans/p/contract.json"],
+            returncode=128,
+            stdout="",
+            stderr=stderr,
+        )
+        with patch.object(chain_module.subprocess, "run", return_value=fake_proc):
+            result = read_plan_artifact_from_commit(Path("/fake"), "abc123", ".megaplan/plans/p/contract.json")
+        assert result is None, f"Should return None for stderr: {stderr!r}"
+
+
+def test_read_plan_artifact_from_commit_raises_on_git_failure() -> None:
+    """Real git failures (not missing-file) raise CliError."""
+    from megaplan.chain.git_ops import read_plan_artifact_from_commit
+
+    fake_proc = subprocess.CompletedProcess(
+        args=["git", "show", "abc123:.megaplan/plans/p/contract.json"],
+        returncode=1,
+        stdout="",
+        stderr="fatal: Not a git repository",
+    )
+    with patch.object(chain_module.subprocess, "run", return_value=fake_proc):
+        with pytest.raises(CliError) as exc_info:
+            read_plan_artifact_from_commit(Path("/fake"), "abc123", ".megaplan/plans/p/contract.json")
+        assert exc_info.value.code == "git_artifact_read_failed"
+
+
+def test_load_contract_for_completed_record_prefers_current_file(tmp_path: Path) -> None:
+    """When contract.json exists on disk, it is loaded and normalized."""
+    plan_dir = tmp_path / ".megaplan" / "plans" / "plan-p"
+    plan_dir.mkdir(parents=True)
+    contract = {"provides": [{"name": "P", "interfaces": [{"symbol": "f", "path": "src/p.py", "signature": "f()"}]}], "assumes": []}
+    (plan_dir / "contract.json").write_text(json.dumps(contract), encoding="utf-8")
+
+    record = {"plan": "plan-p"}
+    result = chain_module._load_contract_for_completed_record(tmp_path, record)
+    assert result is not None
+    assert len(result["provides"]) == 1
+    assert result["provides"][0]["name"] == "P"
+
+
+def test_load_contract_for_completed_record_falls_back_to_commit(tmp_path: Path) -> None:
+    """When contract.json is missing on disk, falls back to git commit artifact."""
+    plan_dir = tmp_path / ".megaplan" / "plans" / "plan-p"
+    plan_dir.mkdir(parents=True)
+    # No contract.json on disk
+    contract_content = json.dumps({"provides": [], "assumes": [{"name": "A", "upstream_milestone": "m1", "interfaces": []}]})
+
+    record = {"plan": "plan-p", "artifact_commit_sha": "abc123"}
+
+    fake_proc = subprocess.CompletedProcess(
+        args=["git", "show", "abc123:.megaplan/plans/plan-p/contract.json"],
+        returncode=0,
+        stdout=contract_content,
+        stderr="",
+    )
+    with patch.object(chain_module.subprocess, "run", return_value=fake_proc):
+        result = chain_module._load_contract_for_completed_record(tmp_path, record)
+    assert result is not None
+    assert len(result["assumes"]) == 1
+    assert result["assumes"][0]["name"] == "A"
+
+
+def test_load_contract_for_completed_record_returns_none_when_missing(tmp_path: Path) -> None:
+    """Returns None when no contract.json on disk and artifact commit is missing/missing-file."""
+    plan_dir = tmp_path / ".megaplan" / "plans" / "plan-p"
+    plan_dir.mkdir(parents=True)
+    # No contract.json, no artifact_commit_sha
+    record = {"plan": "plan-p"}
+    result = chain_module._load_contract_for_completed_record(tmp_path, record)
+    assert result is None
+
+    # With artifact_commit_sha but file missing in commit
+    record_with_sha = {"plan": "plan-p", "artifact_commit_sha": "abc123"}
+    fake_proc = subprocess.CompletedProcess(
+        args=["git", "show", "abc123:.megaplan/plans/plan-p/contract.json"],
+        returncode=128,
+        stdout="",
+        stderr="fatal: path '.megaplan/plans/plan-p/contract.json' does not exist in 'abc123'",
+    )
+    with patch.object(chain_module.subprocess, "run", return_value=fake_proc):
+        result = chain_module._load_contract_for_completed_record(tmp_path, record_with_sha)
+    assert result is None
+
+    # Also returns None for record without plan name
+    assert chain_module._load_contract_for_completed_record(tmp_path, {}) is None
 
 
 def test_branch_head_logs_git_error(

--- a/tests/test_finalize.py
+++ b/tests/test_finalize.py
@@ -330,6 +330,80 @@ def test_render_final_md_pending_partially_done_and_reviewed_states() -> None:
     assert "Verdict: Confirmed." in reviewed_md
 
 
+def test_finalize_writes_contract_json_and_keeps_empty_final_md_inert(
+    plan_fixture: PlanFixture,
+) -> None:
+    state = load_state(plan_fixture.plan_dir)
+    state["config"]["mode"] = "code"
+
+    payload = {
+        "tasks": [],
+        "watch_items": [],
+        "sense_checks": [],
+        "meta_commentary": "ok",
+        "validation": {
+            "plan_steps_covered": [],
+            "orphan_tasks": [],
+            "completeness_notes": "ok",
+            "coverage_complete": True,
+        },
+    }
+
+    _write_finalize_artifacts(plan_fixture.plan_dir, payload, state)
+
+    assert read_json(plan_fixture.plan_dir / "contract.json") == {
+        "provides": [],
+        "assumes": [],
+    }
+    final_md = (plan_fixture.plan_dir / "final.md").read_text(encoding="utf-8")
+    assert "## Provides" not in final_md
+    assert "## Assumes" not in final_md
+
+
+def test_render_final_md_renders_contract_sections_when_present() -> None:
+    from megaplan._core import render_final_md
+
+    data = {
+        "tasks": [],
+        "watch_items": [],
+        "sense_checks": [],
+        "meta_commentary": "Contracts present.",
+        "provides": [
+            {
+                "name": "Planner surface",
+                "description": "shared planner entrypoints",
+                "interfaces": [
+                    {
+                        "symbol": "Planner.run",
+                        "signature": "Planner.run(config) -> None",
+                        "path": "megaplan/planner.py",
+                    }
+                ],
+            }
+        ],
+        "assumes": [
+            {
+                "name": "Runtime contract",
+                "upstream_milestone": "m1",
+                "interfaces": [
+                    {
+                        "symbol": "Runtime.run",
+                        "signature": "Runtime.run(config) -> None",
+                        "path": "megaplan/runtime.py",
+                    }
+                ],
+            }
+        ],
+    }
+
+    rendered = render_final_md(data, phase="review")
+
+    assert "## Provides" in rendered
+    assert "## Assumes" in rendered
+    assert "`Planner.run`" in rendered
+    assert "from `m1`" in rendered
+
+
 def test_finalize_normalize_complexity_missing_defaults_to_4(plan_fixture: PlanFixture) -> None:
     """Worker response missing complexity writes 4 (Sonnet) in finalize artifacts.
 

--- a/tests/test_handlers_review.py
+++ b/tests/test_handlers_review.py
@@ -164,3 +164,95 @@ def test_review_does_not_mutate_finalize_json(tmp_path: Path) -> None:
     review = read_json(plan_dir / "review.json")
     assert review["task_verdicts"][0]["task_id"] == "T1"
     assert review["sense_check_verdicts"][0]["sense_check_id"] == "SC1"
+
+
+def test_review_final_md_preserves_contract_sections(tmp_path: Path) -> None:
+    plan_dir = tmp_path / "plan"
+    project_dir = tmp_path / "project"
+    plan_dir.mkdir()
+    project_dir.mkdir()
+    state = {
+        "name": "plan",
+        "idea": "review",
+        "current_state": STATE_EXECUTED,
+        "iteration": 1,
+        "created_at": "2026-05-21T00:00:00Z",
+        "config": {"project_dir": str(project_dir), "robustness": "full"},
+        "sessions": {},
+        "plan_versions": [{"version": 1, "file": "plan_v1.md"}],
+        "history": [],
+        "meta": {"notes": [], "overrides": [], "total_cost_usd": 0.0},
+    }
+    save_state(plan_dir, state)
+    atomic_write_json(
+        plan_dir / "finalize.json",
+        {
+            "tasks": [{"id": "T1", "status": "done", "description": "task"}],
+            "sense_checks": [{"id": "SC1", "task_id": "T1", "question": "Question?", "check": "Check."}],
+            "watch_items": [],
+            "meta_commentary": "ok",
+            "provides": [
+                {
+                    "name": "Planner surface",
+                    "description": "",
+                    "interfaces": [
+                        {
+                            "symbol": "Planner.run",
+                            "signature": "Planner.run(config) -> None",
+                            "path": "megaplan/planner.py",
+                        }
+                    ],
+                }
+            ],
+            "assumes": [
+                {
+                    "name": "Runtime contract",
+                    "upstream_milestone": "m1",
+                    "interfaces": [
+                        {
+                            "symbol": "Runtime.run",
+                            "signature": "Runtime.run(config) -> None",
+                            "path": "megaplan/runtime.py",
+                        }
+                    ],
+                }
+            ],
+        },
+    )
+    payload = {
+        "review_verdict": "approved",
+        "criteria": [],
+        "issues": [],
+        "rework_items": [],
+        "summary": "approved",
+        "task_verdicts": [{"task_id": "T1", "reviewer_verdict": "Looks correct.", "evidence_files": ["pkg/module.py"]}],
+        "sense_check_verdicts": [{"sense_check_id": "SC1", "verdict": "Confirmed."}],
+    }
+    atomic_write_json(plan_dir / "review.json", payload)
+    worker = WorkerResult(
+        payload=payload,
+        raw_output="review",
+        duration_ms=1,
+        cost_usd=0.0,
+        session_id="session",
+        prompt_tokens=0,
+        completion_tokens=0,
+        total_tokens=0,
+    )
+
+    _finalize_review_outcome(
+        root=tmp_path,
+        args=Namespace(plan="plan"),
+        plan_dir=plan_dir,
+        state=state,
+        worker=worker,
+        agent="codex",
+        mode="persistent",
+        refreshed=False,
+        robustness="full",
+    )
+
+    final_md = (plan_dir / "final.md").read_text(encoding="utf-8")
+    assert "## Provides" in final_md
+    assert "## Assumes" in final_md
+    assert "`Planner.run`" in final_md

--- a/tests/test_plan_contracts.py
+++ b/tests/test_plan_contracts.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from megaplan.orchestration.plan_contracts import (
+    contract_diff_fingerprint,
+    diff_assumes_against_provides,
+    normalize_contract_payload,
+    provided_paths_by_milestone,
+    render_contract_markdown,
+)
+
+
+def test_normalize_contract_payload_defaults_to_empty_contract() -> None:
+    assert normalize_contract_payload(None) == {"provides": [], "assumes": []}
+
+
+def test_normalize_contract_payload_ignores_extra_keys_and_normalizes_paths(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    payload = {
+        "provides": [
+            {
+                "name": "Planner surface",
+                "description": "shared contract",
+                "interfaces": [
+                    {
+                        "symbol": "Planner.run",
+                        "signature": "  Planner.run(config) -> None  ",
+                        "path": str(tmp_path / "megaplan" / "planner.py"),
+                        "extra": "ignored",
+                    },
+                    {
+                        "symbol": "Planner.status",
+                        "signature": "Planner.status() -> str",
+                        "path": ".\\megaplan\\status.py",
+                    },
+                ],
+                "unused": True,
+            }
+        ],
+        "assumes": [
+            {
+                "name": "Runtime contract",
+                "upstream_milestone": "m1",
+                "interfaces": [
+                    {
+                        "symbol": "Planner.run",
+                        "signature": "  Planner.run(config) -> None  ",
+                        "path": "./megaplan/planner.py",
+                    }
+                ],
+                "ignored": "value",
+            }
+        ],
+        "totally_extra": {"ignored": True},
+    }
+
+    normalized = normalize_contract_payload(payload)
+
+    assert normalized == {
+        "provides": [
+            {
+                "name": "Planner surface",
+                "description": "shared contract",
+                "interfaces": [
+                    {
+                        "symbol": "Planner.run",
+                        "signature": "Planner.run(config) -> None",
+                        "path": "megaplan/planner.py",
+                    },
+                    {
+                        "symbol": "Planner.status",
+                        "signature": "Planner.status() -> str",
+                        "path": "megaplan/status.py",
+                    },
+                ],
+            }
+        ],
+        "assumes": [
+            {
+                "name": "Runtime contract",
+                "upstream_milestone": "m1",
+                "interfaces": [
+                    {
+                        "symbol": "Planner.run",
+                        "signature": "Planner.run(config) -> None",
+                        "path": "megaplan/planner.py",
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def test_render_contract_markdown_renders_non_empty_sections() -> None:
+    markdown = render_contract_markdown(
+        {
+            "provides": [
+                {
+                    "name": "Planner surface",
+                    "description": "shared contract",
+                    "interfaces": [
+                        {
+                            "symbol": "Planner.run",
+                            "signature": "Planner.run(config) -> None",
+                            "path": "megaplan/planner.py",
+                        }
+                    ],
+                }
+            ],
+            "assumes": [
+                {
+                    "name": "Runtime contract",
+                    "upstream_milestone": "m1",
+                    "interfaces": [
+                        {
+                            "symbol": "Planner.run",
+                            "signature": "Planner.run(config) -> None",
+                            "path": "megaplan/planner.py",
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+
+    assert "## Provides" in markdown
+    assert "## Assumes" in markdown
+    assert "`Planner.run`" in markdown
+    assert "from `m1`" in markdown
+
+
+def test_provided_paths_by_milestone_collects_unique_sorted_paths() -> None:
+    contracts = [
+        {
+            "milestone_label": "m1",
+            "contract": {
+                "provides": [
+                    {
+                        "name": "A",
+                        "description": "",
+                        "interfaces": [
+                            {"symbol": "one", "signature": "sig", "path": "src/b.py"},
+                            {"symbol": "two", "signature": "sig", "path": "src/a.py"},
+                        ],
+                    }
+                ]
+            },
+        },
+        {
+            "label": "m1",
+            "provides": [
+                {
+                    "name": "B",
+                    "description": "",
+                    "interfaces": [
+                        {"symbol": "three", "signature": "sig", "path": "src/a.py"}
+                    ],
+                }
+            ],
+        },
+        {"label": "m2", "contract": {"provides": []}},
+    ]
+
+    assert provided_paths_by_milestone(contracts) == {
+        "m1": ["src/a.py", "src/b.py"],
+        "m2": [],
+    }
+
+
+def test_diff_assumes_against_provides_reports_ok_missing_and_mismatch() -> None:
+    downstream = {
+        "assumes": [
+            {
+                "name": "Uses m1 runtime",
+                "upstream_milestone": "m1",
+                "interfaces": [
+                    {
+                        "symbol": "Runtime.run",
+                        "signature": "Runtime.run(config) -> None",
+                        "path": "src/runtime.py",
+                    },
+                    {
+                        "symbol": "Runtime.status",
+                        "signature": "Runtime.status() -> str",
+                        "path": "src/runtime.py",
+                    },
+                ],
+            },
+            {
+                "name": "Uses m2 store",
+                "upstream_milestone": "m2",
+                "interfaces": [
+                    {
+                        "symbol": "Store.load",
+                        "signature": "Store.load(id: str) -> Item",
+                        "path": "src/store.py",
+                    }
+                ],
+            },
+        ]
+    }
+    upstream = [
+        {
+            "milestone_label": "m1",
+            "contract": {
+                "provides": [
+                    {
+                        "name": "Runtime",
+                        "description": "",
+                        "interfaces": [
+                            {
+                                "symbol": "Runtime.run",
+                                "signature": "Runtime.run(config) -> None",
+                                "path": "src/runtime.py",
+                            },
+                            {
+                                "symbol": "Runtime.status",
+                                "signature": "Runtime.status() -> bool",
+                                "path": "src/runtime_state.py",
+                            },
+                            {
+                                "symbol": "Runtime.extra",
+                                "signature": "Runtime.extra() -> None",
+                                "path": "src/runtime_extra.py",
+                            },
+                        ],
+                    }
+                ]
+            },
+        }
+    ]
+
+    rows = diff_assumes_against_provides(downstream, upstream, downstream_label="m3")
+
+    assert [row["status"] for row in rows] == ["OK", "MISMATCH", "MISSING_UPSTREAM"]
+    assert rows[0]["downstream_label"] == "m3"
+    assert rows[1]["note"] == "path and signature changed"
+    assert rows[1]["actual_path"] == "src/runtime_state.py"
+    assert rows[2]["note"] == "upstream contract `m2` missing"
+
+
+def test_contract_diff_fingerprint_is_deterministic_for_equivalent_material_rows() -> None:
+    rows_a = [
+        {
+            "downstream_label": "m3",
+            "upstream_label": "m2",
+            "symbol": "Store.load",
+            "expected_path": "src/store.py",
+            "actual_path": "",
+            "expected_signature": "Store.load(id: str) -> Item",
+            "actual_signature": "",
+            "status": "MISSING_UPSTREAM",
+            "note": "upstream contract `m2` missing",
+        },
+        {
+            "downstream_label": "m3",
+            "upstream_label": "m1",
+            "symbol": "Runtime.status",
+            "expected_path": "src/runtime.py",
+            "actual_path": "src/runtime_state.py",
+            "expected_signature": "Runtime.status() -> str",
+            "actual_signature": "Runtime.status() -> bool",
+            "status": "MISMATCH",
+            "note": "path and signature changed",
+        },
+    ]
+    rows_b = [
+        {
+            "downstream_label": "m3",
+            "upstream_label": "m1",
+            "symbol": "Runtime.run",
+            "expected_path": "src/runtime.py",
+            "actual_path": "src/runtime.py",
+            "expected_signature": "Runtime.run(config) -> None",
+            "actual_signature": "Runtime.run(config) -> None",
+            "status": "OK",
+            "note": "",
+        },
+        rows_a[1],
+        rows_a[0],
+    ]
+
+    assert contract_diff_fingerprint(rows_a) == contract_diff_fingerprint(rows_b)

--- a/tests/test_prep_research.py
+++ b/tests/test_prep_research.py
@@ -294,6 +294,7 @@ def test_run_prep_orchestration_caps_fanout_writes_dossier_and_returns_worker(
         ],
         "missing_files": [],
         "shared_files": [],
+        "to_be_built_files": [],
     }
     assert metrics["stage_metrics"]["triage"]["total_tokens"] == 3
     assert metrics["stage_metrics"]["fanout"]["total_tokens"] == 7
@@ -642,3 +643,368 @@ def test_compatible_prep_payload_handles_absent_open_questions() -> None:
     result = prep_research._compatible_prep_payload(payload)
     assert "open_questions" not in result
     assert result["skip"] is False
+
+
+# ---------------------------------------------------------------------------
+# T5: forced upstream-summary prep research areas
+# ---------------------------------------------------------------------------
+
+
+def test_forced_upstream_areas_returns_empty_when_no_chain_policy() -> None:
+    """No forced areas when state lacks chain_policy."""
+    state: PlanState = {
+        "name": "t", "idea": "i", "current_state": "initialized",
+        "iteration": 0, "created_at": "2026-05-24T00:00:00Z",
+        "config": {"project_dir": "/tmp", "robustness": "full"},
+        "sessions": {}, "plan_versions": [], "history": [],
+        "meta": {"total_cost_usd": 0.0, "notes": []},
+        "last_gate": {},
+    }
+    assert prep_research._forced_upstream_areas(state) == []
+
+
+def test_forced_upstream_areas_returns_empty_when_not_plan_only() -> None:
+    """No forced areas when contract_context has plan_only=False."""
+    state: PlanState = {
+        "name": "t", "idea": "i", "current_state": "initialized",
+        "iteration": 0, "created_at": "2026-05-24T00:00:00Z",
+        "config": {"project_dir": "/tmp", "robustness": "full"},
+        "sessions": {}, "plan_versions": [], "history": [],
+        "meta": {
+            "total_cost_usd": 0.0, "notes": [],
+            "chain_policy": {
+                "contract_context": {
+                    "plan_only": False,
+                    "dependency_labels": ["m1"],
+                    "upstream_contracts": [
+                        {
+                            "milestone_label": "m1",
+                            "provides": [{
+                                "name": "P",
+                                "interfaces": [{"symbol": "P.run", "path": "megaplan/p.py", "signature": "P.run()"}],
+                            }],
+                        }
+                    ],
+                },
+            },
+        },
+        "last_gate": {},
+    }
+    assert prep_research._forced_upstream_areas(state) == []
+
+
+def test_forced_upstream_areas_derives_one_area_per_dependency_label() -> None:
+    """Each dependency_label becomes one forced area with upstream path context."""
+    state: PlanState = {
+        "name": "t", "idea": "i", "current_state": "initialized",
+        "iteration": 0, "created_at": "2026-05-24T00:00:00Z",
+        "config": {"project_dir": "/tmp", "robustness": "full"},
+        "sessions": {}, "plan_versions": [], "history": [],
+        "meta": {
+            "total_cost_usd": 0.0, "notes": [],
+            "chain_policy": {
+                "contract_context": {
+                    "plan_only": True,
+                    "dependency_labels": ["m1", "m2"],
+                    "upstream_contracts": [
+                        {
+                            "milestone_label": "m1",
+                            "provides": [{
+                                "name": "Planner surface",
+                                "interfaces": [
+                                    {"symbol": "Planner.run", "path": "megaplan/planner.py", "signature": "Planner.run()"},
+                                ],
+                            }],
+                        },
+                        {
+                            "milestone_label": "m2",
+                            "provides": [{
+                                "name": "Executor surface",
+                                "interfaces": [
+                                    {"symbol": "Executor.run", "path": "megaplan/executor.py", "signature": "Executor.run()"},
+                                ],
+                            }],
+                        },
+                    ],
+                },
+            },
+        },
+        "last_gate": {},
+    }
+    forced = prep_research._forced_upstream_areas(state)
+    assert len(forced) == 2
+    assert forced[0]["id"] == "upstream-m1"
+    assert "megaplan/planner.py" in forced[0]["suggested_files"]
+    assert forced[1]["id"] == "upstream-m2"
+    assert "megaplan/executor.py" in forced[1]["suggested_files"]
+    # Deduplication within forced areas
+    state["meta"]["chain_policy"]["contract_context"]["dependency_labels"] = ["m1", "m1", "m2"]
+    deduped = prep_research._forced_upstream_areas(state)
+    assert len(deduped) == 2
+    assert [a["id"] for a in deduped] == ["upstream-m1", "upstream-m2"]
+
+
+def test_deduplicate_areas_keeps_forced_first_and_drops_duplicate_ids() -> None:
+    """Forced areas appear first; triage areas with same id are dropped."""
+    forced = [{"id": "f1", "area": "forced-1"}, {"id": "f2", "area": "forced-2"}]
+    triage = [{"id": "t1", "area": "triage-1"}, {"id": "f1", "area": "triage-f1-dup"}, {"id": "t2", "area": "triage-2"}]
+    merged = prep_research._deduplicate_areas(forced, triage)
+    ids = [a.get("id") for a in merged]
+    assert ids == ["f1", "f2", "t1", "t2"]
+
+
+def test_cap_research_areas_retains_forced_when_forced_count_exceeds_cap(tmp_path: Path) -> None:
+    """When forced_count >= cap, all slots go to forced areas; triage is culled."""
+    state = _state(tmp_path)
+    state["config"]["robustness"] = "light"  # cap = 2
+    areas = [
+        {"id": "forced-a", "area": "FA"},
+        {"id": "forced-b", "area": "FB"},
+        {"id": "forced-c", "area": "FC"},  # 3 forced
+        {"id": "triage-a", "area": "TA"},
+    ]
+    capped, cap = prep_research._cap_research_areas(state, areas, forced_count=3)
+    assert cap == 2
+    assert len(capped) == 3  # all forced areas retained, triage dropped
+    assert [a["id"] for a in capped] == ["forced-a", "forced-b", "forced-c"]
+
+
+def test_cap_research_areas_normal_cap_when_forced_fewer_than_cap(tmp_path: Path) -> None:
+    """When forced_count < cap, normal slicing applies to merged areas."""
+    state = _state(tmp_path)
+    state["config"]["robustness"] = "full"  # cap = 4
+    areas = [
+        {"id": "forced-a", "area": "FA"},
+        {"id": "triage-a", "area": "TA"},
+        {"id": "triage-b", "area": "TB"},
+        {"id": "triage-c", "area": "TC"},
+        {"id": "triage-d", "area": "TD"},
+    ]
+    capped, cap = prep_research._cap_research_areas(state, areas, forced_count=1)
+    assert cap == 4
+    assert len(capped) == 4
+    assert capped[0]["id"] == "forced-a"
+
+
+def test_prep_metrics_includes_forced_count() -> None:
+    """_prep_metrics records forced_count in the returned dict."""
+    fanout = prep_research.GenericScatterResult(
+        ordered_results=[],
+        total_cost=0.0,
+        total_prompt_tokens=0,
+        total_completion_tokens=0,
+        total_tokens=0,
+        side_results=[],
+    )
+    triage = WorkerResult(
+        payload={}, raw_output="", duration_ms=0, cost_usd=0.0,
+        session_id="s", prompt_tokens=0, completion_tokens=0, total_tokens=0,
+    )
+    distill = WorkerResult(
+        payload={}, raw_output="", duration_ms=0, cost_usd=0.0,
+        session_id="s", prompt_tokens=0, completion_tokens=0, total_tokens=0,
+    )
+    metrics = prep_research._prep_metrics(
+        original_area_count=5,
+        capped_area_count=3,
+        forced_count=2,
+        findings=[],
+        fanout=fanout,
+        triage_worker=triage,
+        distill_worker=distill,
+    )
+    assert metrics["forced_count"] == 2
+    assert metrics["area_count"] == 5
+    assert metrics["fanout_count"] == 3
+
+
+def test_minimal_prep_metrics_has_forced_count() -> None:
+    """minimal_prep_metrics includes forced_count=0."""
+    metrics = prep_research.minimal_prep_metrics()
+    assert "forced_count" in metrics
+    assert metrics["forced_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# T6: upstream-provided path cross-reference classification
+# ---------------------------------------------------------------------------
+
+
+def test_collect_upstream_provided_paths_returns_path_map() -> None:
+    """_collect_upstream_provided_paths maps interface paths to milestone labels."""
+    state: PlanState = {
+        "name": "t", "idea": "i", "current_state": "initialized",
+        "iteration": 0, "created_at": "2026-05-24T00:00:00Z",
+        "config": {"project_dir": "/tmp", "robustness": "full"},
+        "sessions": {}, "plan_versions": [], "history": [],
+        "meta": {
+            "total_cost_usd": 0.0, "notes": [],
+            "chain_policy": {
+                "contract_context": {
+                    "plan_only": True,
+                    "dependency_labels": ["m1"],
+                    "upstream_contracts": [
+                        {
+                            "milestone_label": "m1",
+                            "provides": [{
+                                "name": "Planner surface",
+                                "interfaces": [
+                                    {"symbol": "Planner.run", "path": "megaplan/planner.py", "signature": "Planner.run()"},
+                                    {"symbol": "Planner.init", "path": "megaplan/init.py", "signature": "Planner.init()"},
+                                ],
+                            }],
+                        },
+                    ],
+                },
+            },
+        },
+        "last_gate": {},
+    }
+    paths = prep_research._collect_upstream_provided_paths(state)
+    assert paths == {"megaplan/planner.py": "m1", "megaplan/init.py": "m1"}
+
+
+def test_collect_upstream_provided_paths_returns_empty_without_policy() -> None:
+    """_collect_upstream_provided_paths returns empty dict when plan_only is not True."""
+    state: PlanState = {
+        "name": "t", "idea": "i", "current_state": "initialized",
+        "iteration": 0, "created_at": "2026-05-24T00:00:00Z",
+        "config": {"project_dir": "/tmp", "robustness": "full"},
+        "sessions": {}, "plan_versions": [], "history": [],
+        "meta": {"total_cost_usd": 0.0, "notes": []},
+        "last_gate": {},
+    }
+    assert prep_research._collect_upstream_provided_paths(state) == {}
+
+
+def test_cross_reference_classifies_upstream_paths_as_to_be_built(tmp_path: Path) -> None:
+    """Upstream-provided paths appear in to_be_built_files and are excluded from missing_files."""
+    # Create a file that exists locally
+    (tmp_path / "megaplan").mkdir(parents=True)
+    (tmp_path / "megaplan" / "existing.py").write_text("# exists")
+
+    findings = [
+        {
+            "area": "a", "brief": "b", "status": "complete",
+            "findings": ["f"], "files": ["megaplan/upstream.py", "megaplan/existing.py"],
+            "code_refs": [], "confidence": "high", "error": "",
+        }
+    ]
+    prep_payload: dict[str, Any] = {
+        "relevant_code": [{"file_path": "megaplan/missing.py"}],
+    }
+    upstream_paths = {"megaplan/upstream.py": "m1"}
+
+    cr = prep_research._cross_reference_prep_output(
+        root=tmp_path,
+        findings=findings,
+        prep_payload=prep_payload,
+        upstream_provided_paths=upstream_paths,
+    )
+    assert cr["performed"] is True
+    assert "megaplan/upstream.py" in cr["checked_files"]
+    # upstream.py should be to-be-built, NOT missing
+    assert "megaplan/upstream.py" not in cr["missing_files"]
+    to_be_built = {(item["path"], item["upstream_milestone"]) for item in cr["to_be_built_files"]}
+    assert ("megaplan/upstream.py", "m1") in to_be_built
+    # existing.py exists locally → in existing_files
+    assert "megaplan/existing.py" in cr["existing_files"]
+    # missing.py doesn't exist and isn't upstream → missing
+    assert "megaplan/missing.py" in cr["missing_files"]
+
+
+def test_cross_reference_only_uses_declared_dependency_contract_paths(tmp_path: Path) -> None:
+    """Sibling-only paths stay missing; only declared dependency paths become to-be-built."""
+    state: PlanState = {
+        "name": "t", "idea": "i", "current_state": "initialized",
+        "iteration": 0, "created_at": "2026-05-24T00:00:00Z",
+        "config": {"project_dir": str(tmp_path), "robustness": "full"},
+        "sessions": {}, "plan_versions": [], "history": [],
+        "meta": {
+            "total_cost_usd": 0.0, "notes": [],
+            "chain_policy": {
+                "contract_context": {
+                    "plan_only": True,
+                    "milestone_label": "M-b",
+                    "dependency_labels": ["M-a"],
+                    "upstream_contracts": [
+                        {
+                            "milestone_label": "M-a",
+                            "provides": [{
+                                "name": "Planner surface",
+                                "interfaces": [
+                                    {"symbol": "Planner.run", "path": "planner.py", "signature": "run()"},
+                                ],
+                            }],
+                        },
+                    ],
+                },
+            },
+        },
+        "last_gate": {},
+    }
+    findings = [
+        {
+            "area": "a", "brief": "b", "status": "complete",
+            "findings": ["f"], "files": ["planner.py", "builder.py"],
+            "code_refs": [], "confidence": "high", "error": "",
+        }
+    ]
+    upstream_paths = prep_research._collect_upstream_provided_paths(state)
+
+    cr = prep_research._cross_reference_prep_output(
+        root=tmp_path,
+        findings=findings,
+        prep_payload={},
+        upstream_provided_paths=upstream_paths,
+    )
+
+    assert {(item["path"], item["upstream_milestone"]) for item in cr["to_be_built_files"]} == {
+        ("planner.py", "M-a")
+    }
+    assert "planner.py" not in cr["missing_files"]
+    assert "builder.py" in cr["missing_files"]
+
+
+def test_cross_reference_without_upstream_paths_keeps_old_behavior(tmp_path: Path) -> None:
+    """Without upstream_provided_paths, to_be_built_files is empty and all missing paths stay missing."""
+    findings = [
+        {
+            "area": "a", "brief": "b", "status": "complete",
+            "findings": ["f"], "files": ["megaplan/nonexistent.py"],
+            "code_refs": [], "confidence": "high", "error": "",
+        }
+    ]
+    prep_payload: dict[str, Any] = {}
+
+    cr = prep_research._cross_reference_prep_output(
+        root=tmp_path,
+        findings=findings,
+        prep_payload=prep_payload,
+    )
+    assert cr["to_be_built_files"] == []
+    assert "megaplan/nonexistent.py" in cr["missing_files"]
+
+
+def test_gap_notes_mentions_to_be_built_files() -> None:
+    """_gap_notes includes a note for to_be_built_files."""
+    findings: list[dict[str, Any]] = []
+    prep_payload: dict[str, Any] = {"key_evidence": ["e"], "relevant_code": [], "test_expectations": []}
+    cross_reference = {
+        "performed": True,
+        "checked_files": [],
+        "existing_files": [],
+        "missing_files": [],
+        "shared_files": [],
+        "to_be_built_files": [
+            {"path": "megaplan/planner.py", "upstream_milestone": "m1"},
+            {"path": "megaplan/executor.py", "upstream_milestone": "m2"},
+        ],
+    }
+    notes = prep_research._gap_notes(findings, prep_payload, cross_reference)
+    to_be_built_note = [n for n in notes if "not yet built locally" in n]
+    assert len(to_be_built_note) == 1
+    assert "m1" in to_be_built_note[0]
+    assert "m2" in to_be_built_note[0]
+    assert "megaplan/planner.py" in to_be_built_note[0]
+    assert "megaplan/executor.py" in to_be_built_note[0]

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -486,6 +486,40 @@ def _write_prep_brief(plan_dir: Path) -> None:
     )
 
 
+def _contract_context_payload() -> dict[str, object]:
+    return {
+        "plan_only": True,
+        "dependency_labels": ["m1"],
+        "upstream_contracts": [
+            {
+                "milestone_label": "m1",
+                "provides": [
+                    {
+                        "name": "Planner surface",
+                        "description": "shared planner entrypoints",
+                        "interfaces": [
+                            {
+                                "symbol": "Planner.run",
+                                "signature": "Planner.run(config) -> None",
+                                "path": "megaplan/planner.py",
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def _empty_contract_context_payload(*, milestone_label: str) -> dict[str, object]:
+    return {
+        "plan_only": True,
+        "milestone_label": milestone_label,
+        "dependency_labels": [],
+        "upstream_contracts": [],
+    }
+
+
 def test_plan_prompt_absorbs_clarification_when_missing(tmp_path: Path) -> None:
     plan_dir, state = _scaffold(tmp_path)
     prompt = create_claude_prompt("plan", state, plan_dir)
@@ -536,6 +570,198 @@ def test_prep_prompt_does_not_duplicate_idea_when_notes_present(tmp_path: Path) 
     state["meta"]["notes"] = [{"timestamp": "2026-05-18T00:00:00Z", "note": "n1"}]
     prompt = _prep_prompt(state, plan_dir, root=tmp_path)
     assert prompt.count(state["idea"]) == 1
+
+
+def test_plan_prompt_renders_contract_context_from_explicit_kwarg(tmp_path: Path) -> None:
+    plan_dir, state = _scaffold(tmp_path)
+
+    prompt = create_codex_prompt(
+        "plan",
+        state,
+        plan_dir,
+        contract_context=_contract_context_payload(),
+    )
+
+    assert "Planning-pass upstream contract context:" in prompt
+    assert "`Planner.run` at `megaplan/planner.py`" in prompt
+    assert "planned upstream surfaces" in prompt
+
+
+def test_plan_prompt_uses_metadata_contract_context(tmp_path: Path) -> None:
+    plan_dir, state = _scaffold(tmp_path)
+    state["meta"]["chain_policy"] = {"contract_context": _contract_context_payload()}
+
+    prompt = create_claude_prompt("plan", state, plan_dir)
+
+    assert "Planning-pass upstream contract context:" in prompt
+    assert "Milestone `m1`" in prompt
+
+
+def test_plan_prompt_omits_contract_context_when_not_plan_only(tmp_path: Path) -> None:
+    plan_dir, state = _scaffold(tmp_path)
+    contract_context = _contract_context_payload()
+    contract_context["plan_only"] = False
+
+    prompt = create_claude_prompt("plan", state, plan_dir, contract_context=contract_context)
+
+    assert "Planning-pass upstream contract context:" not in prompt
+
+
+def test_prep_family_prompts_render_contract_context(tmp_path: Path) -> None:
+    plan_dir, state = _scaffold(tmp_path)
+    contract_context = _contract_context_payload()
+
+    prep_prompt = create_claude_prompt(
+        "prep",
+        state,
+        plan_dir,
+        root=tmp_path,
+        contract_context=contract_context,
+    )
+    triage_prompt = create_claude_prompt(
+        "prep-triage",
+        state,
+        plan_dir,
+        root=tmp_path,
+        contract_context=contract_context,
+    )
+    distill_prompt = create_claude_prompt(
+        "prep-distill",
+        state,
+        plan_dir,
+        root=tmp_path,
+        contract_context=contract_context,
+        triage={"triage_framing": "Need targeted investigation", "areas": []},
+        findings=[],
+    )
+
+    assert "Planning-pass upstream contract context:" in prep_prompt
+    assert "planned upstream interfaces to guide prep" in prep_prompt
+    assert "Planning-pass upstream contract context:" in triage_prompt
+    assert "research-area split" in triage_prompt
+    assert "Planning-pass upstream contract context:" in distill_prompt
+    assert "final prep view" in distill_prompt
+
+
+def test_metadata_contract_context_renders_only_for_declared_dependencies(tmp_path: Path) -> None:
+    plan_dir, state = _scaffold(tmp_path)
+    state["meta"]["chain_policy"] = {"contract_context": _contract_context_payload()}
+
+    dependency_plan_prompt = create_claude_prompt("plan", state, plan_dir)
+    dependency_prep_prompt = create_claude_prompt("prep", state, plan_dir, root=tmp_path)
+
+    assert "Planning-pass upstream contract context:" in dependency_plan_prompt
+    assert "Planning-pass upstream contract context:" in dependency_prep_prompt
+    assert "Milestone `m1`" in dependency_plan_prompt
+
+    state["meta"]["chain_policy"] = {
+        "contract_context": _empty_contract_context_payload(milestone_label="m3")
+    }
+    sibling_only_plan_prompt = create_claude_prompt("plan", state, plan_dir)
+    sibling_only_prep_prompt = create_claude_prompt("prep", state, plan_dir, root=tmp_path)
+
+    assert "Planning-pass upstream contract context:" not in sibling_only_plan_prompt
+    assert "Planning-pass upstream contract context:" not in sibling_only_prep_prompt
+
+
+def test_contract_context_routing_preserves_root_for_critique_and_gate(tmp_path: Path) -> None:
+    plan_dir, state = _scaffold(tmp_path, iteration=2)
+    _write_debt_registry(
+        tmp_path,
+        [
+            _debt_entry(
+                concern="timeout recovery: retry backoff remains brittle",
+                occurrence_count=4,
+                plan_ids=["plan-a", "plan-b", "plan-c"],
+            )
+        ],
+    )
+
+    critique_prompt = create_claude_prompt(
+        "critique",
+        state,
+        plan_dir,
+        root=tmp_path,
+        contract_context=_contract_context_payload(),
+    )
+    gate_prompt = create_codex_prompt(
+        "gate",
+        state,
+        plan_dir,
+        root=tmp_path,
+        contract_context=_contract_context_payload(),
+    )
+
+    assert "Known accepted debt grouped by subsystem" in critique_prompt
+    assert "timeout recovery: retry backoff remains brittle" in critique_prompt
+    assert "Escalated debt subsystems" in gate_prompt
+    # Deferred-verification contract language
+    assert "Deferred-verification planning-pass contract context" in critique_prompt
+    assert "Do NOT flag missing files" in critique_prompt
+    assert "Deferred-verification planning-pass contract context" in gate_prompt
+    assert "Do not treat missing upstream files" in gate_prompt
+
+
+def test_critique_and_gate_prompts_unchanged_without_contract_context(tmp_path: Path) -> None:
+    """Default critique/gate prompts should not contain deferred-verification language."""
+    plan_dir, state = _scaffold(tmp_path, iteration=2)
+    _write_debt_registry(
+        tmp_path,
+        [
+            _debt_entry(
+                concern="timeout recovery: retry backoff remains brittle",
+                occurrence_count=4,
+                plan_ids=["plan-a", "plan-b", "plan-c"],
+            )
+        ],
+    )
+
+    critique_prompt = create_claude_prompt("critique", state, plan_dir, root=tmp_path)
+    gate_prompt = create_codex_prompt("gate", state, plan_dir, root=tmp_path)
+
+    # Default prompts should NOT contain deferred-verification language
+    assert "Deferred-verification" not in critique_prompt
+    assert "Deferred-verification" not in gate_prompt
+    # But should still have their standard content
+    assert "You are an independent reviewer" in critique_prompt
+    assert "gatekeeper" in gate_prompt
+
+
+def test_critique_evaluator_prompt_renders_deferred_verification(tmp_path: Path) -> None:
+    """Critique evaluator renders deferred-verification block when plan_only."""
+    plan_dir, state = _scaffold(tmp_path, iteration=2)
+
+    prompt = create_claude_prompt(
+        "critique_evaluator",
+        state,
+        plan_dir,
+        root=tmp_path,
+        contract_context=_contract_context_payload(),
+        flag_lifecycle={"flags": []},
+        iteration_pressure=[],
+        gate_signals={"signals": {}},
+    )
+
+    assert "Deferred-verification planning-pass contract context" in prompt
+    assert "do not route existence/availability checks" in prompt
+
+
+def test_critique_evaluator_prompt_unchanged_without_contract_context(tmp_path: Path) -> None:
+    """Default critique evaluator prompt should not contain deferred-verification language."""
+    plan_dir, state = _scaffold(tmp_path, iteration=2)
+
+    prompt = create_claude_prompt(
+        "critique_evaluator",
+        state,
+        plan_dir,
+        root=tmp_path,
+        flag_lifecycle={"flags": []},
+        iteration_pressure=[],
+        gate_signals={"signals": {}},
+    )
+
+    assert "Deferred-verification" not in prompt
+    assert "Critique Evaluator" in prompt
 
 
 def test_render_prep_block_returns_empty_strings_when_missing(tmp_path: Path) -> None:


### PR DESCRIPTION
Interim snapshot of the M2 execute working tree (T1–T14 applied; T15 test-fix still completing in the live run). Captured via temp index so the running executor is undisturbed. Final validated state follows when the chain completes. +3401/-26 across 24 files; adds plan_contracts.py + the contract/review/reground wiring.