### PR TITLE
shannon .jsonl: accept string-content turn-opener (fixes no-op on real Shannon turns)

### DIFF
--- a/megaplan/workers/shannon.py
+++ b/megaplan/workers/shannon.py
@@ -1774,13 +1774,21 @@ def _read_turn_ndjson_from_transcript(
         if not isinstance(msg, dict):
             continue
         content = msg.get("content")
-        if not isinstance(content, list) or not content:
-            continue
-        # Turn-opener: at least one content block whose type is not tool_result.
-        if not any(
-            isinstance(block, dict) and block.get("type") != "tool_result"
-            for block in content
-        ):
+        # A genuine turn-opener is real user input, not an injected tool_result.
+        # Claude Code writes a plain Shannon prompt as a STRING and tool_result
+        # injections as a LIST of blocks.  Accept both shapes:
+        #   * str  -> a genuine opener (every real Shannon turn-opener is a string)
+        #   * list -> opener only if it carries a non-tool_result block
+        if isinstance(content, str):
+            if not content.strip():
+                continue
+        elif isinstance(content, list) and content:
+            if not any(
+                isinstance(block, dict) and block.get("type") != "tool_result"
+                for block in content
+            ):
+                continue
+        else:
             continue
         # Check the since_user_uuid filter.
         row_uuid = row.get("uuid")

--- a/tests/test_shannon_jsonl_capture.py
+++ b/tests/test_shannon_jsonl_capture.py
@@ -633,3 +633,54 @@ class TestTranscriptIntegration:
         assert result.payload["output"] == "stdout-wins"
 
 
+# ── (k) real Shannon shape: string-content turn-opener ────────────────────────
+
+
+class TestStringContentOpener:
+    """Real Claude Code writes the Shannon prompt opener's ``message.content`` as
+    a plain STRING — only injected ``tool_result`` records are list-form.  The
+    parser MUST treat a string opener as a genuine turn-opener; the earlier
+    list-only assumption made the whole .jsonl path a no-op on real Shannon turns
+    (recovered 0/49 real structural-decomp transcripts).  Regression guard."""
+
+    @staticmethod
+    def _string_opener(uuid: str, text: str = "Execute the approved plan.") -> dict:
+        return {
+            "type": "user",
+            "uuid": uuid,
+            "message": {"content": text},  # STRING, as real Claude Code writes it
+        }
+
+    def test_recovers_turn_with_string_opener(self, tmp_path: Path) -> None:
+        user_uuid = str(uuid_mod.uuid4())
+        assistant_uuid = str(uuid_mod.uuid4())
+        records = [
+            self._string_opener(user_uuid),
+            _assistant_msg(uuid=assistant_uuid, stop_reason="end_turn"),
+            _turn_duration(parent_uuid=assistant_uuid),
+        ]
+        path = tmp_path / "transcript.jsonl"
+        _write_ndjson(path, records)
+
+        result = _read_turn_ndjson_from_transcript(str(path))
+        assert result is not None, "string-content opener must be recognized as a turn-opener"
+        parsed = [json.loads(ln) for ln in result.strip().split("\n")]
+        assert len(parsed) == 3
+        assert parsed[0]["type"] == "user"
+        assert parsed[0]["message"]["content"] == "Execute the approved plan."
+        assert parsed[1]["message"]["stop_reason"] == "end_turn"
+        assert parsed[2]["subtype"] == "turn_duration"
+
+    def test_blank_string_opener_is_not_a_turn_opener(self, tmp_path: Path) -> None:
+        # A whitespace-only string is not genuine user input → no completed turn.
+        assistant_uuid = str(uuid_mod.uuid4())
+        records = [
+            self._string_opener(str(uuid_mod.uuid4()), text="   "),
+            _assistant_msg(uuid=assistant_uuid, stop_reason="end_turn"),
+            _turn_duration(parent_uuid=assistant_uuid),
+        ]
+        path = tmp_path / "transcript.jsonl"
+        _write_ndjson(path, records)
+        assert _read_turn_ndjson_from_transcript(str(path)) is None
+
+


### PR DESCRIPTION
The `.jsonl` capture shipped in #63 required the turn-opener's `message.content` to be a **list** of blocks, but real Claude Code writes the Shannon prompt opener as a plain **string** (only `tool_result` injections are list-form). The list-only check made the whole `.jsonl` path a **no-op on every real Shannon turn** — it recovered **0/49** real production transcripts; #63's unit tests passed only because the fixture used list content.

Fix: accept `str` content as a genuine opener. Re-validated against real on-disk transcripts → **48/48** completed-turn transcripts now recover. +2 regression tests (string opener, blank-string opener). Full shannon suite: 131 passed.

Found by an independent test subagent run against the chain's real transcripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)