### PR TITLE
fix: harden critique and agent loop recovery

### DIFF
--- a/megaplan/_core/workflow.py
+++ b/megaplan/_core/workflow.py
@@ -77,10 +77,12 @@ def adaptive_critique_enabled(state: PlanState) -> bool:
 def pinned_critic_model(state: PlanState) -> str:
     """Return the model the farmed-out critic is pinned to, or "" if unpinned.
 
-    When set, the adaptive evaluator still selects lenses, but every critic
-    dispatch is forced to this model instead of the evaluator's per-lens
-    assignment (which can escalate to premium models).
+    Only an explicitly operator-provided pin is honored. Older/persisted states
+    may carry a ``config.critic_model`` value from a profile or stale default;
+    without the provenance bit that value must not shadow per-lens routing.
     """
+    if not bool(state["config"].get("critic_model_explicit", False)):
+        return ""
     return str(state["config"].get("critic_model", "") or "").strip()
 
 

--- a/megaplan/agent/run_agent.py
+++ b/megaplan/agent/run_agent.py
@@ -77,6 +77,48 @@ from hermes_constants import OPENROUTER_BASE_URL
 
 DEFAULT_API_TIMEOUT_SECONDS = 300.0
 DEFAULT_DEEPSEEK_API_TIMEOUT_SECONDS = 1200.0
+DEFAULT_MAX_SAME_FILE_READS = 5
+DEFAULT_HARD_MAX_SAME_FILE_READS = 10
+DEFAULT_STREAMING_TIMEOUT_HARD_CEILING_SECONDS = 3600.0
+
+
+def _env_int_at_least(name: str, default: int, minimum: int) -> int:
+    try:
+        value = int(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        value = default
+    return max(value, minimum)
+
+
+def _max_same_file_reads() -> int:
+    return _env_int_at_least(
+        "HERMES_MAX_SAME_FILE_READS", DEFAULT_MAX_SAME_FILE_READS, 1
+    )
+
+
+def _hard_max_same_file_reads(soft_limit: int | None = None) -> int:
+    soft = _max_same_file_reads() if soft_limit is None else soft_limit
+    hard = _env_int_at_least(
+        "HERMES_HARD_MAX_SAME_FILE_READS",
+        DEFAULT_HARD_MAX_SAME_FILE_READS,
+        soft + 1,
+    )
+    return max(hard, soft + 1)
+
+
+def _streaming_timeout_hard_ceiling_seconds() -> float:
+    try:
+        value = float(
+            os.getenv(
+                "HERMES_STREAMING_TIMEOUT_HARD_CEILING_SECONDS",
+                DEFAULT_STREAMING_TIMEOUT_HARD_CEILING_SECONDS,
+            )
+        )
+    except (TypeError, ValueError):
+        value = DEFAULT_STREAMING_TIMEOUT_HARD_CEILING_SECONDS
+    return max(value, 1.0)
+
+
 # Per-read (inter-chunk) socket inactivity bound for streaming SSE responses.
 # A synchronous `for chunk in stream:` read with no httpx read-timeout blocks
 # inside the C-level socket recv() and CANNOT be interrupted by another thread
@@ -1008,12 +1050,20 @@ class AIAgent:
         # they bloat the prompt past the streaming deadline.
         self._tool_dedup_cache: dict[tuple[str, str], str] = {}
 
+        # Per-agent read counts keyed by canonical file path. This deliberately
+        # persists across run_conversation() calls so cross-turn read loops are
+        # stopped before they keep injecting the same file into the prompt.
+        self._file_read_counts: dict[str, int] = {}
+
         # Consecutive streaming-deadline timeouts. Increments on each
         # TimeoutError("Streaming API call exceeded ..."); resets to 0 after
         # any successful streaming call. _api_timeout_seconds() multiplies
         # the base deadline by 1.5× per streak level (capped at 4×) so a
         # slow generation on a large prompt has a real shot on the retry.
         self._streaming_timeout_streak: int = 0
+        self._last_streaming_timeout_tokens: int | None = None
+        self._streaming_timeout_wall_start_monotonic: float | None = None
+        self._last_streaming_request_started_at: float | None = None
         
         # Store OpenRouter provider preferences
         self.providers_allowed = providers_allowed
@@ -3603,7 +3653,52 @@ class AIAgent:
         if streak > 0:
             scale = min(1.5 ** streak, 4.0)
             timeout = timeout * scale
+        wall_start = getattr(self, "_streaming_timeout_wall_start_monotonic", None)
+        if wall_start is not None:
+            remaining = _streaming_timeout_hard_ceiling_seconds() - (
+                time.monotonic() - wall_start
+            )
+            timeout = min(timeout, remaining)
         return max(timeout, 0.1)
+
+    def _record_streaming_timeout_or_abort(
+        self,
+        *,
+        approx_tokens: int,
+        message_count: int,
+        elapsed_seconds: float,
+    ) -> str | None:
+        request_started = getattr(self, "_last_streaming_request_started_at", None)
+        if getattr(self, "_streaming_timeout_wall_start_monotonic", None) is None:
+            self._streaming_timeout_wall_start_monotonic = (
+                request_started if request_started is not None else time.monotonic()
+            )
+
+        previous_tokens = getattr(self, "_last_streaming_timeout_tokens", None)
+        if (
+            isinstance(previous_tokens, int)
+            and previous_tokens > 0
+            and approx_tokens > previous_tokens * 1.2
+        ):
+            return (
+                "Streaming deadline hit again while the prompt grew from "
+                f"~{previous_tokens:,} to ~{approx_tokens:,} tokens "
+                f"({message_count} messages). Treating this as a probable "
+                "tool-call loop; aborting without escalating the deadline."
+            )
+
+        ceiling = _streaming_timeout_hard_ceiling_seconds()
+        wall_elapsed = time.monotonic() - self._streaming_timeout_wall_start_monotonic
+        if wall_elapsed >= ceiling:
+            return (
+                "Streaming deadline retry ceiling reached "
+                f"({wall_elapsed:.0f}s >= {ceiling:.0f}s, last request "
+                f"elapsed {elapsed_seconds:.0f}s). Aborting without another retry."
+            )
+
+        self._last_streaming_timeout_tokens = approx_tokens
+        self._streaming_timeout_streak = getattr(self, "_streaming_timeout_streak", 0) + 1
+        return None
 
     def _abort_request_client(self, request_client_holder: dict, *, reason: str) -> None:
         try:
@@ -3922,6 +4017,7 @@ class AIAgent:
                 if request_client is not None:
                     self._close_request_openai_client(request_client, reason="request_complete")
 
+        self._last_streaming_request_started_at = time.monotonic()
         t = threading.Thread(target=_call, daemon=True)
         t.start()
         timeout_seconds = self._api_timeout_seconds()
@@ -4471,6 +4567,9 @@ class AIAgent:
         # Successful streaming call — reset the deadline-extension streak so
         # the next request starts from the configured base timeout.
         self._streaming_timeout_streak = 0
+        self._last_streaming_timeout_tokens = None
+        self._streaming_timeout_wall_start_monotonic = None
+        self._last_streaming_request_started_at = None
         return result["response"]
 
     # ── Provider fallback ──────────────────────────────────────────────────
@@ -5357,8 +5456,14 @@ class AIAgent:
         instead. Also clears the cache when a mutating tool runs, so later
         reads see fresh content.
         """
+        if function_name == "read_file" and function_result.startswith(
+            "[megaplan file-read circuit breaker]"
+        ):
+            return function_result
+
         if function_name in _DEDUP_INVALIDATING_TOOLS:
             self._tool_dedup_cache.clear()
+            self._invalidate_file_read_counts(function_name, function_args)
             return function_result
 
         if function_name not in _DEDUPABLE_TOOLS:
@@ -5388,6 +5493,64 @@ class AIAgent:
             f"of re-issuing this call. If external state may have changed, "
             f"vary the arguments (e.g. offset/limit) to force a re-read."
         )
+
+    def _canonical_read_file_path(self, function_args: dict) -> str | None:
+        raw_path = function_args.get("path")
+        if not isinstance(raw_path, str) or not raw_path.strip():
+            return None
+        try:
+            path = Path(raw_path).expanduser()
+            if not path.is_absolute():
+                path = Path(_resolve_checkpoint_cwd()).expanduser() / path
+            return str(path.resolve(strict=False))
+        except Exception:
+            return str(Path(raw_path).expanduser())
+
+    def _invalidate_file_read_counts(self, function_name: str, function_args: dict) -> None:
+        counts = getattr(self, "_file_read_counts", None)
+        if not isinstance(counts, dict) or not counts:
+            return
+        if function_name in {"write_file", "patch"}:
+            path_key = self._canonical_read_file_path(function_args)
+            if path_key:
+                counts.pop(path_key, None)
+            return
+        if function_name == "terminal":
+            counts.clear()
+
+    def _maybe_short_circuit_file_read(self, function_name: str, function_args: dict) -> str | None:
+        if function_name != "read_file":
+            return None
+        path_key = self._canonical_read_file_path(function_args)
+        if not path_key:
+            return None
+
+        counts = getattr(self, "_file_read_counts", None)
+        if not isinstance(counts, dict):
+            counts = {}
+            self._file_read_counts = counts
+
+        next_count = int(counts.get(path_key, 0)) + 1
+        counts[path_key] = next_count
+
+        soft_limit = _max_same_file_reads()
+        hard_limit = _hard_max_same_file_reads(soft_limit)
+        if next_count > hard_limit:
+            return (
+                "[megaplan file-read circuit breaker] REFUSED read_file: "
+                f"{path_key} has already been read {next_count} times in this "
+                "agent conversation. The repeated reads are a loop signal. "
+                "Do not call read_file for this path again; proceed with your "
+                "findings using the content already in context."
+            )
+        if next_count > soft_limit:
+            return (
+                "[megaplan file-read circuit breaker] Skipped read_file: "
+                f"{path_key} was already read {next_count} times in this agent "
+                "conversation and its content is unchanged. Reuse the content "
+                "already in context instead of re-reading it."
+            )
+        return None
 
     def _execute_tool_calls(self, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:
         """Execute tool calls from the assistant message and append results to messages.
@@ -5567,7 +5730,9 @@ class AIAgent:
             """Worker function executed in a thread."""
             start = time.time()
             try:
-                result = self._invoke_tool(function_name, function_args, effective_task_id)
+                result = self._maybe_short_circuit_file_read(function_name, function_args)
+                if result is None:
+                    result = self._invoke_tool(function_name, function_args, effective_task_id)
             except Exception as tool_error:
                 result = f"Error executing tool '{function_name}': {tool_error}"
                 logger.error("_invoke_tool raised for %s: %s", function_name, tool_error, exc_info=True)
@@ -5747,8 +5912,14 @@ class AIAgent:
                     pass  # never block tool execution
 
             tool_start_time = time.time()
+            _file_read_guard_result = self._maybe_short_circuit_file_read(
+                function_name, function_args
+            )
 
-            if function_name == "todo":
+            if _file_read_guard_result is not None:
+                function_result = _file_read_guard_result
+                tool_duration = time.time() - tool_start_time
+            elif function_name == "todo":
                 from tools.todo_tool import todo_tool as _todo_tool
                 function_result = _todo_tool(
                     todos=function_args.get("todos"),
@@ -6261,6 +6432,9 @@ class AIAgent:
         # a prior conversation's slow phase shouldn't extend the new one's
         # default deadline.
         self._streaming_timeout_streak = 0
+        self._last_streaming_timeout_tokens = None
+        self._streaming_timeout_wall_start_monotonic = None
+        self._last_streaming_request_started_at = None
         # NOTE: _turns_since_memory and _iters_since_skill are NOT reset here.
         # They are initialized in __init__ and must persist across run_conversation
         # calls so that nudge logic accumulates correctly in CLI mode.
@@ -7165,7 +7339,27 @@ class AIAgent:
                         or is_read_timeout
                     )
                     if is_streaming_timeout:
-                        self._streaming_timeout_streak += 1
+                        timeout_abort = self._record_streaming_timeout_or_abort(
+                            approx_tokens=approx_tokens,
+                            message_count=len(api_messages),
+                            elapsed_seconds=elapsed_time,
+                        )
+                        if timeout_abort:
+                            self._vprint(
+                                f"{self.log_prefix}❌ {timeout_abort}",
+                                force=True,
+                            )
+                            logging.error("%s%s", self.log_prefix, timeout_abort)
+                            self._persist_session(messages, conversation_history)
+                            return {
+                                "final_response": None,
+                                "messages": messages,
+                                "api_calls": api_call_count,
+                                "completed": False,
+                                "failed": True,
+                                "non_retryable": True,
+                                "error": timeout_abort,
+                            }
                         next_deadline = self._api_timeout_seconds()
                         self._vprint(
                             f"{self.log_prefix}⚠️  Streaming deadline exceeded "

--- a/megaplan/handlers/critique.py
+++ b/megaplan/handlers/critique.py
@@ -50,6 +50,75 @@ from .tiebreaker import _build_tiebreaker_reprompt
 
 log = logging.getLogger("megaplan")
 
+
+def _apply_adaptive_critique_routing(
+    state: PlanState,
+    args: argparse.Namespace,
+    active_checks: list[dict[str, Any]],
+) -> str | None:
+    """Attach per-check critic modes or return an explicit operator pin."""
+    _pin = pinned_critic_model(state)
+    if _pin:
+        if any(isinstance(check.get("complexity"), int) and check["complexity"] >= 4 for check in active_checks):
+            msg = (
+                "[megaplan] WARNING: explicit critic_model pin "
+                f"{_pin!r} disables per-lens critique escalation for "
+                "complexity >= 4 checks; all selected lenses will run on the pin."
+            )
+            print(msg, file=sys.stderr, flush=True)
+            log.warning(msg)
+        return _pin
+
+    # No operator pin: resolve per-check AgentMode from tier_models.critique
+    # (complexity-based routing, SD1). Cache complexity -> AgentMode to avoid
+    # redundant resolution when multiple checks share the same complexity tier.
+    _tier_models = getattr(args, "tier_models", None)
+    if not isinstance(_tier_models, dict):
+        return None
+    _critique_tiers = _tier_models.get("critique")
+    if not isinstance(_critique_tiers, dict) or not _critique_tiers:
+        return None
+
+    from megaplan.execute.batch import _resolve_tier_spec
+    from megaplan.types import AgentMode as _TierAgentMode
+
+    _complexity_cache: dict[int, _TierAgentMode] = {}
+    for _check in active_checks:
+        _cid = _check.get("id", "?")
+        _cx = _check.get("complexity")
+        if not isinstance(_cx, int) or _cx < 1 or _cx > 5:
+            raise CliError(
+                "critique_complexity_invariant",
+                f"Check '{_cid}' has missing or invalid "
+                f"complexity ({_cx!r}); cannot resolve tier "
+                "routing. This is an invariant error in "
+                "the evaluator output.",
+            )
+        if _cx not in _complexity_cache:
+            _spec = _critique_tiers.get(_cx)
+            if not _spec:
+                raise CliError(
+                    "critique_tier_missing",
+                    f"No tier spec for complexity {_cx} "
+                    f"in tier_models.critique; cannot "
+                    f"route check '{_cid}'.",
+                )
+            _t_agent, _t_mode, _t_model = _resolve_tier_spec(
+                args, _spec, phase="critique"
+            )
+            _complexity_cache[_cx] = _TierAgentMode(
+                agent=_t_agent,
+                mode=_t_mode,
+                refreshed=False,
+                model=_t_model,
+                effort=None,
+                resolved_model=_t_model,
+            )
+        _check["_resolved_agent_mode"] = _complexity_cache[_cx]
+
+    return None
+
+
 def handle_critique(root: Path, args: argparse.Namespace) -> StepResponse:
     with load_plan_locked(root, args.plan, step="critique") as (plan_dir, state):
         require_state(state, "critique", {STATE_PLANNED})
@@ -336,64 +405,14 @@ def handle_critique(root: Path, args: argparse.Namespace) -> StepResponse:
             active_checks = select_active_checks(state, robustness, plan_dir=plan_dir)
             expected_ids = [check["id"] for check in active_checks]
             resolved = _pkg.resolve_agent_mode("critique", args)
-        # Operator pin: when execution.critic_model is set, the evaluator still
-        # selects which lenses fire, but every farmed-out critic is forced to
-        # the pinned model instead of the complexity-based tier routing
-        # (tier_models.critique). "" leaves tier-based routing in force.
+        # Explicit operator pin: when execution.critic_model was explicitly
+        # supplied, the evaluator still selects which lenses fire, but every
+        # critic is forced to that model. Stale/profile/default critic_model
+        # values are ignored so tier_models.critique can route per complexity.
         if adaptive_path:
-            _pin = pinned_critic_model(state)
-            if _pin:
-                critic_model_override = _pin
-            else:
-                # No operator pin: resolve per-check AgentMode from
-                # tier_models.critique (complexity-based routing, SD1).
-                # Cache complexity → AgentMode to avoid redundant resolution
-                # when multiple checks share the same complexity tier.
-                _tier_models = getattr(args, "tier_models", None)
-                if isinstance(_tier_models, dict):
-                    _critique_tiers = _tier_models.get("critique")
-                    if isinstance(_critique_tiers, dict) and _critique_tiers:
-                        from megaplan.execute.batch import _resolve_tier_spec
-                        from megaplan.types import AgentMode as _TierAgentMode
-
-                        _complexity_cache: dict[int, _TierAgentMode] = {}
-                        for _check in active_checks:
-                            _cid = _check.get("id", "?")
-                            _cx = _check.get("complexity")
-                            if not isinstance(_cx, int) or _cx < 1 or _cx > 5:
-                                raise CliError(
-                                    "critique_complexity_invariant",
-                                    f"Check '{_cid}' has missing or invalid "
-                                    f"complexity ({_cx!r}); cannot resolve tier "
-                                    "routing. This is an invariant error in "
-                                    "the evaluator output.",
-                                )
-                            if _cx not in _complexity_cache:
-                                _spec = _critique_tiers.get(_cx)
-                                if not _spec:
-                                    raise CliError(
-                                        "critique_tier_missing",
-                                        f"No tier spec for complexity {_cx} "
-                                        f"in tier_models.critique; cannot "
-                                        f"route check '{_cid}'.",
-                                    )
-                                (
-                                    _t_agent,
-                                    _t_mode,
-                                    _t_model,
-                                ) = _resolve_tier_spec(
-                                    args, _spec, phase="critique"
-                                )
-                                _complexity_cache[_cx] = _TierAgentMode(
-                                    agent=_t_agent,
-                                    mode=_t_mode,
-                                    refreshed=False,
-                                    model=_t_model,
-                                    effort=None,
-                                    resolved_model=_t_model,
-                                )
-                            # Attach resolved AgentMode to check metadata (SD1)
-                            _check["_resolved_agent_mode"] = _complexity_cache[_cx]
+            critic_model_override = _apply_adaptive_critique_routing(
+                state, args, active_checks
+            )
         from megaplan.types import AgentMode as _AgentMode
 
         agent_type, mode, refreshed, model = _agent_mode_parts(resolved)

--- a/megaplan/handlers/init.py
+++ b/megaplan/handlers/init.py
@@ -156,14 +156,18 @@ def _build_state_config(
 
         assert_adaptive_critique_wired()
 
-    # Precedence mirrors adaptive_critique: explicit --critic-model CLI flag >
-    # explicit user-config setting > profile-level `critic_model` field > global
-    # default (""). When set, the adaptive evaluator still picks lenses, but the
-    # farmed-out critic is pinned to this model (no per-lens escalation).
+    # Precedence mirrors adaptive_critique for the stored value, but only an
+    # explicit operator source (CLI flag or explicit user config) is allowed to
+    # act as a pin at critique time. Profile/default values are informational
+    # and must not shadow per-lens tier routing.
+    critic_model_explicit = False
     critic_model_value = getattr(args, "critic_model", None)
+    if critic_model_value is not None:
+        critic_model_explicit = True
     if critic_model_value is None:
         if setting_is_explicit("execution", "critic_model"):
             critic_model_value = get_effective("execution", "critic_model")
+            critic_model_explicit = True
         else:
             profile_name = getattr(args, "profile", None)
             profile_critic: Any = None
@@ -233,6 +237,7 @@ def _build_state_config(
         "adaptive_critique": adaptive_critique,
         "strict_adaptive_critique": strict_adaptive_critique,
         "critic_model": critic_model,
+        "critic_model_explicit": critic_model_explicit,
         "robustness": robustness,
         "mode": mode,
         "strict_notes": strict_notes,

--- a/megaplan/orchestration/parallel_critique.py
+++ b/megaplan/orchestration/parallel_critique.py
@@ -29,6 +29,25 @@ from megaplan.types import CliError, PlanState
 from megaplan.workers import STEP_SCHEMA_FILENAMES, WorkerResult
 
 
+_CRITIQUE_WORKER_SHAPE_RETRIES = 2
+_CRITIQUE_REPAIR_INSTRUCTION = (
+    "Return a JSON object with a top-level `checks` array containing EXACTLY ONE "
+    "check object for this single lens. Do not include multiple checks or wrap it differently."
+)
+
+
+class _RetryableCritiqueShapeError(Exception):
+    """Internal signal for a critique worker payload that can be repaired by retry."""
+
+    def __init__(self, check_id: str, check_count: int, raw_payload: Any) -> None:
+        super().__init__(
+            f"Parallel critique output for check '{check_id}' did not contain exactly one check"
+        )
+        self.check_id = check_id
+        self.check_count = check_count
+        self.raw_payload = raw_payload
+
+
 def _run_check(
     index: int,
     check: dict[str, Any],
@@ -262,14 +281,11 @@ def run_parallel_critique(
     # Parse hook: extract exactly one check + verified/disputed per unit
     # ------------------------------------------------------------------
     def _parse_result(_index: int, raw_payload: Any, unit: WorkerUnit) -> tuple[dict[str, Any], list[str], list[str]]:
-        _checks_list = raw_payload.get("checks") if isinstance(raw_payload, dict) else []
+        _checks_list = raw_payload.get("checks") if isinstance(raw_payload, dict) else None
         if not isinstance(_checks_list, list) or len(_checks_list) != 1 or not isinstance(_checks_list[0], dict):
             _cid = unit.extra.get("check_id", "?")
-            raise CliError(
-                "worker_parse_error",
-                f"Parallel critique output for check '{_cid}' did not contain exactly one check",
-                extra={"raw_output": str(raw_payload)},
-            )
+            _count = len(_checks_list) if isinstance(_checks_list, list) else 0
+            raise _RetryableCritiqueShapeError(str(_cid), _count, raw_payload)
         _verified = raw_payload.get("verified_flag_ids", [])
         _disputed = raw_payload.get("disputed_flag_ids", [])
         return (
@@ -278,18 +294,96 @@ def run_parallel_critique(
             _disputed if isinstance(_disputed, list) else [],
         )
 
+    def _repair_unit(unit: WorkerUnit) -> WorkerUnit:
+        return WorkerUnit(
+            step=unit.step,
+            resolved=unit.resolved,
+            prompt=f"{_CRITIQUE_REPAIR_INSTRUCTION}\n\n{unit.prompt}",
+            output_path=unit.output_path,
+            read_only=unit.read_only,
+            extra=dict(unit.extra),
+        )
+
+    def _scatter_raw(current_units: list[WorkerUnit]) -> Any:
+        return scatter_worker_units(
+            units=current_units,
+            state=state,
+            plan_dir=plan_dir,
+            root=root,
+            args=_args,
+            max_concurrent=max_concurrent,
+        )
+
+    def _accumulate_scatter_totals(scatter_result: Any) -> None:
+        nonlocal _total_cost, _total_prompt_tokens, _total_completion_tokens, _total_tokens
+        _total_cost += scatter_result.total_cost
+        _total_prompt_tokens += scatter_result.total_prompt_tokens
+        _total_completion_tokens += scatter_result.total_completion_tokens
+        _total_tokens += scatter_result.total_tokens
+
     # ------------------------------------------------------------------
-    # Scatter
+    # Scatter + repair malformed worker shapes locally
     # ------------------------------------------------------------------
-    sr = scatter_worker_units(
-        units=units,
-        state=state,
-        plan_dir=plan_dir,
-        root=root,
-        args=_args,
-        parse_result=_parse_result,
-        max_concurrent=max_concurrent,
-    )
+    _total_cost = 0.0
+    _total_prompt_tokens = 0
+    _total_completion_tokens = 0
+    _total_tokens = 0
+    _parsed_results: list[tuple[dict[str, Any], list[str], list[str]] | None] = [None] * len(units)
+
+    _sr = _scatter_raw(units)
+    _accumulate_scatter_totals(_sr)
+
+    _failures: dict[int, _RetryableCritiqueShapeError] = {}
+    for _idx, _payload in enumerate(_sr.ordered_results):
+        try:
+            _parsed_results[_idx] = _parse_result(_idx, _payload, units[_idx])
+        except _RetryableCritiqueShapeError as exc:
+            _failures[_idx] = exc
+
+    _retry_units = units
+    for _retry_number in range(1, _CRITIQUE_WORKER_SHAPE_RETRIES + 1):
+        if not _failures:
+            break
+        _next_attempt = _retry_number + 1
+        _total_attempts = _CRITIQUE_WORKER_SHAPE_RETRIES + 1
+        _retry_indices = list(_failures)
+        for _failure in _failures.values():
+            print(
+                f"[parallel-critique] worker '{_failure.check_id}' returned "
+                f"{_failure.check_count} checks, retrying (attempt {_next_attempt}/{_total_attempts})",
+                file=sys.stderr,
+            )
+
+        _subset_units = [_repair_unit(_retry_units[_idx]) for _idx in _retry_indices]
+        _retry_units_by_index = dict(zip(_retry_indices, _subset_units, strict=True))
+        _retry_sr = _scatter_raw(_subset_units)
+        _accumulate_scatter_totals(_retry_sr)
+
+        _next_failures: dict[int, _RetryableCritiqueShapeError] = {}
+        for _subset_pos, _payload in enumerate(_retry_sr.ordered_results):
+            _original_idx = _retry_indices[_subset_pos]
+            _unit = _retry_units_by_index[_original_idx]
+            try:
+                _parsed_results[_original_idx] = _parse_result(_original_idx, _payload, _unit)
+            except _RetryableCritiqueShapeError as exc:
+                _next_failures[_original_idx] = exc
+        _failures = _next_failures
+        for _idx, _unit in _retry_units_by_index.items():
+            _retry_units[_idx] = _unit
+
+    if _failures:
+        _details = ", ".join(
+            f"{exc.check_id} returned {exc.check_count} checks"
+            for exc in _failures.values()
+        )
+        raise CliError(
+            "worker_parse_error",
+            "Parallel critique worker shape retry budget exhausted: " + _details,
+            extra={
+                "attempts": _CRITIQUE_WORKER_SHAPE_RETRIES + 1,
+                "raw_outputs": {idx: str(exc.raw_payload) for idx, exc in _failures.items()},
+            },
+        )
 
     # ------------------------------------------------------------------
     # Reduce: ordered checks + flag merge (disputed trumps verified)
@@ -297,7 +391,12 @@ def run_parallel_critique(
     ordered_checks: list[dict[str, Any]] = []
     verified_groups: list[list[str]] = []
     disputed_groups: list[list[str]] = []
-    for _item in sr.ordered_results:
+    for _item in _parsed_results:
+        if _item is None:
+            raise CliError(
+                "worker_parse_error",
+                "Parallel critique worker result missing after retry processing",
+            )
         _check_payload, _v_ids, _d_ids = _item
         ordered_checks.append(_check_payload)
         verified_groups.append(_v_ids)
@@ -318,9 +417,9 @@ def run_parallel_critique(
         },
         raw_output="parallel",
         duration_ms=int((time.monotonic() - started) * 1000),
-        cost_usd=sr.total_cost,
+        cost_usd=_total_cost,
         session_id=None,
-        prompt_tokens=sr.total_prompt_tokens,
-        completion_tokens=sr.total_completion_tokens,
-        total_tokens=sr.total_tokens,
+        prompt_tokens=_total_prompt_tokens,
+        completion_tokens=_total_completion_tokens,
+        total_tokens=_total_tokens,
     )

--- a/tests/test_critique.py
+++ b/tests/test_critique.py
@@ -840,6 +840,7 @@ def test_handle_critique_pin_forces_critic_model_over_evaluator_assignment(
     persisted = json.loads(state_path.read_text(encoding="utf-8"))
     persisted["config"]["adaptive_critique"] = True
     persisted["config"]["critic_model"] = "deepseek-v4-pro"
+    persisted["config"]["critic_model_explicit"] = True
     state_path.write_text(json.dumps(persisted, indent=2), encoding="utf-8")
 
     all_check_ids = [c["id"] for c in CRITIQUE_CHECKS]
@@ -2052,6 +2053,7 @@ def test_operator_pin_overrides_all_per_lens_complexity_routing(
     persisted["config"]["adaptive_critique"] = True
     # Set the operator pin — this must override complexity routing.
     persisted["config"]["critic_model"] = "deepseek-v4-pro"
+    persisted["config"]["critic_model_explicit"] = True
     state_path.write_text(json.dumps(persisted, indent=2), encoding="utf-8")
 
     all_check_ids = [c["id"] for c in CRITIQUE_CHECKS]
@@ -2496,6 +2498,7 @@ def test_operator_pin_forces_same_resolved_model_across_all_lenses_with_non_herm
     persisted["config"]["adaptive_critique"] = True
     # Operator pin to deepseek-v4-pro — must override all complexity routing.
     persisted["config"]["critic_model"] = "deepseek-v4-pro"
+    persisted["config"]["critic_model_explicit"] = True
     state_path.write_text(json.dumps(persisted, indent=2), encoding="utf-8")
 
     all_check_ids = [c["id"] for c in CRITIQUE_CHECKS]

--- a/tests/test_parallel_critique.py
+++ b/tests/test_parallel_critique.py
@@ -15,7 +15,7 @@ from megaplan.audits.robustness import checks_for_robustness
 from megaplan.workers.hermes import parse_agent_output
 from megaplan.orchestration.parallel_critique import _run_check, run_parallel_critique
 from megaplan.prompts.critique import write_single_check_template
-from megaplan.types import AgentMode, PlanState
+from megaplan.types import AgentMode, CliError, PlanState
 from megaplan.workers import STEP_SCHEMA_FILENAMES, WorkerResult
 
 
@@ -96,6 +96,20 @@ def _check_payload(check: dict[str, str], detail: str, *, flagged: bool = False)
     }
 
 
+def _raw_critique_payload(
+    check_payload: dict[str, Any],
+    *,
+    verified: list[str] | None = None,
+    disputed: list[str] | None = None,
+) -> dict[str, object]:
+    return {
+        "checks": [check_payload],
+        "flags": [],
+        "verified_flag_ids": verified or [],
+        "disputed_flag_ids": disputed or [],
+    }
+
+
 def _resolved_mode(
     agent: str = "hermes",
     mode: str = "creative",
@@ -126,16 +140,15 @@ def test_run_parallel_critique_merges_in_original_order(monkeypatch: pytest.Monk
     raw_checks = checks_for_robustness("standard")
     enriched = _enrich_checks(raw_checks)
 
-    # Build synthetic ordered_results in the shape _parse_result returns:
-    # (check_payload, verified_ids, disputed_ids)
     def _fake_scatter(**kwargs: Any) -> GenericScatterResult:
-        items: list[tuple[dict[str, Any], list[str], list[str]]] = []
+        items: list[dict[str, object]] = []
         for i, chk in enumerate(enriched):
-            items.append((
-                _check_payload(chk, f"Checked {chk['id']} in detail for ordered merge coverage.", flagged=False),
-                [f"FLAG-{i + 1:03d}"],
-                [],
-            ))
+            items.append(
+                _raw_critique_payload(
+                    _check_payload(chk, f"Checked {chk['id']} in detail for ordered merge coverage.", flagged=False),
+                    verified=[f"FLAG-{i + 1:03d}"],
+                )
+            )
         return GenericScatterResult(
             ordered_results=items,
             total_cost=0.25 * len(enriched),
@@ -170,15 +183,17 @@ def test_run_parallel_critique_disputed_flags_override_verified(
     enriched = _enrich_checks(raw_checks[:2])
 
     def _fake_scatter(**kwargs: Any) -> GenericScatterResult:
-        items: list[tuple[dict[str, Any], list[str], list[str]]] = []
+        items: list[dict[str, object]] = []
         for i, chk in enumerate(enriched):
             verified = ["FLAG-001"] if i == 0 else []
             disputed = ["FLAG-001"] if i == 1 else []
-            items.append((
-                _check_payload(chk, f"Checked {chk['id']} with explicit flag merge coverage.", flagged=(i == 1)),
-                verified,
-                disputed,
-            ))
+            items.append(
+                _raw_critique_payload(
+                    _check_payload(chk, f"Checked {chk['id']} with explicit flag merge coverage.", flagged=(i == 1)),
+                    verified=verified,
+                    disputed=disputed,
+                )
+            )
         return GenericScatterResult(
             ordered_results=items,
             total_cost=0.2,
@@ -197,6 +212,152 @@ def test_run_parallel_critique_disputed_flags_override_verified(
 
     assert result.payload["disputed_flag_ids"] == ["FLAG-001"]
     assert "FLAG-001" not in result.payload["verified_flag_ids"]
+
+
+def test_run_parallel_critique_retries_malformed_worker_shape(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A malformed single worker payload is retried without aborting the batch."""
+    plan_dir, _project_dir, state = _scaffold(tmp_path)
+    enriched = _enrich_checks(checks_for_robustness("standard")[:2])
+    bad_id = enriched[0]["id"]
+    attempts: dict[str, int] = {}
+    calls: list[list[str]] = []
+    retry_prompts: list[str] = []
+
+    def _fake_scatter(*, units: Any, **kwargs: Any) -> GenericScatterResult:
+        calls.append([unit.extra["check_id"] for unit in units])
+        items: list[dict[str, object]] = []
+        for unit in units:
+            check_id = unit.extra["check_id"]
+            attempts[check_id] = attempts.get(check_id, 0) + 1
+            chk = next(chk for chk in enriched if chk["id"] == check_id)
+            if check_id == bad_id and attempts[check_id] == 1:
+                items.append({"checks": [], "flags": [], "verified_flag_ids": [], "disputed_flag_ids": []})
+            else:
+                if check_id == bad_id:
+                    retry_prompts.append(unit.prompt)
+                items.append(
+                    _raw_critique_payload(
+                        _check_payload(chk, f"valid payload for {check_id}", flagged=False),
+                        verified=[f"FLAG-{check_id}"],
+                    )
+                )
+        return GenericScatterResult(
+            ordered_results=items,
+            total_cost=0.1 * len(items),
+            total_prompt_tokens=10 * len(items),
+            total_completion_tokens=5 * len(items),
+            total_tokens=15 * len(items),
+            side_results=[],
+        )
+
+    monkeypatch.setattr(
+        "megaplan.orchestration.parallel_critique.scatter_worker_units",
+        _fake_scatter,
+    )
+
+    result = run_parallel_critique(state, plan_dir, root=REPO_ROOT, model="mock-model", checks=tuple(enriched))
+
+    assert [check["id"] for check in result.payload["checks"]] == [chk["id"] for chk in enriched]
+    assert attempts[bad_id] == 2
+    assert attempts[enriched[1]["id"]] == 1
+    assert calls == [[chk["id"] for chk in enriched], [bad_id]]
+    assert retry_prompts and retry_prompts[0].startswith("Return a JSON object with a top-level `checks` array")
+    assert result.prompt_tokens == 30
+    assert "worker '" + bad_id + "' returned 0 checks, retrying (attempt 2/3)" in capsys.readouterr().err
+
+
+def test_run_parallel_critique_retry_budget_exhaustion_reraises_for_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A persistently malformed worker raises after a bounded retry budget."""
+    plan_dir, _project_dir, state = _scaffold(tmp_path)
+    enriched = _enrich_checks(checks_for_robustness("standard")[:2])
+    bad_id = enriched[0]["id"]
+    attempts: dict[str, int] = {}
+    calls: list[list[str]] = []
+
+    def _fake_scatter(*, units: Any, **kwargs: Any) -> GenericScatterResult:
+        calls.append([unit.extra["check_id"] for unit in units])
+        items: list[dict[str, object]] = []
+        for unit in units:
+            check_id = unit.extra["check_id"]
+            attempts[check_id] = attempts.get(check_id, 0) + 1
+            chk = next(chk for chk in enriched if chk["id"] == check_id)
+            if check_id == bad_id:
+                items.append(
+                    {
+                        "checks": [
+                            _check_payload(chk, "first duplicate malformed payload", flagged=False),
+                            _check_payload(chk, "second duplicate malformed payload", flagged=False),
+                        ],
+                        "flags": [],
+                        "verified_flag_ids": [],
+                        "disputed_flag_ids": [],
+                    }
+                )
+            else:
+                items.append(_raw_critique_payload(_check_payload(chk, f"valid payload for {check_id}", flagged=False)))
+        return GenericScatterResult(
+            ordered_results=items,
+            total_cost=0.0,
+            total_prompt_tokens=0,
+            total_completion_tokens=0,
+            total_tokens=0,
+            side_results=[],
+        )
+
+    monkeypatch.setattr(
+        "megaplan.orchestration.parallel_critique.scatter_worker_units",
+        _fake_scatter,
+    )
+
+    with pytest.raises(CliError, match="retry budget exhausted"):
+        run_parallel_critique(state, plan_dir, root=REPO_ROOT, model="mock-model", checks=tuple(enriched))
+
+    assert attempts[bad_id] == 3
+    assert attempts[enriched[1]["id"]] == 1
+    assert calls == [[chk["id"] for chk in enriched], [bad_id], [bad_id]]
+
+
+def test_run_parallel_critique_well_formed_output_does_not_retry(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Well-formed output still succeeds in one scatter pass."""
+    plan_dir, _project_dir, state = _scaffold(tmp_path)
+    enriched = _enrich_checks(checks_for_robustness("standard")[:2])
+    calls = 0
+
+    def _fake_scatter(*, units: Any, **kwargs: Any) -> GenericScatterResult:
+        nonlocal calls
+        calls += 1
+        items: list[dict[str, object]] = []
+        for unit in units:
+            chk = next(chk for chk in enriched if chk["id"] == unit.extra["check_id"])
+            items.append(_raw_critique_payload(_check_payload(chk, f"valid payload for {chk['id']}", flagged=False)))
+        return GenericScatterResult(
+            ordered_results=items,
+            total_cost=0.0,
+            total_prompt_tokens=0,
+            total_completion_tokens=0,
+            total_tokens=0,
+            side_results=[],
+        )
+
+    monkeypatch.setattr(
+        "megaplan.orchestration.parallel_critique.scatter_worker_units",
+        _fake_scatter,
+    )
+
+    result = run_parallel_critique(state, plan_dir, root=REPO_ROOT, model="mock-model", checks=tuple(enriched))
+
+    assert calls == 1
+    assert [check["id"] for check in result.payload["checks"]] == [chk["id"] for chk in enriched]
 
 
 def test_write_single_check_template_filters_prior_findings_to_target_check(tmp_path: Path) -> None:
@@ -311,14 +472,15 @@ def test_run_parallel_critique_does_not_mutate_session_state(
     raw_checks = checks_for_robustness("standard")
     enriched = _enrich_checks(raw_checks)
 
-    def _fake_scatter(**kwargs: Any) -> GenericScatterResult:
-        items: list[tuple[dict[str, Any], list[str], list[str]]] = []
-        for chk in enriched:
-            items.append((
-                _check_payload(chk, f"Checked {chk['id']} while preserving the outer session state.", flagged=False),
-                [],
-                [],
-            ))
+    def _fake_scatter(*, units: Any, **kwargs: Any) -> GenericScatterResult:
+        items: list[dict[str, object]] = []
+        for unit in units:
+            chk = next(chk for chk in enriched if chk["id"] == unit.extra["check_id"])
+            items.append(
+                _raw_critique_payload(
+                    _check_payload(chk, f"Checked {chk['id']} while preserving the outer session state.", flagged=False)
+                )
+            )
         return GenericScatterResult(
             ordered_results=items,
             total_cost=0.0,
@@ -357,9 +519,10 @@ def test_run_parallel_critique_builds_read_only_worker_units(
 
     def _fake_scatter(*, units: Any, **kwargs: Any) -> GenericScatterResult:
         captured_units.extend(units)
-        items: list[tuple[dict[str, Any], list[str], list[str]]] = []
-        for chk in enriched:
-            items.append((_check_payload(chk, "read-only verify", flagged=False), [], []))
+        items: list[dict[str, object]] = []
+        for unit in units:
+            chk = next(chk for chk in enriched if chk["id"] == unit.extra["check_id"])
+            items.append(_raw_critique_payload(_check_payload(chk, "read-only verify", flagged=False)))
         return GenericScatterResult(
             ordered_results=items,
             total_cost=0.0,
@@ -403,9 +566,10 @@ def test_run_parallel_critique_uses_per_lens_resolved_agent_mode(
 
     def _fake_scatter(*, units: Any, **kwargs: Any) -> GenericScatterResult:
         captured_units.extend(units)
-        items: list[tuple[dict[str, Any], list[str], list[str]]] = []
-        for chk in enriched:
-            items.append((_check_payload(chk, "per-lens verify", flagged=False), [], []))
+        items: list[dict[str, object]] = []
+        for unit in units:
+            chk = next(chk for chk in enriched if chk["id"] == unit.extra["check_id"])
+            items.append(_raw_critique_payload(_check_payload(chk, "per-lens verify", flagged=False)))
         return GenericScatterResult(
             ordered_results=items,
             total_cost=0.0,
@@ -442,9 +606,10 @@ def test_run_parallel_critique_unique_output_paths_per_check(
 
     def _fake_scatter(*, units: Any, **kwargs: Any) -> GenericScatterResult:
         captured_units.extend(units)
-        items: list[tuple[dict[str, Any], list[str], list[str]]] = []
-        for chk in enriched:
-            items.append((_check_payload(chk, "unique paths verify", flagged=False), [], []))
+        items: list[dict[str, object]] = []
+        for unit in units:
+            chk = next(chk for chk in enriched if chk["id"] == unit.extra["check_id"])
+            items.append(_raw_critique_payload(_check_payload(chk, "unique paths verify", flagged=False)))
         return GenericScatterResult(
             ordered_results=items,
             total_cost=0.0,
@@ -487,6 +652,8 @@ def test_run_parallel_critique_missing_resolved_agent_mode_raises_invariant_erro
     raw_checks = checks_for_robustness("standard")
     # Do NOT enrich — leave checks without _resolved_agent_mode
     bare_checks = [dict(chk) for chk in raw_checks]
+    for chk in bare_checks:
+        chk.pop("_resolved_agent_mode", None)
 
     from megaplan.types import CliError
 
@@ -520,9 +687,10 @@ def test_run_parallel_critique_worker_units_have_unique_step_paths(
 
     def _fake_scatter(*, units: Any, **kwargs: Any) -> GenericScatterResult:
         captured_units.extend(units)
-        items: list[tuple[dict[str, Any], list[str], list[str]]] = []
-        for chk in enriched:
-            items.append((_check_payload(chk, "unique step/path verify", flagged=False), [], []))
+        items: list[dict[str, object]] = []
+        for unit in units:
+            chk = next(chk for chk in enriched if chk["id"] == unit.extra["check_id"])
+            items.append(_raw_critique_payload(_check_payload(chk, "unique step/path verify", flagged=False)))
         return GenericScatterResult(
             ordered_results=items,
             total_cost=0.0,

--- a/tests/test_run_agent_loop_guards.py
+++ b/tests/test_run_agent_loop_guards.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+import json
+import time
+from argparse import Namespace
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import megaplan.agent  # noqa: F401  (side-effect: makes top-level run_agent importable)
+from megaplan.handlers.critique import _apply_adaptive_critique_routing
+from run_agent import AIAgent, DEFAULT_API_TIMEOUT_SECONDS
+
+
+def _minimal_agent() -> AIAgent:
+    agent = AIAgent.__new__(AIAgent)
+    agent._interrupt_requested = False
+    agent._checkpoint_mgr = SimpleNamespace(enabled=False)
+    agent.quiet_mode = True
+    agent.verbose_logging = False
+    agent.tool_progress_callback = None
+    agent._honcho = None
+    agent._honcho_session_key = None
+    agent.valid_tool_names = set()
+    agent.log_prefix = ""
+    agent.log_prefix_chars = 120
+    agent._output_stream = None
+    agent.tool_delay = 0
+    agent.max_iterations = 100
+    agent._tool_dedup_cache = {}
+    agent._file_read_counts = {}
+    agent._get_budget_warning = lambda _api_call_count: None
+    return agent
+
+
+def _init_args(**overrides):
+    base = {
+        "project_dir": "/tmp/proj",
+        "hermes": None,
+        "profile": None,
+        "vendor": None,
+        "critic": None,
+        "critic_model": None,
+        "depth": None,
+        "deepseek_provider": None,
+        "with_prep": False,
+        "with_feedback": False,
+        "prep_direction": None,
+        "phase_model": None,
+    }
+    base.update(overrides)
+    return Namespace(**base)
+
+
+def test_init_records_critic_model_provenance(monkeypatch):
+    import megaplan.handlers.init as init_mod
+
+    defaults = {
+        "robustness": "full",
+        "auto_approve": False,
+        "adaptive_critique": False,
+        "critic_model": "",
+        "strict_notes": False,
+        "strict_adaptive_critique": False,
+        "max_tasks_per_batch": 3,
+        "completion_contract_mode": "off",
+        "test_command": "pytest",
+        "test_baseline_timeout": 900,
+    }
+
+    monkeypatch.setattr(init_mod, "get_effective", lambda _section, key: defaults[key])
+    monkeypatch.setattr(init_mod, "load_profile_metadata", lambda project_dir: {})
+
+    monkeypatch.setattr(init_mod, "setting_is_explicit", lambda section, key: False)
+    config, *_ = init_mod._build_state_config(
+        _init_args(critic_model="deepseek-v4-pro"),
+        project_dir=Path("/tmp/proj"),
+        pipeline=None,
+        mode="code",
+        raw_form=None,
+        normalized_output_path=None,
+        normalized_primary_criterion=None,
+        from_doc_rel=None,
+    )
+    assert config["critic_model"] == "deepseek-v4-pro"
+    assert config["critic_model_explicit"] is True
+
+    monkeypatch.setattr(
+        init_mod,
+        "setting_is_explicit",
+        lambda section, key: section == "execution" and key == "critic_model",
+    )
+    defaults["critic_model"] = "config-pin"
+    config, *_ = init_mod._build_state_config(
+        _init_args(),
+        project_dir=Path("/tmp/proj"),
+        pipeline=None,
+        mode="code",
+        raw_form=None,
+        normalized_output_path=None,
+        normalized_primary_criterion=None,
+        from_doc_rel=None,
+    )
+    assert config["critic_model"] == "config-pin"
+    assert config["critic_model_explicit"] is True
+
+    monkeypatch.setattr(init_mod, "setting_is_explicit", lambda section, key: False)
+    monkeypatch.setattr(
+        init_mod,
+        "load_profile_metadata",
+        lambda project_dir: {"partnered": {"critic_model": "profile-pin"}},
+    )
+    config, *_ = init_mod._build_state_config(
+        _init_args(profile="partnered"),
+        project_dir=Path("/tmp/proj"),
+        pipeline=None,
+        mode="code",
+        raw_form=None,
+        normalized_output_path=None,
+        normalized_primary_criterion=None,
+        from_doc_rel=None,
+    )
+    assert config["critic_model"] == "profile-pin"
+    assert config["critic_model_explicit"] is False
+
+
+def test_stale_critic_model_without_provenance_uses_per_lens_tier(monkeypatch, capsys):
+    state = {
+        "config": {
+            "critic_model": "deepseek-v4-pro",
+            "critic_model_explicit": False,
+        }
+    }
+    checks = [{"id": "correctness", "complexity": 4}]
+    args = Namespace(tier_models={"critique": {4: "claude:claude-opus-4-7"}})
+
+    def fake_resolve_tier_spec(args, spec, *, phase="execute"):
+        assert phase == "critique"
+        assert spec == "claude:claude-opus-4-7"
+        return ("claude", "persistent", "claude-opus-4-7")
+
+    monkeypatch.setattr("megaplan.execute.batch._resolve_tier_spec", fake_resolve_tier_spec)
+
+    pin = _apply_adaptive_critique_routing(state, args, checks)
+
+    assert pin is None
+    assert checks[0]["_resolved_agent_mode"].model == "claude-opus-4-7"
+    assert "WARNING" not in capsys.readouterr().err
+
+
+def test_explicit_critic_model_pin_is_honored_and_warns_for_high_complexity(
+    monkeypatch, capsys
+):
+    state = {
+        "config": {
+            "critic_model": "deepseek-v4-pro",
+            "critic_model_explicit": True,
+        }
+    }
+    checks = [{"id": "correctness", "complexity": 4}]
+    args = Namespace(tier_models={"critique": {4: "claude:claude-opus-4-7"}})
+
+    def fail_resolve(*_args, **_kwargs):
+        raise AssertionError("explicit critic_model pin must bypass tier routing")
+
+    monkeypatch.setattr("megaplan.execute.batch._resolve_tier_spec", fail_resolve)
+
+    pin = _apply_adaptive_critique_routing(state, args, checks)
+
+    assert pin == "deepseek-v4-pro"
+    err = capsys.readouterr().err
+    assert "WARNING" in err
+    assert "deepseek-v4-pro" in err
+    assert "disables per-lens critique escalation" in err
+
+
+def test_repeated_file_read_breaker_persists_across_turns(monkeypatch, tmp_path):
+    import run_agent
+
+    monkeypatch.setenv("HERMES_MAX_SAME_FILE_READS", "5")
+    monkeypatch.setenv("HERMES_HARD_MAX_SAME_FILE_READS", "10")
+    calls = {"count": 0}
+
+    def fake_handle_function_call(function_name, function_args, effective_task_id, **kwargs):
+        calls["count"] += 1
+        return "file content"
+
+    monkeypatch.setattr(run_agent, "handle_function_call", fake_handle_function_call)
+
+    agent = _minimal_agent()
+    path = tmp_path / "session.py"
+    path.write_text("file content", encoding="utf-8")
+
+    class _ToolCall:
+        def __init__(self, call_id: str) -> None:
+            self.id = call_id
+            self.function = SimpleNamespace(
+                name="read_file",
+                arguments=json.dumps({"path": str(path)}),
+            )
+
+    messages: list[dict] = []
+    for i in range(7):
+        agent._tool_dedup_cache.clear()  # run_conversation clears this per turn.
+        assistant_message = SimpleNamespace(tool_calls=[_ToolCall(f"call-{i}")])
+        agent._execute_tool_calls_sequential(
+            assistant_message, messages, effective_task_id="task", api_call_count=i
+        )
+
+    assert calls["count"] == 5
+    assert agent._file_read_counts[str(path.resolve())] == 7
+    assert "already read 6 times" in messages[5]["content"]
+    assert "already read 7 times" in messages[6]["content"]
+
+
+def test_repeated_file_read_hard_ceiling_refuses(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_MAX_SAME_FILE_READS", "2")
+    monkeypatch.setenv("HERMES_HARD_MAX_SAME_FILE_READS", "3")
+    agent = _minimal_agent()
+    path = tmp_path / "session.py"
+    path.write_text("file content", encoding="utf-8")
+
+    results = [
+        agent._maybe_short_circuit_file_read("read_file", {"path": str(path)})
+        for _ in range(4)
+    ]
+
+    assert results[:2] == [None, None]
+    assert "already read 3 times" in results[2]
+    assert "REFUSED read_file" in results[3]
+
+
+def test_streaming_timeout_growing_prompt_aborts_without_escalation(monkeypatch):
+    monkeypatch.setenv("HERMES_STREAMING_TIMEOUT_HARD_CEILING_SECONDS", "3600")
+    agent = _minimal_agent()
+    agent._streaming_timeout_streak = 0
+    agent._last_streaming_timeout_tokens = None
+    agent._streaming_timeout_wall_start_monotonic = time.monotonic()
+    agent._last_streaming_request_started_at = time.monotonic()
+
+    assert agent._record_streaming_timeout_or_abort(
+        approx_tokens=1000, message_count=10, elapsed_seconds=300
+    ) is None
+    abort = agent._record_streaming_timeout_or_abort(
+        approx_tokens=1300, message_count=14, elapsed_seconds=320
+    )
+
+    assert abort is not None
+    assert "prompt grew from ~1,000 to ~1,300 tokens" in abort
+    assert agent._streaming_timeout_streak == 1
+
+
+def test_streaming_timeout_static_prompt_still_escalates(monkeypatch):
+    monkeypatch.delenv("HERMES_API_TIMEOUT", raising=False)
+    monkeypatch.delenv("HERMES_STREAMING_TIMEOUT_HARD_CEILING_SECONDS", raising=False)
+    agent = _minimal_agent()
+    agent.provider = "openrouter"
+    agent._base_url_lower = "https://openrouter.ai/api/v1"
+    agent._streaming_timeout_streak = 0
+    agent._last_streaming_timeout_tokens = None
+    agent._streaming_timeout_wall_start_monotonic = time.monotonic()
+    agent._last_streaming_request_started_at = time.monotonic()
+
+    assert agent._record_streaming_timeout_or_abort(
+        approx_tokens=1000, message_count=10, elapsed_seconds=300
+    ) is None
+    assert agent._api_timeout_seconds() == pytest.approx(DEFAULT_API_TIMEOUT_SECONDS * 1.5)
+    assert agent._record_streaming_timeout_or_abort(
+        approx_tokens=1100, message_count=10, elapsed_seconds=450
+    ) is None
+    assert agent._api_timeout_seconds() == pytest.approx(DEFAULT_API_TIMEOUT_SECONDS * 2.25)
+
+
+def test_streaming_timeout_hard_wall_clock_ceiling_aborts(monkeypatch):
+    monkeypatch.setenv("HERMES_STREAMING_TIMEOUT_HARD_CEILING_SECONDS", "10")
+    agent = _minimal_agent()
+    agent._streaming_timeout_streak = 1
+    agent._last_streaming_timeout_tokens = 1000
+    agent._streaming_timeout_wall_start_monotonic = time.monotonic() - 11
+    agent._last_streaming_request_started_at = time.monotonic() - 11
+
+    abort = agent._record_streaming_timeout_or_abort(
+        approx_tokens=1000, message_count=10, elapsed_seconds=11
+    )
+
+    assert abort is not None
+    assert "retry ceiling reached" in abort


### PR DESCRIPTION
Preserves the previously loose dirty main checkout work.\n\nIncludes critique worker shape retry handling plus related agent loop recovery updates and tests.\n\nGenerated composed bundles were regenerated by the commit hook.