### PR TITLE
[codex] Validate suspension decision routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ cd ~/Documents
 git clone https://github.com/peteromallet/arnold.git
 cd arnold
 python -m pip install -e .
-python -m megaplan setup
+python -m arnold.pipelines.megaplan setup
 
 The default `partnered` profile pairs a premium model (Claude or Codex) with cheap DeepSeek. Ask me for whichever I have — an Anthropic/Claude or OpenAI/Codex login — plus a DeepSeek API key (or Fireworks key), and wire them up.
 
@@ -72,10 +72,10 @@ cd ~/Documents
 git clone https://github.com/peteromallet/arnold.git
 cd arnold
 python -m pip install -e .
-python -m megaplan setup
+python -m arnold.pipelines.megaplan setup
 ```
 
-`megaplan setup` detects your installed agents and walks you through credentials. The old `[agent]` extra remains as a no-op compatibility alias on current releases, but it is no longer required. You need two things:
+The setup command detects your installed agents and walks you through credentials. The old `[agent]` extra remains as a no-op compatibility alias on current releases, but it is no longer required. You need two things:
 
 - **A premium model** — **Claude** (the default; your Claude Code login or `ANTHROPIC_API_KEY`) **or Codex** (your Codex login or `OPENAI_API_KEY`, selected with `--vendor codex`). The public `claude` agent route always uses the Shannon-backed interactive tmux worker — it preserves OAuth subscription billing and never falls back to a headless `claude -p` subprocess.
 - **DeepSeek access** for the cheap phases — a **`DEEPSEEK_API_KEY`** (the default route) or a **Fireworks** key (`FIREWORKS_API_KEY`, via `--deepseek-provider fireworks`).
@@ -83,10 +83,10 @@ python -m megaplan setup
 Direct-provider keys live in `~/.hermes/.env`. Then point megaplan at an idea:
 
 ```bash
-megaplan init --project-dir . "Fix the authentication bug in login.py"
+python -m arnold.pipelines.megaplan init --project-dir . "Fix the authentication bug in login.py"
 ```
 
-In subagent mode (the default for Claude Code and Codex) the agent drives the phases and returns at breakpoints. To run them by hand: `megaplan plan|critique|gate|finalize|execute --plan <name>`.
+In subagent mode (the default for Claude Code and Codex) the agent drives the phases and returns at breakpoints. To run them by hand, reuse the same verified launcher: `python -m arnold.pipelines.megaplan plan|critique|gate|finalize|execute --plan <name>`.
 
 ## Development
 
@@ -99,15 +99,15 @@ python -m pytest tests/characterization/test_import_surface.py tests/test_pipeli
 ## Some other features
 
 - **Epics** — chain many sprints into one long-running effort. Megaplan runs them in sequence with carried context, so it can deliver the equivalent of months of work reliably instead of one sprint at a time.
-- **Different models per phase** — pick a named profile (`megaplan init --profile <name>`) or override one phase (`--phase-model execute=claude`). Inspect with `megaplan config profiles list`; define your own in `.megaplan/profiles.toml`. Built-ins span all-Claude, all-Codex, all-DeepSeek, and all-open (Kimi/GLM via OpenRouter).
-- **Cloud runs** — `megaplan cloud` runs a plan (or a whole chain) on a remote Railway box with a persistent workspace volume, so it outlives your terminal. Ask your agent to `megaplan cloud bootstrap <idea>`. See [docs/cloud.md](docs/cloud.md).
-- **Bake-offs** — `megaplan bakeoff` runs the same idea through multiple profiles concurrently (one git worktree each), compares the results, and merges only the human-picked winner — the way to find the cheapest model mix that still passes review.
-- **Metaplan mode** — produce a design doc / RFC / spec instead of a code diff: `megaplan init --mode metaplan --output docs/foo.md "..."`.
+- **Different models per phase** — pick a named profile (`python -m arnold.pipelines.megaplan init --profile <name>`) or override one phase (`--phase-model execute=claude`). Inspect with `python -m arnold.pipelines.megaplan config profiles list`; define your own in `.megaplan/profiles.toml`. Built-ins span all-Claude, all-Codex, all-DeepSeek, and all-open (Kimi/GLM via OpenRouter).
+- **Cloud runs** — `python -m arnold.pipelines.megaplan cloud` runs a plan (or a whole chain) on a remote Railway box with a persistent workspace volume, so it outlives your terminal. Ask your agent to `python -m arnold.pipelines.megaplan cloud bootstrap <idea>`. See [docs/cloud.md](docs/cloud.md).
+- **Bake-offs** — `python -m arnold.pipelines.megaplan bakeoff` runs the same idea through multiple profiles concurrently (one git worktree each), compares the results, and merges only the human-picked winner — the way to find the cheapest model mix that still passes review.
+- **Metaplan mode** — produce a design doc / RFC / spec instead of a code diff: `python -m arnold.pipelines.megaplan init --mode metaplan --output docs/foo.md "..."`.
 - **Robustness levels** — `--robustness light|standard|robust|superrobust` dials critique depth and parallelism, from a single critique pass up to parallel critique + parallel review.
-- **Database mode** — keep state in Supabase Postgres instead of `.megaplan/` for shared state across machines and cloud runs (`pip install 'megaplan-harness[db]'`, then set `MEGAPLAN_ACTOR_ID`).
-- **Observability** — `megaplan status --plan <name>` shows the active step, cost, execute progress, and next-step guidance.
-- **Configuration** — `megaplan config show | set <key> <value> | reset` tunes timeouts, critique concurrency, and per-phase agents. See [docs/configuration.md](docs/configuration.md) for the full config and environment map.
-- **Adaptive critique defense** — `megaplan doctor --adaptive-critique` probes the adaptive critique wiring; `[execution] strict_adaptive_critique = true` refuses silent fallback to static lenses on production runs. See [docs/critique.md](docs/critique.md).
+- **Database mode** — keep state in Supabase Postgres instead of `.megaplan/` for shared state across machines and cloud runs (`pip install 'arnold[db]'`, then set `MEGAPLAN_ACTOR_ID`).
+- **Observability** — `python -m arnold.pipelines.megaplan status --plan <name>` shows the active step, cost, execute progress, and next-step guidance.
+- **Configuration** — `python -m arnold.pipelines.megaplan config show | set <key> <value> | reset` tunes timeouts, critique concurrency, and per-phase agents. See [docs/configuration.md](docs/configuration.md) for the full config and environment map.
+- **Adaptive critique defense** — `python -m arnold.pipelines.megaplan doctor --adaptive-critique` probes the adaptive critique wiring; `[execution] strict_adaptive_critique = true` refuses silent fallback to static lenses on production runs. See [docs/critique.md](docs/critique.md).
 
 ## Code health
 

--- a/arnold/pipeline/types.py
+++ b/arnold/pipeline/types.py
@@ -208,6 +208,18 @@ class Stage:
     corresponding set of valid override-action strings (e.g.
     ``frozenset({"force_proceed", "abort"})``).  Both are plugin-owned:
     Arnold imposes no literal set; runtimes declare their own vocabulary.
+
+    ``decision_routes`` maps human decision keys to outgoing edge labels
+    (e.g. ``{"approved": "next", "rejected": "halt"}``).  A value of
+    ``None`` means the decision is terminal / has no next stage.  This
+    field is build-time metadata for route-target validation; the runtime
+    ``HumanSuspension`` serialization is not affected.
+
+    ``suspension_schema`` carries an optional JSON Schema (or compatible
+    ``Mapping``) that describes the expected shape of the suspension
+    interaction envelope for this stage.  Validators may use it to
+    extract decision enums, surface structural mismatches, or provide
+    IDE diagnostics.  ``None`` means no schema is declared.
     """
 
     name: str
@@ -215,6 +227,8 @@ class Stage:
     edges: tuple[Edge, ...] = ()
     decision_vocabulary: frozenset[str] = field(default_factory=frozenset)
     override_vocabulary: frozenset[str] = field(default_factory=frozenset)
+    decision_routes: dict[str, str | None] = field(default_factory=dict)
+    suspension_schema: Mapping[str, Any] | None = None
     reads: tuple["ReadRef | PortRef", ...] = field(default_factory=tuple)
     writes: tuple["WriteRef | Port", ...] = field(default_factory=tuple)
     produces: tuple["Port", ...] = field(default_factory=tuple)
@@ -237,6 +251,18 @@ class ParallelStage:
     ``decision_vocabulary`` and ``override_vocabulary`` serve the same
     purpose as in :class:`Stage` — they declare the set of valid decision
     and override-action strings for the join result's dispatch.
+
+    ``decision_routes`` maps human decision keys to outgoing edge labels
+    (e.g. ``{"approved": "next", "rejected": "halt"}``).  A value of
+    ``None`` means the decision is terminal / has no next stage.  This
+    field is build-time metadata for route-target validation; the runtime
+    ``HumanSuspension`` serialization is not affected.
+
+    ``suspension_schema`` carries an optional JSON Schema (or compatible
+    ``Mapping``) that describes the expected shape of the suspension
+    interaction envelope for this stage.  Validators may use it to
+    extract decision enums, surface structural mismatches, or provide
+    IDE diagnostics.  ``None`` means no schema is declared.
     """
 
     name: str
@@ -246,6 +272,8 @@ class ParallelStage:
     max_workers: int | None = None
     decision_vocabulary: frozenset[str] = field(default_factory=frozenset)
     override_vocabulary: frozenset[str] = field(default_factory=frozenset)
+    decision_routes: dict[str, str | None] = field(default_factory=dict)
+    suspension_schema: Mapping[str, Any] | None = None
     reads: tuple["ReadRef | PortRef", ...] = field(default_factory=tuple)
     writes: tuple["WriteRef | Port", ...] = field(default_factory=tuple)
     produces: tuple["Port", ...] = field(default_factory=tuple)

--- a/arnold/pipeline/validator.py
+++ b/arnold/pipeline/validator.py
@@ -8,6 +8,8 @@ Pure graph-shape validation with zero megaplan imports.  Checks:
 * ``"halt"`` is never used as an :class:`Edge`.``label`` (it is reserved
   as a target only), except for the conventional ``label='halt' target='halt'``
   terminal pair;
+* every stage's ``decision_routes`` values are validated against outgoing
+  edge labels (``None`` values for terminal decisions are accepted);
 * every stage that emits at least one ``kind == "decision"`` edge must cover
   the declared ``decision_vocabulary`` when non-empty;
 * every stage that emits at least one ``kind == "override"`` edge must cover
@@ -184,6 +186,117 @@ def _stage_override_vocabulary(
     return options.override_vocabulary_fallback
 
 
+# ── Suspension-schema enum extraction ──────────────────────────────────────
+
+# Reserved extension keys that signal schema intent unrelated to decisions.
+_X_EXTENSION_KEYS: frozenset[str] = frozenset({"x-arnold-resume"})
+
+
+def _decision_enum_from_suspension_schema(schema: Any) -> frozenset[str] | None:
+    """Extract decision enum values from a suspension schema.
+
+    Only two conservative patterns are recognised:
+
+    1. **Simple key/value maps** — a ``Mapping`` whose values are all
+       ``str`` type-hint literals (e.g. ``{"approved": "str", "rejected":
+       "str"}``) AND whose keys do **not** include any ``x-`` extension
+       keys.  The returned frozenset is the set of keys.
+
+    2. **JSON Schema ``properties.choice.enum``** — a JSON Schema object
+       with a ``properties.choice`` sub-object that carries an ``enum``
+       array of string values.  Only ``choice`` is recognised; enums on
+       other property names are ignored.
+
+    Returns ``None`` for:
+
+    * Non-mappings (including ``None``)
+    * Loose schemas (mappings that match neither pattern)
+    * Empty enums (the enum array exists but is empty or has no strings)
+    * Unrelated property enums (enum on a property other than ``choice``)
+    * Schemas whose only signal is an ``x-`` extension key (e.g.
+      ``x-arnold-resume``) with no other decision-bearing shape
+    """
+    if not isinstance(schema, Mapping):
+        return None
+
+    # ── Pattern 1: simple key/value map with string type hints ────────
+    if _is_simple_kv_map_with_string_types(schema):
+        return frozenset(schema.keys())
+
+    # ── Pattern 2: JSON Schema properties.choice.enum ─────────────────
+    enum_values = _extract_choice_enum_from_json_schema(schema)
+    if enum_values is not None:
+        return enum_values
+
+    # ── Check if the schema has ONLY x- extension keys (no other signal)
+    if _only_x_extension_keys(schema):
+        return None
+
+    return None
+
+
+def _is_simple_kv_map_with_string_types(schema: Mapping) -> bool:
+    """Return True when *schema* is a key/value map with string type hints.
+
+    Every value must be a ``str`` (conventionally type-hint literals like
+    ``"str"``, ``"int"``, ``"bool"``), no key may start with ``x-``, and
+    there must be at least one key.
+    """
+    if not schema:
+        return False
+    for key, value in schema.items():
+        if isinstance(key, str) and key.startswith("x-"):
+            return False
+        if not isinstance(value, str):
+            return False
+    return True
+
+
+def _extract_choice_enum_from_json_schema(schema: Mapping) -> frozenset[str] | None:
+    """Extract ``properties.choice.enum`` string values from a JSON Schema.
+
+    Requires the top-level ``type`` to be ``"object"``, ``properties`` to
+    be a ``Mapping``, ``properties.choice`` to be a ``Mapping`` with
+    ``type: "string"``, and ``choice.enum`` to be a non-empty sequence of
+    strings.
+
+    Returns ``None`` when the schema does not satisfy this shape.
+    """
+    if schema.get("type") != "object":
+        return None
+    properties = schema.get("properties")
+    if not isinstance(properties, Mapping):
+        return None
+    choice = properties.get("choice")
+    if not isinstance(choice, Mapping):
+        return None
+    if choice.get("type") != "string":
+        return None
+    enum = choice.get("enum")
+    if not isinstance(enum, (list, tuple)) or not enum:
+        return None
+    strings: set[str] = set()
+    for item in enum:
+        if isinstance(item, str):
+            strings.add(item)
+        else:
+            # Non-string enum value — bail out conservatively
+            return None
+    if not strings:
+        return None
+    return frozenset(strings)
+
+
+def _only_x_extension_keys(schema: Mapping) -> bool:
+    """Return True when every key in *schema* is an ``x-`` extension key."""
+    if not schema:
+        return False
+    for key in schema:
+        if not (isinstance(key, str) and key.startswith("x-")):
+            return False
+    return True
+
+
 # ── Validation ────────────────────────────────────────────────────────────
 
 
@@ -193,7 +306,8 @@ def validate_control_flow(
     """Run control-flow validation over *pipeline*.
 
     Checks: entry existence, edge targets, reserved halt label,
-    decision/override vocabulary coverage, reachability from entry,
+    decision/override vocabulary coverage, decision_route target
+    validation against outgoing edge labels, reachability from entry,
     and unguarded cycle detection.
 
     Returns a :class:`Diagnostics` whose ``defects`` list is empty iff
@@ -246,6 +360,24 @@ def validate_control_flow(
                     edge=edge,
                     details={"known_stages": sorted(stage_names)},
                 )
+
+        # ── decision_route target validation ──────────────────────────
+        decision_routes = getattr(stage, "decision_routes", None)
+        if decision_routes:
+            edge_labels = {getattr(e, "label", "") for e in edges}
+            for decision_key, route_target in decision_routes.items():
+                if route_target is not None and route_target not in edge_labels:
+                    diag.add_defect(
+                        f"stage {stage_name!r}: decision_route {decision_key!r} "
+                        f"targets unknown edge label {route_target!r}",
+                        code="decision_route_target_unknown",
+                        stage=stage_name,
+                        details={
+                            "decision_key": decision_key,
+                            "route_target": route_target,
+                            "available_edge_labels": sorted(edge_labels),
+                        },
+                    )
 
         # ── decision vocabulary check ────────────────────────────────
         if decision_edges:

--- a/arnold/pipelines/megaplan/cloud/cli.py
+++ b/arnold/pipelines/megaplan/cloud/cli.py
@@ -36,7 +36,7 @@ load_spec = load_cloud_spec
 
 # Cloud deployments always drive phases via subprocess (remote SSH exec);
 # the substrate is pinned here so the cloud CLI explicitly declares its
-# execution model to _phase_command (M3 Step 12 shim).
+# execution model to _phase_command (M3 Step 12 compatibility boundary).
 cloud_substrate: str = "subprocess_isolated"
 
 
@@ -86,7 +86,7 @@ def _register_cloud_subcommands(cloud_parser: argparse.ArgumentParser) -> None:
         "--no-git-refresh",
         action="store_true",
         help=(
-            "Pass --no-git-refresh to the remote `arnold chain start`, "
+            "Pass --no-git-refresh to the remote `python -m arnold.pipelines.megaplan chain start`, "
             "skipping the automatic base-branch refresh."
         ),
     )
@@ -919,7 +919,7 @@ def _chain_start_command(
     no_git_refresh: bool = False,
     log_relative: str = _CHAIN_LOG_RELATIVE,
 ) -> str:
-    """Construct the ``arnold chain start`` command with canonical quoting.
+    """Construct the ``python -m arnold.pipelines.megaplan chain start`` command with canonical quoting.
 
     Both ``_run_chain_wrapper`` and ``cloud_supervise_tick`` use this helper
     so the session name, log path, trusted env var, and shell quoting stay
@@ -931,7 +931,7 @@ def _chain_start_command(
     if no_git_refresh:
         flags += " --no-git-refresh"
     return (
-        f"MEGAPLAN_TRUSTED_CONTAINER=1 arnold chain start {flags} "
+        f"MEGAPLAN_TRUSTED_CONTAINER=1 python -m arnold.pipelines.megaplan chain start {flags} "
         f">> {shlex.quote(log_relative)} 2>&1"
     )
 
@@ -1901,7 +1901,7 @@ def _remote_human_verification_status_command(
     """
     return (
         f"cd {shlex.quote(workspace)} && "
-        f"MEGAPLAN_TRUSTED_CONTAINER=1 arnold verify-human --list "
+        f"MEGAPLAN_TRUSTED_CONTAINER=1 python -m arnold.pipelines.megaplan verify-human --list "
         f"--plan {shlex.quote(plan_name)} --json"
     )
 

--- a/arnold/pipelines/megaplan/cloud/wrappers/arnold-chain
+++ b/arnold/pipelines/megaplan/cloud/wrappers/arnold-chain
@@ -4,7 +4,7 @@ SPEC="$1"
 ONE_FLAG="${2:-}"
 CANONICAL_LOG=".megaplan/cloud-chain.log"
 if [ "$ONE_FLAG" = "--one" ]; then
-    exec env MEGAPLAN_TRUSTED_CONTAINER=1 arnold chain start --spec "$SPEC" --one >> "$CANONICAL_LOG" 2>&1
+    exec env MEGAPLAN_TRUSTED_CONTAINER=1 python -m arnold.pipelines.megaplan chain start --spec "$SPEC" --one >> "$CANONICAL_LOG" 2>&1
 else
-    exec env MEGAPLAN_TRUSTED_CONTAINER=1 arnold chain start --spec "$SPEC" >> "$CANONICAL_LOG" 2>&1
+    exec env MEGAPLAN_TRUSTED_CONTAINER=1 python -m arnold.pipelines.megaplan chain start --spec "$SPEC" >> "$CANONICAL_LOG" 2>&1
 fi

--- a/arnold/pipelines/megaplan/data/_codex_skills/megaplan/SKILL.md
+++ b/arnold/pipelines/megaplan/data/_codex_skills/megaplan/SKILL.md
@@ -5,20 +5,20 @@ description: AI agent harness for coordinating Claude and GPT to make and execut
 
 # Megaplan
 
-> **Before you invoke megaplan, run the `megaplan-prep` skill.** It's the front door for every run: it sizes the work (one plan vs. an epic), shapes the brief, and picks the profile (intelligence tier), robustness level, and thinking depth. Do not run `megaplan init` without it.
+> **Before you invoke megaplan, run the `megaplan-prep` skill.** It's the front door for every run: it sizes the work (one plan vs. an epic), shapes the brief, and picks the profile (intelligence tier), robustness level, and thinking depth. Do not run `<launcher> init` without it.
 
 **Scope:** This skill covers tooling — how to invoke and drive megaplan. For the decisions that come *before* invocation (scoping, brief, profile, robustness, depth), consult the **megaplan-prep** skill. If anything here contradicts megaplan-prep on decision-making content, megaplan-prep wins.
 
-Route every step through the `megaplan` CLI. Never call agents directly.
-Before the first CLI call, resolve a working launcher and reuse it for the whole run. Do not assume `megaplan` itself is on `PATH`; command presence alone is not enough. Prove the launcher works by successfully running a harmless CLI call with it first. In the instructions below, treat `<launcher>` as that verified command.
+Route every step through the Arnold CLI's Megaplan subcommands. Never call agents directly.
+Before the first CLI call, resolve a working launcher and reuse it for the whole run. Do not assume the removed `megaplan` entrypoint is on `PATH`; command presence alone is not enough. Prove the launcher works by successfully running a harmless CLI call with it first. In the instructions below, treat `<launcher>` as that verified command.
 Launcher resolution order:
 1. Try `python -m arnold.pipelines.megaplan config show`.
 2. If that fails, try `./.venv/bin/python -m arnold.pipelines.megaplan config show`.
 3. If that fails, try `uv run python -m arnold.pipelines.megaplan config show`.
-4. If that fails, try a version-selected shim such as `PYENV_VERSION=3.11.11 arnold config show`.
-5. Only use bare `megaplan ...` if that exact form already succeeded during this check.
+4. If those fail, stop and report that the Arnold Megaplan module launcher is unavailable.
+5. Do not use the removed `megaplan` module or console entrypoint; the repo-root `megaplan.py` file is a clean-break guard.
 ## Triage
-Decision-making (scoping, profile, robustness, depth, brief structure) lives in the **megaplan-prep** skill — consult it before running `megaplan init`. **Always run megaplan, even for tiny work** — `bare` robustness is the floor, never skip the harness. The few seconds of overhead pay back in the captured brief, plan, and outcome record.
+Decision-making (scoping, profile, robustness, depth, brief structure) lives in the **megaplan-prep** skill — consult it before running `<launcher> init`. **Always run megaplan, even for tiny work** — `bare` robustness is the floor, never skip the harness. The few seconds of overhead pay back in the captured brief, plan, and outcome record.
 ## Modes
 Megaplan has two output modes, picked with `--mode` at `init`:
 - **`--mode code`** (default): the run produces a code diff. Execute workers emit per-task file changes. Use for features, refactors, bug fixes, migrations — anything whose deliverable is source code.
@@ -90,27 +90,27 @@ At `--robustness extreme`, the loop is the same as thorough but also enables par
 - `review`: judge success against the success criteria and the user's intent, not plan elegance. Only block on `must` criteria failures. `should` failures are flagged but don't require rework. `info` criteria are waived.
 ## Gate Principle
 The gate response tells the orchestrator what to do next. Follow `orchestrator_guidance` unless you have a concrete reason to disagree after investigating the repository or plan artifacts yourself.
-Investigate before disagreeing: read the current plan and critique artifacts, check the project code to verify whether a flagged issue is real, or use `megaplan status --plan <name>` / `megaplan audit --plan <name>`.
+Investigate before disagreeing: read the current plan and critique artifacts, check the project code to verify whether a flagged issue is real, or use `<launcher> status --plan <name>` / `<launcher> audit --plan <name>`.
 If you disagree with the guidance, explain why briefly and use an override. Do not manually reinterpret score trajectory, flag quality, or loop state when the gate already did that work for you.
 ## Execute
-- After a successful gate, run `megaplan finalize` to produce the execution-ready briefing document.
-- In auto-approve mode, run `megaplan execute --confirm-destructive` after finalize.
+- After a successful gate, run `<launcher> finalize` to produce the execution-ready briefing document.
+- In auto-approve mode, run `<launcher> execute --confirm-destructive` after finalize.
 - In review mode, pause at the finalize-to-execute checkpoint and wait for explicit approval before running:
 ```bash
-arnold execute --confirm-destructive --user-approved
+<launcher> execute --confirm-destructive --user-approved
 ```
 ## Long-Running Execution
 For plans with multiple batches, use per-batch mode to drive execution incrementally:
 ```bash
-arnold execute --plan <name> --confirm-destructive --user-approved --batch 1
-arnold execute --plan <name> --confirm-destructive --user-approved --batch 2
+<launcher> execute --plan <name> --confirm-destructive --user-approved --batch 1
+<launcher> execute --plan <name> --confirm-destructive --user-approved --batch 2
 # ... continue until all batches complete
 ```
 Between batches, poll progress:
 ```bash
-megaplan progress --plan <name>
+<launcher> progress --plan <name>
 ```
-Use `megaplan status --plan <name>` for the full plan state, including active-step timing and any `next_step_runtime` guidance from the latest response.
+Use `<launcher> status --plan <name>` for the full plan state, including active-step timing and any `next_step_runtime` guidance from the latest response.
 Per-batch mode uses global batch numbering (1-indexed, computed from ALL tasks). Each `--batch N` call:
 - Validates that batches 1..N-1 are complete
 - Executes only batch N's tasks
@@ -119,23 +119,23 @@ Per-batch mode uses global batch numbering (1-indexed, computed from ALL tasks).
 Timeout recovery: re-run the same `--batch N`. The harness checks prerequisite completion and merges only untracked tasks.
 Note: `progress` shows completed state only (between-batch granularity). With per-batch mode, each batch is a separate CLI call, so the orchestrator has full visibility.
 ## Overrides
-- `megaplan override add-note --plan <name> --note "..."`
-- `megaplan override force-proceed --plan <name> --reason "..."`
-- `megaplan override replan --plan <name> --reason "..." [--note "..."]`
-- `megaplan override abort --plan <name> --reason "..."`
+- `<launcher> override add-note --plan <name> --note "..."`
+- `<launcher> override force-proceed --plan <name> --reason "..."`
+- `<launcher> override replan --plan <name> --reason "..." [--note "..."]`
+- `<launcher> override abort --plan <name> --reason "..."`
 `force-proceed` is available from `critiqued` (routes to finalize, not execute). `replan` is available from `gated`, `finalized`, or `critiqued`. `add-note` is safe from any active state.
 ## Replan
 Use `replan` when the orchestrator itself needs to edit the plan directly instead of asking the revise worker to do it.
 ```bash
-megaplan override replan --plan <name> --reason "expanding scope" --note "Also clean up the display layer"
+<launcher> override replan --plan <name> --reason "expanding scope" --note "Also clean up the display layer"
 ```
-After `replan`, read the returned plan file, edit it directly, then run `megaplan critique`.
+After `replan`, read the returned plan file, edit it directly, then run `<launcher> critique`.
 ## Step Editing
 Use `step` when you need to insert, remove, or reorder step sections (`## Step N:` or `### Step N:`) without hand-editing the markdown.
 ```bash
-megaplan step add --plan <name> --after S3 "Add regression coverage for the parser"
-megaplan step remove --plan <name> S4
-megaplan step move --plan <name> S4 --after S2
+<launcher> step add --plan <name> --after S3 "Add regression coverage for the parser"
+<launcher> step remove --plan <name> S4
+<launcher> step move --plan <name> S4 --after S2
 ```
 Each edit writes a new same-iteration plan artifact, preserves the latest plan meta questions/success criteria/assumptions, and resets the plan to `planned` so it re-enters critique.
 ## Sessions And Autonomy
@@ -146,14 +146,14 @@ Each edit writes a new same-iteration plan artifact, preserves the latest plan m
 - Keep moving and show results at each step.
 - Only pause at finalize to execute in review mode.
 ## Configuration
-View current defaults with `megaplan config show`. Override with `megaplan config set <key> <value>`. Reset with `megaplan config reset`.
-When routing or behavior depends on config, check `megaplan config show` and respect user overrides instead of assuming defaults.
+View current defaults with `<launcher> config show`. Override with `<launcher> config set <key> <value>`. Reset with `<launcher> config reset`.
+When routing or behavior depends on config, check `<launcher> config show` and respect user overrides instead of assuming defaults.
 Settable execution keys: `execution.auto_approve`, `execution.robustness`.
 ## Profiles
 A profile is a named preset that maps each workflow phase to an agent/model spec. Pass `--profile <name>` to any command that accepts `--phase-model` (`init`, `loop-init`, `tiebreaker`, etc.) to apply the preset.
-See **megaplan-prep** for profile selection. Inspect available profiles with `megaplan config profiles list`.
+See **megaplan-prep** for profile selection. Inspect available profiles with `<launcher> config profiles list`.
 Resolution order, later overrides earlier within the same name: built-in (`megaplan/profiles/*.toml`) → user (`~/.config/megaplan/profiles.toml`, or `$XDG_CONFIG_HOME/megaplan/profiles.toml`) → project (`<project_dir>/.megaplan/profiles.toml`).
-Inspect with `megaplan config profiles list` and `megaplan config profiles show <name>`.
+Inspect with `<launcher> config profiles list` and `<launcher> config profiles show <name>`.
 File format: TOML with a `[profiles.<name>]` table. Keys are phase names (`plan`, `prep`, `critique`, `revise`, `gate`, `finalize`, `execute`, `loop_plan`, `loop_execute`, `review`, `tiebreaker_researcher`, `tiebreaker_challenger`); values are agent specs like `"claude"`, `"codex"`, `"hermes:fireworks:accounts/fireworks/models/kimi-k2p6"`, `"hermes:glm-5.1"`. Example:
 ```toml
 [profiles.my-mix]
@@ -166,80 +166,80 @@ review   = "codex"
 ## Bakeoff
 See the **bakeoff** skill for methodology and the **megaplan-prep** skill for when bake-offs earn their cost. This section covers the CLI mechanics once you've decided to run one.
 
-`megaplan bakeoff run` runs the same idea through multiple profiles concurrently, each in its own git worktree, each driven autonomously by `megaplan auto`. Use it when the user wants to compare profiles head-to-head on the same task (e.g., "run this with kimi and the default profile side-by-side").
-Supports `--mode code` (default) and `--mode doc` / `--mode metaplan` (alias). For doc-mode bake-offs, `--output <relative/path>` is required and is threaded into each profile's `megaplan init`; merge brings the chosen profile's doc artifact back to main instead of applying a code patch. Joke mode is not yet supported.
+`<launcher> bakeoff run` runs the same idea through multiple profiles concurrently, each in its own git worktree, each driven autonomously by `<launcher> auto`. Use it when the user wants to compare profiles head-to-head on the same task (e.g., "run this with kimi and the default profile side-by-side").
+Supports `--mode code` (default) and `--mode doc` / `--mode metaplan` (alias). For doc-mode bake-offs, `--output <relative/path>` is required and is threaded into each profile's `<launcher> init`; merge brings the chosen profile's doc artifact back to main instead of applying a code patch. Joke mode is not yet supported.
 Requires a clean main worktree by default — pass `--allow-dirty` when there are unrelated uncommitted changes you want to keep on main. Those changes stay on main and are NOT copied into the worktrees, since worktrees branch off the current commit's SHA.
 The idea must be a file (`--idea-file <path>`), not an inline string. Write the idea to a file first.
-Bakeoff is inherently autonomous (it spawns `megaplan auto`), so the execution-mode question doesn't apply to bakeoff runs. `--robustness` is forwarded to each profile's `init`. When a project-layer `.megaplan/profiles.toml` exists, it's automatically copied into each worktree so project-only profiles resolve.
+Bakeoff is inherently autonomous (it spawns `<launcher> auto`), so the execution-mode question doesn't apply to bakeoff runs. `--robustness` is forwarded to each profile's `init`. When a project-layer `.megaplan/profiles.toml` exists, it's automatically copied into each worktree so project-only profiles resolve.
 Lifecycle:
-- `megaplan bakeoff run --idea-file <path> --profiles <p1> <p2> [--mode code|doc|metaplan] [--output <relative/path>] [--exp-id <id>] [--detach] [--robustness <level>] [--allow-dirty]` — kicks off N concurrent profile runs. Without `--detach` it streams a live status table every 5s and blocks until all profiles finish; with `--detach` it returns immediately and the user polls via `status`. `--output` is required with `--mode doc|metaplan` and rejected with `--mode code`.
-- `megaplan bakeoff status [--exp <id>]` — current state of each profile (running / completed / crashed).
-- `megaplan bakeoff tail [--exp <id>]` — tail the per-profile auto logs.
-- `megaplan bakeoff compare --exp <id> [--judge <model>]` — collect metrics across profiles; with `--judge`, an LLM judge ranks the outputs.
-- `megaplan bakeoff pick --exp <id> --profile <name> --rationale "..."` — record the human-selected winner.
-- `megaplan bakeoff merge --exp <id>` — merge the chosen profile's worktree back to main.
-- `megaplan bakeoff resume --exp <id>` — resume unfinished profile runs.
-- `megaplan bakeoff abandon --exp <id>` — discard worktrees but keep audit data.
+- `<launcher> bakeoff run --idea-file <path> --profiles <p1> <p2> [--mode code|doc|metaplan] [--output <relative/path>] [--exp-id <id>] [--detach] [--robustness <level>] [--allow-dirty]` — kicks off N concurrent profile runs. Without `--detach` it streams a live status table every 5s and blocks until all profiles finish; with `--detach` it returns immediately and the user polls via `status`. `--output` is required with `--mode doc|metaplan` and rejected with `--mode code`.
+- `<launcher> bakeoff status [--exp <id>]` — current state of each profile (running / completed / crashed).
+- `<launcher> bakeoff tail [--exp <id>]` — tail the per-profile auto logs.
+- `<launcher> bakeoff compare --exp <id> [--judge <model>]` — collect metrics across profiles; with `--judge`, an LLM judge ranks the outputs.
+- `<launcher> bakeoff pick --exp <id> --profile <name> --rationale "..."` — record the human-selected winner.
+- `<launcher> bakeoff merge --exp <id>` — merge the chosen profile's worktree back to main.
+- `<launcher> bakeoff resume --exp <id>` — resume unfinished profile runs.
+- `<launcher> bakeoff abandon --exp <id>` — discard worktrees but keep audit data.
 ## Cloud Mode
-`megaplan cloud` runs a plan inside a provider-managed container with a persistent workspace volume, so the run survives the user's terminal session. Suggest it for long-running plans that would outlast a local session, multi-repo work, or when the user wants an isolated persistent sandbox. Sprint 1 ships the `railway` provider only; `ssh` and `local` are planned.
+`<launcher> cloud` runs a plan inside a provider-managed container with a persistent workspace volume, so the run survives the user's terminal session. Suggest it for long-running plans that would outlast a local session, multi-repo work, or when the user wants an isolated persistent sandbox. Sprint 1 ships the `railway` provider only; `ssh` and `local` are planned.
 
-Quick subcommand reference: `init`, `build`, `deploy`, `chain`, `status`, `attach`, `logs`, `exec`, `resume`, `down`, `destroy`. Typical flow: `megaplan cloud init` → edit `cloud.yaml` → export secrets → `megaplan cloud deploy` → `megaplan cloud chain <chain.yaml>`.
+Quick subcommand reference: `init`, `build`, `deploy`, `chain`, `status`, `attach`, `logs`, `exec`, `resume`, `down`, `destroy`. Typical flow: `<launcher> cloud init` → edit `cloud.yaml` → export secrets → `<launcher> cloud deploy` → `<launcher> cloud chain <chain.yaml>`.
 
 For the full reference — `cloud.yaml` fields, the `extra_repos[]` + `chain_session` multi-tenancy model, the operator loop, and the gotchas that wedge fresh runs (committed `chain_state.json`, profile-alias gap, secret-upload behavior, "internal_error" masking credit failures) — see the **megaplan-cloud** skill. Read it before launching the first cloud chain in a new project; the gotchas section will save hours.
 ## Tickets
-`megaplan ticket new` creates a repo-scoped issue ticket. Use it when:
+`<launcher> ticket new` creates a repo-scoped issue ticket. Use it when:
 - During epic/plan work you notice an out-of-scope problem, bug, or rough edge
 - A user explicitly asks you to capture something for later attention
 - You want to log an observation that doesn't block the current task but should be tracked
 
-The command prints only a ULID to stdout on success. Tickets live as `.megaplan/tickets/{ulid}-{slug}.md` files and are auto-discovered by the planner for future epics. Link them to epics with `megaplan ticket link <ticket> <epic> --resolves` so they auto-address when the epic completes.
+The command prints only a ULID to stdout on success. Tickets live as `.megaplan/tickets/{ulid}-{slug}.md` files and are auto-discovered by the planner for future epics. Link them to epics with `<launcher> ticket link <ticket> <epic> --resolves` so they auto-address when the epic completes.
 
 ## Briefs
-`megaplan brief` creates canonical source artifacts for work you intend to run.
+`<launcher> brief` creates canonical source artifacts for work you intend to run.
 Use it when:
 - You are turning an idea into a durable single-plan input
 - You are scaffolding an epic's `chain.yaml` and milestone idea files
-- You want the source document committed before `megaplan init` snapshots it into plan state
+- You want the source document committed before `<launcher> init` snapshots it into plan state
 
 Briefs live as committed files under `.megaplan/briefs/`. Single-plan ideas live
 at `.megaplan/briefs/{slug}.md`; epics live at
 `.megaplan/briefs/{epic-slug}/chain.yaml` with milestone briefs beside the chain
 spec. This is ticket-like in storage and ergonomics, but not in lifecycle:
-briefs feed `megaplan init` / `megaplan chain start`; tickets are open problem
+briefs feed `<launcher> init` / `<launcher> chain start`; tickets are open problem
 notes that can be discovered, linked, and auto-addressed by epics.
 
 Briefs and tickets share the local artifact substrate: common `.megaplan/<kind>/`
 path handling, slug normalization, optional frontmatter parsing, keyword
-filtering, and snippets. Use `megaplan brief list`, `megaplan brief show`, and
-`megaplan brief search` for the brief side of that common read surface.
+filtering, and snippets. Use `<launcher> brief list`, `<launcher> brief show`, and
+`<launcher> brief search` for the brief side of that common read surface.
 
-`megaplan init --idea-file <path>` reads the file and snapshots its text; it does
+`<launcher> init --idea-file <path>` reads the file and snapshots its text; it does
 not move arbitrary files into `.megaplan/briefs/`. If the idea file is a markdown
 artifact with YAML frontmatter, `init` snapshots only the markdown body. Use
-`megaplan brief new --init` to create the canonical source file first and then
+`<launcher> brief new --init` to create the canonical source file first and then
 initialize from it.
 
 ## Feedback
 See **megaplan-prep** for when to add the feedback phase (`--with-feedback`). This section covers the CLI mechanics once you've decided to use it.
 
-`megaplan feedback --plan <name>` scaffolds a `feedback.md` file in the plan directory and opens it in `$EDITOR` (or `$VISUAL`). The file has one section per workflow stage — `prep`, `plan`, `critique`, `revise`, `gate`, `tiebreaker`, `finalize`, `execute`, `review` — plus an `Overall` section. Each section has a `rating:` (integer 0–10) and a free-form `comment:` field; leave any field blank to skip it.
+`<launcher> feedback --plan <name>` scaffolds a `feedback.md` file in the plan directory and opens it in `$EDITOR` (or `$VISUAL`). The file has one section per workflow stage — `prep`, `plan`, `critique`, `revise`, `gate`, `tiebreaker`, `finalize`, `execute`, `review` — plus an `Overall` section. Each section has a `rating:` (integer 0–10) and a free-form `comment:` field; leave any field blank to skip it.
 
-This is **user feedback**, owned by the human after a run finishes — megaplan only scaffolds the template and parses it back on load, it never overwrites edits. Old plans without a `feedback.md` simply have no feedback attached; running `megaplan feedback --plan <name>` on an older plan scaffolds the template on demand (backwards compatible).
+This is **user feedback**, owned by the human after a run finishes — megaplan only scaffolds the template and parses it back on load, it never overwrites edits. Old plans without a `feedback.md` simply have no feedback attached; running `<launcher> feedback --plan <name>` on an older plan scaffolds the template on demand (backwards compatible).
 
-Use `megaplan feedback show --plan <name>` to print the parsed summary, and `--no-edit` to just scaffold the template and print the path without launching an editor. Parsed feedback is exposed on the in-memory `Plan` record as `Plan.feedback` (a dict shaped `{"overall": {...}, "stages": {stage: {...}}}`), so downstream tooling can read it the same way as any other artifact. When `--actor`/`MEGAPLAN_ACTOR_ID` is set, parsed feedback is also written to the `plans.feedback` jsonb column so the DB and file backends stay in sync.
+Use `<launcher> feedback show --plan <name>` to print the parsed summary, and `--no-edit` to just scaffold the template and print the path without launching an editor. Parsed feedback is exposed on the in-memory `Plan` record as `Plan.feedback` (a dict shaped `{"overall": {...}, "stages": {stage: {...}}}`), so downstream tooling can read it the same way as any other artifact. When `--actor`/`MEGAPLAN_ACTOR_ID` is set, parsed feedback is also written to the `plans.feedback` jsonb column so the DB and file backends stay in sync.
 
 ### Filling feedback with subagents
 Recommended process when an agent (rather than the human) is producing the initial assessment:
 
-1. **Scaffold**: run `megaplan feedback --plan <name> --no-edit` to create the empty `feedback.md`. Note the plan directory it prints — that is where the per-stage artifacts live (`plan_v*.md`, `critique*.json`, `gate.json`, `tiebreaker_*.json`, `finalize.json`, `execution*.json`, `review.json`, etc.).
+1. **Scaffold**: run `<launcher> feedback --plan <name> --no-edit` to create the empty `feedback.md`. Note the plan directory it prints — that is where the per-stage artifacts live (`plan_v*.md`, `critique*.json`, `gate.json`, `tiebreaker_*.json`, `finalize.json`, `execution*.json`, `review.json`, etc.).
 2. **Per-stage assessment**: dispatch one read-only subagent per stage that actually ran (skip stages with no artifacts). Brief each subagent narrowly — give it the plan idea, the stage name, and the artifact filenames for that stage only. Ask it to return a 0–10 rating plus a 1–3 sentence comment grounded in what the artifacts show (what worked, what was weak, what was missed). Run these in parallel; they have no dependencies on each other.
 3. **Synthesize Overall**: after the per-stage results come back, *you* (the orchestrating agent, not a subagent) read the per-stage ratings and comments together with the final outcome (`final.md`, `review.json`, any `latest_failure`) and decide an Overall rating and comment. The Overall is a judgment call about whether the run delivered the goal, not an average of stage ratings.
-4. **Write**: edit `feedback.md` with the ratings and comments. Leave a stage blank if it didn't run or you can't form a defensible opinion — empty is better than guessed. Run `megaplan feedback show --plan <name>` to confirm the parser picked everything up.
+4. **Write**: edit `feedback.md` with the ratings and comments. Leave a stage blank if it didn't run or you can't form a defensible opinion — empty is better than guessed. Run `<launcher> feedback show --plan <name>` to confirm the parser picked everything up.
 
 Keep comments grounded in specific artifact evidence ("critique flagged X but reviewer didn't catch the regression in Y") rather than vibes. The point of feedback is signal for future runs, not a participation score.
 
 ### Searching feedback across plans
-`megaplan feedback search` queries every plan with non-empty feedback across both backends — local `feedback.md` files in this project tree plus, when an actor is configured, the `plans.feedback` jsonb column in the DB. Duplicates between backends are de-duped by (plan name, project_dir). Use this to answer "which profile actually scored well on this repo?" or "where did the executor get a 6 or below?". Filters:
+`<launcher> feedback search` queries every plan with non-empty feedback across both backends — local `feedback.md` files in this project tree plus, when an actor is configured, the `plans.feedback` jsonb column in the DB. Duplicates between backends are de-duped by (plan name, project_dir). Use this to answer "which profile actually scored well on this repo?" or "where did the executor get a 6 or below?". Filters:
 - `--profile <substr>` — substring match on the plan's profile (e.g. `--profile claude` matches `all-claude`, `claude-led`, etc.).
 - `--repo <substr>` — substring match on the plan's `project_dir` / repo path.
 - `--min-rating N` / `--max-rating N` — bounds on the Overall rating.
@@ -248,70 +248,70 @@ Keep comments grounded in specific artifact evidence ("critique flagged X but re
 - `--all` — scan every megaplan project root on this machine, not just the current tree.
 - `--json` — emit raw rows instead of a table.
 
-Default output is a compact table (plan, profile, overall rating, backend, repo, plus the first line of the Overall comment). Combine with `megaplan feedback show --plan <name>` to drill into a specific match.
+Default output is a compact table (plan, profile, overall rating, backend, repo, plus the first line of the Overall comment). Combine with `<launcher> feedback show --plan <name>` to drill into a specific match.
 ## Observability
 Plans started after this layer landed write an append-only `events.ndjson` event journal to their plan dir. Four CLI surfaces read from it; reach for them whenever a run is in flight or you need to reconstruct what happened. See the **megaplan-observe** skill for the full failure-mode catalog and worked invocation chains.
 
-- `megaplan introspect --plan <name>` — single structured-JSON snapshot. Always check this first when something looks stuck; the `active_phase.liveness` enum (`progressing | quiet | stalled | timeout-imminent`) and `block_details.recoverable_via` together tell you whether to wait, intervene, or override. Also surfaces `outstanding_flags_count`, useful when a plan is sitting on unresolved critique signals.
-- `megaplan trace --plan <name> [--follow] [--format json|pretty|narrative] [--phase <p>] [--since <duration>]` — stream events. `narrative` format is the agent-facing affordance; `--follow` tails as the plan progresses; `--phase` and `--since` filter. Prints `trace: no events.ndjson for plan <name>` cleanly when a plan predates the journal.
-- `megaplan doctor [--plan <name> | --repo]` — diagnostic. `--repo` catches rubric/binary drift (skill profile names vs `profiles list`) and editable-install dirtiness *before* `megaplan init`, so reach for it after a branch switch / pull / fresh checkout. `--plan` reports lock, phase liveness, LLM liveness, cost-vs-cap, orphan subprocesses, and outstanding flags.
-- `megaplan record-tag --plan <name> --tag <name> --note "..."` — annotate a moment in the journal so later trace/introspect calls can find it. All three args are required.
+- `<launcher> introspect --plan <name>` — single structured-JSON snapshot. Always check this first when something looks stuck; the `active_phase.liveness` enum (`progressing | quiet | stalled | timeout-imminent`) and `block_details.recoverable_via` together tell you whether to wait, intervene, or override. Also surfaces `outstanding_flags_count`, useful when a plan is sitting on unresolved critique signals.
+- `<launcher> trace --plan <name> [--follow] [--format json|pretty|narrative] [--phase <p>] [--since <duration>]` — stream events. `narrative` format is the agent-facing affordance; `--follow` tails as the plan progresses; `--phase` and `--since` filter. Prints `trace: no events.ndjson for plan <name>` cleanly when a plan predates the journal.
+- `<launcher> doctor [--plan <name> | --repo]` — diagnostic. `--repo` catches rubric/binary drift (skill profile names vs `profiles list`) and editable-install dirtiness *before* `<launcher> init`, so reach for it after a branch switch / pull / fresh checkout. `--plan` reports lock, phase liveness, LLM liveness, cost-vs-cap, orphan subprocesses, and outstanding flags.
+- `<launcher> record-tag --plan <name> --tag <name> --note "..."` — annotate a moment in the journal so later trace/introspect calls can find it. All three args are required.
 
 Stale-timestamp inference, opaque blocked state, and "model thinking vs TCP wedged" are the three confusions this layer is designed to kill — if you find yourself running `lsof`, `ps`, or doing manual `ls -lat` time math on a plan dir, you should be running `introspect` or `trace` instead.
 ## Commands
 ```bash
-arnold status --plan <name>
-megaplan progress --plan <name>
-megaplan audit --plan <name>
-megaplan list
-megaplan prep --plan <name>
-megaplan plan --plan <name>
-megaplan critique --plan <name>
-megaplan revise --plan <name>
-megaplan gate --plan <name>
-megaplan finalize --plan <name>
-arnold execute --plan <name> --confirm-destructive [--batch N]
-arnold review --plan <name>
-megaplan step add --plan <name> [--after S<N>] "description"
-megaplan step remove --plan <name> S<N>
-megaplan step move --plan <name> S<N> --after S<M>
-megaplan override add-note --plan <name> --note "..."
-megaplan override force-proceed --plan <name> --reason "..."
-megaplan override replan --plan <name> --reason "..." [--note "..."]
-megaplan override abort --plan <name> --reason "..."
-arnold config show
-arnold config set <key> <value>
-arnold config reset
-arnold config profiles list
-arnold config profiles show <name>
-megaplan bakeoff run --idea-file <path> --profiles <p1> <p2> [--mode code|doc|metaplan] [--output <relative/path>] [--exp-id <id>] [--detach] [--robustness <level>] [--allow-dirty]
-megaplan bakeoff status [--exp <id>]
-megaplan bakeoff tail [--exp <id>]
-megaplan bakeoff compare --exp <id> [--judge <model>]
-megaplan bakeoff pick --exp <id> --profile <name> --rationale "..."
-megaplan bakeoff merge --exp <id>
-megaplan bakeoff resume --exp <id>
-megaplan bakeoff abandon --exp <id>
-megaplan brief new <slug> [-b <body> | --from <path> | -] [--force] [--init]
-megaplan brief epic <slug> --milestone LABEL=TITLE [--base-branch <branch>] [--force]
-megaplan brief list [--json]
-megaplan brief show <id-or-path> [--json]
-megaplan brief search [KW ...] [--all] [--sort path|title|length] [--desc] [--limit N] [--json]
-megaplan ticket new "title" -b "body"
-megaplan ticket list [--status <s>] [--tags <t>] [--json]
-megaplan ticket show <id> [--json]
-megaplan ticket edit <id> [--title <t>] [--body <b>] [--status <s>]
-megaplan ticket link <ticket> <epic> [--resolves]
-megaplan ticket unlink <ticket> <epic>
-megaplan ticket addressed <id> [--note <n>]
-megaplan ticket dismiss <id> --reason "..."
-megaplan ticket reopen <id>
-megaplan feedback show --plan <name> [--no-edit]
-megaplan feedback search [--profile <s>] [--repo <s>] [--min-rating N] [--max-rating N] [--stage <name>] [--has-comment] [--all] [--json]
-megaplan introspect --plan <name> [--json]
-megaplan trace --plan <name> [--follow] [--format json|pretty|narrative] [--phase <p>] [--since <duration>]
-megaplan doctor [--plan <name> | --repo]
-megaplan record-tag --plan <name> --tag <name> --note "..."
+<launcher> status --plan <name>
+<launcher> progress --plan <name>
+<launcher> audit --plan <name>
+<launcher> list
+<launcher> prep --plan <name>
+<launcher> plan --plan <name>
+<launcher> critique --plan <name>
+<launcher> revise --plan <name>
+<launcher> gate --plan <name>
+<launcher> finalize --plan <name>
+<launcher> execute --plan <name> --confirm-destructive [--batch N]
+<launcher> review --plan <name>
+<launcher> step add --plan <name> [--after S<N>] "description"
+<launcher> step remove --plan <name> S<N>
+<launcher> step move --plan <name> S<N> --after S<M>
+<launcher> override add-note --plan <name> --note "..."
+<launcher> override force-proceed --plan <name> --reason "..."
+<launcher> override replan --plan <name> --reason "..." [--note "..."]
+<launcher> override abort --plan <name> --reason "..."
+<launcher> config show
+<launcher> config set <key> <value>
+<launcher> config reset
+<launcher> config profiles list
+<launcher> config profiles show <name>
+<launcher> bakeoff run --idea-file <path> --profiles <p1> <p2> [--mode code|doc|metaplan] [--output <relative/path>] [--exp-id <id>] [--detach] [--robustness <level>] [--allow-dirty]
+<launcher> bakeoff status [--exp <id>]
+<launcher> bakeoff tail [--exp <id>]
+<launcher> bakeoff compare --exp <id> [--judge <model>]
+<launcher> bakeoff pick --exp <id> --profile <name> --rationale "..."
+<launcher> bakeoff merge --exp <id>
+<launcher> bakeoff resume --exp <id>
+<launcher> bakeoff abandon --exp <id>
+<launcher> brief new <slug> [-b <body> | --from <path> | -] [--force] [--init]
+<launcher> brief epic <slug> --milestone LABEL=TITLE [--base-branch <branch>] [--force]
+<launcher> brief list [--json]
+<launcher> brief show <id-or-path> [--json]
+<launcher> brief search [KW ...] [--all] [--sort path|title|length] [--desc] [--limit N] [--json]
+<launcher> ticket new "title" -b "body"
+<launcher> ticket list [--status <s>] [--tags <t>] [--json]
+<launcher> ticket show <id> [--json]
+<launcher> ticket edit <id> [--title <t>] [--body <b>] [--status <s>]
+<launcher> ticket link <ticket> <epic> [--resolves]
+<launcher> ticket unlink <ticket> <epic>
+<launcher> ticket addressed <id> [--note <n>]
+<launcher> ticket dismiss <id> --reason "..."
+<launcher> ticket reopen <id>
+<launcher> feedback show --plan <name> [--no-edit]
+<launcher> feedback search [--profile <s>] [--repo <s>] [--min-rating N] [--max-rating N] [--stage <name>] [--has-comment] [--all] [--json]
+<launcher> introspect --plan <name> [--json]
+<launcher> trace --plan <name> [--follow] [--format json|pretty|narrative] [--phase <p>] [--since <duration>]
+<launcher> doctor [--plan <name> | --repo]
+<launcher> record-tag --plan <name> --tag <name> --note "..."
 ```
 
 

--- a/arnold/pipelines/megaplan/data/_composed/claude_skill.md
+++ b/arnold/pipelines/megaplan/data/_composed/claude_skill.md
@@ -5,20 +5,20 @@ description: AI agent harness for coordinating Claude and GPT to make and execut
 
 # Megaplan
 
-> **Before you invoke megaplan, run the `megaplan-prep` skill.** It's the front door for every run: it sizes the work (one plan vs. an epic), shapes the brief, and picks the profile (intelligence tier), robustness level, and thinking depth. Do not run `megaplan init` without it.
+> **Before you invoke megaplan, run the `megaplan-prep` skill.** It's the front door for every run: it sizes the work (one plan vs. an epic), shapes the brief, and picks the profile (intelligence tier), robustness level, and thinking depth. Do not run `<launcher> init` without it.
 
 **Scope:** This skill covers tooling — how to invoke and drive megaplan. For the decisions that come *before* invocation (scoping, brief, profile, robustness, depth), consult the **megaplan-prep** skill. If anything here contradicts megaplan-prep on decision-making content, megaplan-prep wins.
 
-Route every step through the `megaplan` CLI. Never call agents directly.
-Before the first CLI call, resolve a working launcher and reuse it for the whole run. Do not assume `megaplan` itself is on `PATH`; command presence alone is not enough. Prove the launcher works by successfully running a harmless CLI call with it first. In the instructions below, treat `<launcher>` as that verified command.
+Route every step through the Arnold CLI's Megaplan subcommands. Never call agents directly.
+Before the first CLI call, resolve a working launcher and reuse it for the whole run. Do not assume the removed `megaplan` entrypoint is on `PATH`; command presence alone is not enough. Prove the launcher works by successfully running a harmless CLI call with it first. In the instructions below, treat `<launcher>` as that verified command.
 Launcher resolution order:
 1. Try `python -m arnold.pipelines.megaplan config show`.
 2. If that fails, try `./.venv/bin/python -m arnold.pipelines.megaplan config show`.
 3. If that fails, try `uv run python -m arnold.pipelines.megaplan config show`.
-4. If that fails, try a version-selected shim such as `PYENV_VERSION=3.11.11 arnold config show`.
-5. Only use bare `megaplan ...` if that exact form already succeeded during this check.
+4. If those fail, stop and report that the Arnold Megaplan module launcher is unavailable.
+5. Do not use the removed `megaplan` module or console entrypoint; the repo-root `megaplan.py` file is a clean-break guard.
 ## Triage
-Decision-making (scoping, profile, robustness, depth, brief structure) lives in the **megaplan-prep** skill — consult it before running `megaplan init`. **Always run megaplan, even for tiny work** — `bare` robustness is the floor, never skip the harness. The few seconds of overhead pay back in the captured brief, plan, and outcome record.
+Decision-making (scoping, profile, robustness, depth, brief structure) lives in the **megaplan-prep** skill — consult it before running `<launcher> init`. **Always run megaplan, even for tiny work** — `bare` robustness is the floor, never skip the harness. The few seconds of overhead pay back in the captured brief, plan, and outcome record.
 ## Modes
 Megaplan has two output modes, picked with `--mode` at `init`:
 - **`--mode code`** (default): the run produces a code diff. Execute workers emit per-task file changes. Use for features, refactors, bug fixes, migrations — anything whose deliverable is source code.
@@ -90,27 +90,27 @@ At `--robustness extreme`, the loop is the same as thorough but also enables par
 - `review`: judge success against the success criteria and the user's intent, not plan elegance. Only block on `must` criteria failures. `should` failures are flagged but don't require rework. `info` criteria are waived.
 ## Gate Principle
 The gate response tells the orchestrator what to do next. Follow `orchestrator_guidance` unless you have a concrete reason to disagree after investigating the repository or plan artifacts yourself.
-Investigate before disagreeing: read the current plan and critique artifacts, check the project code to verify whether a flagged issue is real, or use `megaplan status --plan <name>` / `megaplan audit --plan <name>`.
+Investigate before disagreeing: read the current plan and critique artifacts, check the project code to verify whether a flagged issue is real, or use `<launcher> status --plan <name>` / `<launcher> audit --plan <name>`.
 If you disagree with the guidance, explain why briefly and use an override. Do not manually reinterpret score trajectory, flag quality, or loop state when the gate already did that work for you.
 ## Execute
-- After a successful gate, run `megaplan finalize` to produce the execution-ready briefing document.
-- In auto-approve mode, run `megaplan execute --confirm-destructive` after finalize.
+- After a successful gate, run `<launcher> finalize` to produce the execution-ready briefing document.
+- In auto-approve mode, run `<launcher> execute --confirm-destructive` after finalize.
 - In review mode, pause at the finalize-to-execute checkpoint and wait for explicit approval before running:
 ```bash
-arnold execute --confirm-destructive --user-approved
+<launcher> execute --confirm-destructive --user-approved
 ```
 ## Long-Running Execution
 For plans with multiple batches, use per-batch mode to drive execution incrementally:
 ```bash
-arnold execute --plan <name> --confirm-destructive --user-approved --batch 1
-arnold execute --plan <name> --confirm-destructive --user-approved --batch 2
+<launcher> execute --plan <name> --confirm-destructive --user-approved --batch 1
+<launcher> execute --plan <name> --confirm-destructive --user-approved --batch 2
 # ... continue until all batches complete
 ```
 Between batches, poll progress:
 ```bash
-megaplan progress --plan <name>
+<launcher> progress --plan <name>
 ```
-Use `megaplan status --plan <name>` for the full plan state, including active-step timing and any `next_step_runtime` guidance from the latest response.
+Use `<launcher> status --plan <name>` for the full plan state, including active-step timing and any `next_step_runtime` guidance from the latest response.
 Per-batch mode uses global batch numbering (1-indexed, computed from ALL tasks). Each `--batch N` call:
 - Validates that batches 1..N-1 are complete
 - Executes only batch N's tasks
@@ -119,23 +119,23 @@ Per-batch mode uses global batch numbering (1-indexed, computed from ALL tasks).
 Timeout recovery: re-run the same `--batch N`. The harness checks prerequisite completion and merges only untracked tasks.
 Note: `progress` shows completed state only (between-batch granularity). With per-batch mode, each batch is a separate CLI call, so the orchestrator has full visibility.
 ## Overrides
-- `megaplan override add-note --plan <name> --note "..."`
-- `megaplan override force-proceed --plan <name> --reason "..."`
-- `megaplan override replan --plan <name> --reason "..." [--note "..."]`
-- `megaplan override abort --plan <name> --reason "..."`
+- `<launcher> override add-note --plan <name> --note "..."`
+- `<launcher> override force-proceed --plan <name> --reason "..."`
+- `<launcher> override replan --plan <name> --reason "..." [--note "..."]`
+- `<launcher> override abort --plan <name> --reason "..."`
 `force-proceed` is available from `critiqued` (routes to finalize, not execute). `replan` is available from `gated`, `finalized`, or `critiqued`. `add-note` is safe from any active state.
 ## Replan
 Use `replan` when the orchestrator itself needs to edit the plan directly instead of asking the revise worker to do it.
 ```bash
-megaplan override replan --plan <name> --reason "expanding scope" --note "Also clean up the display layer"
+<launcher> override replan --plan <name> --reason "expanding scope" --note "Also clean up the display layer"
 ```
-After `replan`, read the returned plan file, edit it directly, then run `megaplan critique`.
+After `replan`, read the returned plan file, edit it directly, then run `<launcher> critique`.
 ## Step Editing
 Use `step` when you need to insert, remove, or reorder step sections (`## Step N:` or `### Step N:`) without hand-editing the markdown.
 ```bash
-megaplan step add --plan <name> --after S3 "Add regression coverage for the parser"
-megaplan step remove --plan <name> S4
-megaplan step move --plan <name> S4 --after S2
+<launcher> step add --plan <name> --after S3 "Add regression coverage for the parser"
+<launcher> step remove --plan <name> S4
+<launcher> step move --plan <name> S4 --after S2
 ```
 Each edit writes a new same-iteration plan artifact, preserves the latest plan meta questions/success criteria/assumptions, and resets the plan to `planned` so it re-enters critique.
 ## Sessions And Autonomy
@@ -146,14 +146,14 @@ Each edit writes a new same-iteration plan artifact, preserves the latest plan m
 - Keep moving and show results at each step.
 - Only pause at finalize to execute in review mode.
 ## Configuration
-View current defaults with `megaplan config show`. Override with `megaplan config set <key> <value>`. Reset with `megaplan config reset`.
-When routing or behavior depends on config, check `megaplan config show` and respect user overrides instead of assuming defaults.
+View current defaults with `<launcher> config show`. Override with `<launcher> config set <key> <value>`. Reset with `<launcher> config reset`.
+When routing or behavior depends on config, check `<launcher> config show` and respect user overrides instead of assuming defaults.
 Settable execution keys: `execution.auto_approve`, `execution.robustness`.
 ## Profiles
 A profile is a named preset that maps each workflow phase to an agent/model spec. Pass `--profile <name>` to any command that accepts `--phase-model` (`init`, `loop-init`, `tiebreaker`, etc.) to apply the preset.
-See **megaplan-prep** for profile selection. Inspect available profiles with `megaplan config profiles list`.
+See **megaplan-prep** for profile selection. Inspect available profiles with `<launcher> config profiles list`.
 Resolution order, later overrides earlier within the same name: built-in (`megaplan/profiles/*.toml`) → user (`~/.config/megaplan/profiles.toml`, or `$XDG_CONFIG_HOME/megaplan/profiles.toml`) → project (`<project_dir>/.megaplan/profiles.toml`).
-Inspect with `megaplan config profiles list` and `megaplan config profiles show <name>`.
+Inspect with `<launcher> config profiles list` and `<launcher> config profiles show <name>`.
 File format: TOML with a `[profiles.<name>]` table. Keys are phase names (`plan`, `prep`, `critique`, `revise`, `gate`, `finalize`, `execute`, `loop_plan`, `loop_execute`, `review`, `tiebreaker_researcher`, `tiebreaker_challenger`); values are agent specs like `"claude"`, `"codex"`, `"hermes:fireworks:accounts/fireworks/models/kimi-k2p6"`, `"hermes:glm-5.1"`. Example:
 ```toml
 [profiles.my-mix]
@@ -166,80 +166,80 @@ review   = "codex"
 ## Bakeoff
 See the **bakeoff** skill for methodology and the **megaplan-prep** skill for when bake-offs earn their cost. This section covers the CLI mechanics once you've decided to run one.
 
-`megaplan bakeoff run` runs the same idea through multiple profiles concurrently, each in its own git worktree, each driven autonomously by `megaplan auto`. Use it when the user wants to compare profiles head-to-head on the same task (e.g., "run this with kimi and the default profile side-by-side").
-Supports `--mode code` (default) and `--mode doc` / `--mode metaplan` (alias). For doc-mode bake-offs, `--output <relative/path>` is required and is threaded into each profile's `megaplan init`; merge brings the chosen profile's doc artifact back to main instead of applying a code patch. Joke mode is not yet supported.
+`<launcher> bakeoff run` runs the same idea through multiple profiles concurrently, each in its own git worktree, each driven autonomously by `<launcher> auto`. Use it when the user wants to compare profiles head-to-head on the same task (e.g., "run this with kimi and the default profile side-by-side").
+Supports `--mode code` (default) and `--mode doc` / `--mode metaplan` (alias). For doc-mode bake-offs, `--output <relative/path>` is required and is threaded into each profile's `<launcher> init`; merge brings the chosen profile's doc artifact back to main instead of applying a code patch. Joke mode is not yet supported.
 Requires a clean main worktree by default — pass `--allow-dirty` when there are unrelated uncommitted changes you want to keep on main. Those changes stay on main and are NOT copied into the worktrees, since worktrees branch off the current commit's SHA.
 The idea must be a file (`--idea-file <path>`), not an inline string. Write the idea to a file first.
-Bakeoff is inherently autonomous (it spawns `megaplan auto`), so the execution-mode question doesn't apply to bakeoff runs. `--robustness` is forwarded to each profile's `init`. When a project-layer `.megaplan/profiles.toml` exists, it's automatically copied into each worktree so project-only profiles resolve.
+Bakeoff is inherently autonomous (it spawns `<launcher> auto`), so the execution-mode question doesn't apply to bakeoff runs. `--robustness` is forwarded to each profile's `init`. When a project-layer `.megaplan/profiles.toml` exists, it's automatically copied into each worktree so project-only profiles resolve.
 Lifecycle:
-- `megaplan bakeoff run --idea-file <path> --profiles <p1> <p2> [--mode code|doc|metaplan] [--output <relative/path>] [--exp-id <id>] [--detach] [--robustness <level>] [--allow-dirty]` — kicks off N concurrent profile runs. Without `--detach` it streams a live status table every 5s and blocks until all profiles finish; with `--detach` it returns immediately and the user polls via `status`. `--output` is required with `--mode doc|metaplan` and rejected with `--mode code`.
-- `megaplan bakeoff status [--exp <id>]` — current state of each profile (running / completed / crashed).
-- `megaplan bakeoff tail [--exp <id>]` — tail the per-profile auto logs.
-- `megaplan bakeoff compare --exp <id> [--judge <model>]` — collect metrics across profiles; with `--judge`, an LLM judge ranks the outputs.
-- `megaplan bakeoff pick --exp <id> --profile <name> --rationale "..."` — record the human-selected winner.
-- `megaplan bakeoff merge --exp <id>` — merge the chosen profile's worktree back to main.
-- `megaplan bakeoff resume --exp <id>` — resume unfinished profile runs.
-- `megaplan bakeoff abandon --exp <id>` — discard worktrees but keep audit data.
+- `<launcher> bakeoff run --idea-file <path> --profiles <p1> <p2> [--mode code|doc|metaplan] [--output <relative/path>] [--exp-id <id>] [--detach] [--robustness <level>] [--allow-dirty]` — kicks off N concurrent profile runs. Without `--detach` it streams a live status table every 5s and blocks until all profiles finish; with `--detach` it returns immediately and the user polls via `status`. `--output` is required with `--mode doc|metaplan` and rejected with `--mode code`.
+- `<launcher> bakeoff status [--exp <id>]` — current state of each profile (running / completed / crashed).
+- `<launcher> bakeoff tail [--exp <id>]` — tail the per-profile auto logs.
+- `<launcher> bakeoff compare --exp <id> [--judge <model>]` — collect metrics across profiles; with `--judge`, an LLM judge ranks the outputs.
+- `<launcher> bakeoff pick --exp <id> --profile <name> --rationale "..."` — record the human-selected winner.
+- `<launcher> bakeoff merge --exp <id>` — merge the chosen profile's worktree back to main.
+- `<launcher> bakeoff resume --exp <id>` — resume unfinished profile runs.
+- `<launcher> bakeoff abandon --exp <id>` — discard worktrees but keep audit data.
 ## Cloud Mode
-`megaplan cloud` runs a plan inside a provider-managed container with a persistent workspace volume, so the run survives the user's terminal session. Suggest it for long-running plans that would outlast a local session, multi-repo work, or when the user wants an isolated persistent sandbox. Sprint 1 ships the `railway` provider only; `ssh` and `local` are planned.
+`<launcher> cloud` runs a plan inside a provider-managed container with a persistent workspace volume, so the run survives the user's terminal session. Suggest it for long-running plans that would outlast a local session, multi-repo work, or when the user wants an isolated persistent sandbox. Sprint 1 ships the `railway` provider only; `ssh` and `local` are planned.
 
-Quick subcommand reference: `init`, `build`, `deploy`, `chain`, `status`, `attach`, `logs`, `exec`, `resume`, `down`, `destroy`. Typical flow: `megaplan cloud init` → edit `cloud.yaml` → export secrets → `megaplan cloud deploy` → `megaplan cloud chain <chain.yaml>`.
+Quick subcommand reference: `init`, `build`, `deploy`, `chain`, `status`, `attach`, `logs`, `exec`, `resume`, `down`, `destroy`. Typical flow: `<launcher> cloud init` → edit `cloud.yaml` → export secrets → `<launcher> cloud deploy` → `<launcher> cloud chain <chain.yaml>`.
 
 For the full reference — `cloud.yaml` fields, the `extra_repos[]` + `chain_session` multi-tenancy model, the operator loop, and the gotchas that wedge fresh runs (committed `chain_state.json`, profile-alias gap, secret-upload behavior, "internal_error" masking credit failures) — see the **megaplan-cloud** skill. Read it before launching the first cloud chain in a new project; the gotchas section will save hours.
 ## Tickets
-`megaplan ticket new` creates a repo-scoped issue ticket. Use it when:
+`<launcher> ticket new` creates a repo-scoped issue ticket. Use it when:
 - During epic/plan work you notice an out-of-scope problem, bug, or rough edge
 - A user explicitly asks you to capture something for later attention
 - You want to log an observation that doesn't block the current task but should be tracked
 
-The command prints only a ULID to stdout on success. Tickets live as `.megaplan/tickets/{ulid}-{slug}.md` files and are auto-discovered by the planner for future epics. Link them to epics with `megaplan ticket link <ticket> <epic> --resolves` so they auto-address when the epic completes.
+The command prints only a ULID to stdout on success. Tickets live as `.megaplan/tickets/{ulid}-{slug}.md` files and are auto-discovered by the planner for future epics. Link them to epics with `<launcher> ticket link <ticket> <epic> --resolves` so they auto-address when the epic completes.
 
 ## Briefs
-`megaplan brief` creates canonical source artifacts for work you intend to run.
+`<launcher> brief` creates canonical source artifacts for work you intend to run.
 Use it when:
 - You are turning an idea into a durable single-plan input
 - You are scaffolding an epic's `chain.yaml` and milestone idea files
-- You want the source document committed before `megaplan init` snapshots it into plan state
+- You want the source document committed before `<launcher> init` snapshots it into plan state
 
 Briefs live as committed files under `.megaplan/briefs/`. Single-plan ideas live
 at `.megaplan/briefs/{slug}.md`; epics live at
 `.megaplan/briefs/{epic-slug}/chain.yaml` with milestone briefs beside the chain
 spec. This is ticket-like in storage and ergonomics, but not in lifecycle:
-briefs feed `megaplan init` / `megaplan chain start`; tickets are open problem
+briefs feed `<launcher> init` / `<launcher> chain start`; tickets are open problem
 notes that can be discovered, linked, and auto-addressed by epics.
 
 Briefs and tickets share the local artifact substrate: common `.megaplan/<kind>/`
 path handling, slug normalization, optional frontmatter parsing, keyword
-filtering, and snippets. Use `megaplan brief list`, `megaplan brief show`, and
-`megaplan brief search` for the brief side of that common read surface.
+filtering, and snippets. Use `<launcher> brief list`, `<launcher> brief show`, and
+`<launcher> brief search` for the brief side of that common read surface.
 
-`megaplan init --idea-file <path>` reads the file and snapshots its text; it does
+`<launcher> init --idea-file <path>` reads the file and snapshots its text; it does
 not move arbitrary files into `.megaplan/briefs/`. If the idea file is a markdown
 artifact with YAML frontmatter, `init` snapshots only the markdown body. Use
-`megaplan brief new --init` to create the canonical source file first and then
+`<launcher> brief new --init` to create the canonical source file first and then
 initialize from it.
 
 ## Feedback
 See **megaplan-prep** for when to add the feedback phase (`--with-feedback`). This section covers the CLI mechanics once you've decided to use it.
 
-`megaplan feedback --plan <name>` scaffolds a `feedback.md` file in the plan directory and opens it in `$EDITOR` (or `$VISUAL`). The file has one section per workflow stage — `prep`, `plan`, `critique`, `revise`, `gate`, `tiebreaker`, `finalize`, `execute`, `review` — plus an `Overall` section. Each section has a `rating:` (integer 0–10) and a free-form `comment:` field; leave any field blank to skip it.
+`<launcher> feedback --plan <name>` scaffolds a `feedback.md` file in the plan directory and opens it in `$EDITOR` (or `$VISUAL`). The file has one section per workflow stage — `prep`, `plan`, `critique`, `revise`, `gate`, `tiebreaker`, `finalize`, `execute`, `review` — plus an `Overall` section. Each section has a `rating:` (integer 0–10) and a free-form `comment:` field; leave any field blank to skip it.
 
-This is **user feedback**, owned by the human after a run finishes — megaplan only scaffolds the template and parses it back on load, it never overwrites edits. Old plans without a `feedback.md` simply have no feedback attached; running `megaplan feedback --plan <name>` on an older plan scaffolds the template on demand (backwards compatible).
+This is **user feedback**, owned by the human after a run finishes — megaplan only scaffolds the template and parses it back on load, it never overwrites edits. Old plans without a `feedback.md` simply have no feedback attached; running `<launcher> feedback --plan <name>` on an older plan scaffolds the template on demand (backwards compatible).
 
-Use `megaplan feedback show --plan <name>` to print the parsed summary, and `--no-edit` to just scaffold the template and print the path without launching an editor. Parsed feedback is exposed on the in-memory `Plan` record as `Plan.feedback` (a dict shaped `{"overall": {...}, "stages": {stage: {...}}}`), so downstream tooling can read it the same way as any other artifact. When `--actor`/`MEGAPLAN_ACTOR_ID` is set, parsed feedback is also written to the `plans.feedback` jsonb column so the DB and file backends stay in sync.
+Use `<launcher> feedback show --plan <name>` to print the parsed summary, and `--no-edit` to just scaffold the template and print the path without launching an editor. Parsed feedback is exposed on the in-memory `Plan` record as `Plan.feedback` (a dict shaped `{"overall": {...}, "stages": {stage: {...}}}`), so downstream tooling can read it the same way as any other artifact. When `--actor`/`MEGAPLAN_ACTOR_ID` is set, parsed feedback is also written to the `plans.feedback` jsonb column so the DB and file backends stay in sync.
 
 ### Filling feedback with subagents
 Recommended process when an agent (rather than the human) is producing the initial assessment:
 
-1. **Scaffold**: run `megaplan feedback --plan <name> --no-edit` to create the empty `feedback.md`. Note the plan directory it prints — that is where the per-stage artifacts live (`plan_v*.md`, `critique*.json`, `gate.json`, `tiebreaker_*.json`, `finalize.json`, `execution*.json`, `review.json`, etc.).
+1. **Scaffold**: run `<launcher> feedback --plan <name> --no-edit` to create the empty `feedback.md`. Note the plan directory it prints — that is where the per-stage artifacts live (`plan_v*.md`, `critique*.json`, `gate.json`, `tiebreaker_*.json`, `finalize.json`, `execution*.json`, `review.json`, etc.).
 2. **Per-stage assessment**: dispatch one read-only subagent per stage that actually ran (skip stages with no artifacts). Brief each subagent narrowly — give it the plan idea, the stage name, and the artifact filenames for that stage only. Ask it to return a 0–10 rating plus a 1–3 sentence comment grounded in what the artifacts show (what worked, what was weak, what was missed). Run these in parallel; they have no dependencies on each other.
 3. **Synthesize Overall**: after the per-stage results come back, *you* (the orchestrating agent, not a subagent) read the per-stage ratings and comments together with the final outcome (`final.md`, `review.json`, any `latest_failure`) and decide an Overall rating and comment. The Overall is a judgment call about whether the run delivered the goal, not an average of stage ratings.
-4. **Write**: edit `feedback.md` with the ratings and comments. Leave a stage blank if it didn't run or you can't form a defensible opinion — empty is better than guessed. Run `megaplan feedback show --plan <name>` to confirm the parser picked everything up.
+4. **Write**: edit `feedback.md` with the ratings and comments. Leave a stage blank if it didn't run or you can't form a defensible opinion — empty is better than guessed. Run `<launcher> feedback show --plan <name>` to confirm the parser picked everything up.
 
 Keep comments grounded in specific artifact evidence ("critique flagged X but reviewer didn't catch the regression in Y") rather than vibes. The point of feedback is signal for future runs, not a participation score.
 
 ### Searching feedback across plans
-`megaplan feedback search` queries every plan with non-empty feedback across both backends — local `feedback.md` files in this project tree plus, when an actor is configured, the `plans.feedback` jsonb column in the DB. Duplicates between backends are de-duped by (plan name, project_dir). Use this to answer "which profile actually scored well on this repo?" or "where did the executor get a 6 or below?". Filters:
+`<launcher> feedback search` queries every plan with non-empty feedback across both backends — local `feedback.md` files in this project tree plus, when an actor is configured, the `plans.feedback` jsonb column in the DB. Duplicates between backends are de-duped by (plan name, project_dir). Use this to answer "which profile actually scored well on this repo?" or "where did the executor get a 6 or below?". Filters:
 - `--profile <substr>` — substring match on the plan's profile (e.g. `--profile claude` matches `all-claude`, `claude-led`, etc.).
 - `--repo <substr>` — substring match on the plan's `project_dir` / repo path.
 - `--min-rating N` / `--max-rating N` — bounds on the Overall rating.
@@ -248,70 +248,70 @@ Keep comments grounded in specific artifact evidence ("critique flagged X but re
 - `--all` — scan every megaplan project root on this machine, not just the current tree.
 - `--json` — emit raw rows instead of a table.
 
-Default output is a compact table (plan, profile, overall rating, backend, repo, plus the first line of the Overall comment). Combine with `megaplan feedback show --plan <name>` to drill into a specific match.
+Default output is a compact table (plan, profile, overall rating, backend, repo, plus the first line of the Overall comment). Combine with `<launcher> feedback show --plan <name>` to drill into a specific match.
 ## Observability
 Plans started after this layer landed write an append-only `events.ndjson` event journal to their plan dir. Four CLI surfaces read from it; reach for them whenever a run is in flight or you need to reconstruct what happened. See the **megaplan-observe** skill for the full failure-mode catalog and worked invocation chains.
 
-- `megaplan introspect --plan <name>` — single structured-JSON snapshot. Always check this first when something looks stuck; the `active_phase.liveness` enum (`progressing | quiet | stalled | timeout-imminent`) and `block_details.recoverable_via` together tell you whether to wait, intervene, or override. Also surfaces `outstanding_flags_count`, useful when a plan is sitting on unresolved critique signals.
-- `megaplan trace --plan <name> [--follow] [--format json|pretty|narrative] [--phase <p>] [--since <duration>]` — stream events. `narrative` format is the agent-facing affordance; `--follow` tails as the plan progresses; `--phase` and `--since` filter. Prints `trace: no events.ndjson for plan <name>` cleanly when a plan predates the journal.
-- `megaplan doctor [--plan <name> | --repo]` — diagnostic. `--repo` catches rubric/binary drift (skill profile names vs `profiles list`) and editable-install dirtiness *before* `megaplan init`, so reach for it after a branch switch / pull / fresh checkout. `--plan` reports lock, phase liveness, LLM liveness, cost-vs-cap, orphan subprocesses, and outstanding flags.
-- `megaplan record-tag --plan <name> --tag <name> --note "..."` — annotate a moment in the journal so later trace/introspect calls can find it. All three args are required.
+- `<launcher> introspect --plan <name>` — single structured-JSON snapshot. Always check this first when something looks stuck; the `active_phase.liveness` enum (`progressing | quiet | stalled | timeout-imminent`) and `block_details.recoverable_via` together tell you whether to wait, intervene, or override. Also surfaces `outstanding_flags_count`, useful when a plan is sitting on unresolved critique signals.
+- `<launcher> trace --plan <name> [--follow] [--format json|pretty|narrative] [--phase <p>] [--since <duration>]` — stream events. `narrative` format is the agent-facing affordance; `--follow` tails as the plan progresses; `--phase` and `--since` filter. Prints `trace: no events.ndjson for plan <name>` cleanly when a plan predates the journal.
+- `<launcher> doctor [--plan <name> | --repo]` — diagnostic. `--repo` catches rubric/binary drift (skill profile names vs `profiles list`) and editable-install dirtiness *before* `<launcher> init`, so reach for it after a branch switch / pull / fresh checkout. `--plan` reports lock, phase liveness, LLM liveness, cost-vs-cap, orphan subprocesses, and outstanding flags.
+- `<launcher> record-tag --plan <name> --tag <name> --note "..."` — annotate a moment in the journal so later trace/introspect calls can find it. All three args are required.
 
 Stale-timestamp inference, opaque blocked state, and "model thinking vs TCP wedged" are the three confusions this layer is designed to kill — if you find yourself running `lsof`, `ps`, or doing manual `ls -lat` time math on a plan dir, you should be running `introspect` or `trace` instead.
 ## Commands
 ```bash
-arnold status --plan <name>
-megaplan progress --plan <name>
-megaplan audit --plan <name>
-megaplan list
-megaplan prep --plan <name>
-megaplan plan --plan <name>
-megaplan critique --plan <name>
-megaplan revise --plan <name>
-megaplan gate --plan <name>
-megaplan finalize --plan <name>
-arnold execute --plan <name> --confirm-destructive [--batch N]
-arnold review --plan <name>
-megaplan step add --plan <name> [--after S<N>] "description"
-megaplan step remove --plan <name> S<N>
-megaplan step move --plan <name> S<N> --after S<M>
-megaplan override add-note --plan <name> --note "..."
-megaplan override force-proceed --plan <name> --reason "..."
-megaplan override replan --plan <name> --reason "..." [--note "..."]
-megaplan override abort --plan <name> --reason "..."
-arnold config show
-arnold config set <key> <value>
-arnold config reset
-arnold config profiles list
-arnold config profiles show <name>
-megaplan bakeoff run --idea-file <path> --profiles <p1> <p2> [--mode code|doc|metaplan] [--output <relative/path>] [--exp-id <id>] [--detach] [--robustness <level>] [--allow-dirty]
-megaplan bakeoff status [--exp <id>]
-megaplan bakeoff tail [--exp <id>]
-megaplan bakeoff compare --exp <id> [--judge <model>]
-megaplan bakeoff pick --exp <id> --profile <name> --rationale "..."
-megaplan bakeoff merge --exp <id>
-megaplan bakeoff resume --exp <id>
-megaplan bakeoff abandon --exp <id>
-megaplan brief new <slug> [-b <body> | --from <path> | -] [--force] [--init]
-megaplan brief epic <slug> --milestone LABEL=TITLE [--base-branch <branch>] [--force]
-megaplan brief list [--json]
-megaplan brief show <id-or-path> [--json]
-megaplan brief search [KW ...] [--all] [--sort path|title|length] [--desc] [--limit N] [--json]
-megaplan ticket new "title" -b "body"
-megaplan ticket list [--status <s>] [--tags <t>] [--json]
-megaplan ticket show <id> [--json]
-megaplan ticket edit <id> [--title <t>] [--body <b>] [--status <s>]
-megaplan ticket link <ticket> <epic> [--resolves]
-megaplan ticket unlink <ticket> <epic>
-megaplan ticket addressed <id> [--note <n>]
-megaplan ticket dismiss <id> --reason "..."
-megaplan ticket reopen <id>
-megaplan feedback show --plan <name> [--no-edit]
-megaplan feedback search [--profile <s>] [--repo <s>] [--min-rating N] [--max-rating N] [--stage <name>] [--has-comment] [--all] [--json]
-megaplan introspect --plan <name> [--json]
-megaplan trace --plan <name> [--follow] [--format json|pretty|narrative] [--phase <p>] [--since <duration>]
-megaplan doctor [--plan <name> | --repo]
-megaplan record-tag --plan <name> --tag <name> --note "..."
+<launcher> status --plan <name>
+<launcher> progress --plan <name>
+<launcher> audit --plan <name>
+<launcher> list
+<launcher> prep --plan <name>
+<launcher> plan --plan <name>
+<launcher> critique --plan <name>
+<launcher> revise --plan <name>
+<launcher> gate --plan <name>
+<launcher> finalize --plan <name>
+<launcher> execute --plan <name> --confirm-destructive [--batch N]
+<launcher> review --plan <name>
+<launcher> step add --plan <name> [--after S<N>] "description"
+<launcher> step remove --plan <name> S<N>
+<launcher> step move --plan <name> S<N> --after S<M>
+<launcher> override add-note --plan <name> --note "..."
+<launcher> override force-proceed --plan <name> --reason "..."
+<launcher> override replan --plan <name> --reason "..." [--note "..."]
+<launcher> override abort --plan <name> --reason "..."
+<launcher> config show
+<launcher> config set <key> <value>
+<launcher> config reset
+<launcher> config profiles list
+<launcher> config profiles show <name>
+<launcher> bakeoff run --idea-file <path> --profiles <p1> <p2> [--mode code|doc|metaplan] [--output <relative/path>] [--exp-id <id>] [--detach] [--robustness <level>] [--allow-dirty]
+<launcher> bakeoff status [--exp <id>]
+<launcher> bakeoff tail [--exp <id>]
+<launcher> bakeoff compare --exp <id> [--judge <model>]
+<launcher> bakeoff pick --exp <id> --profile <name> --rationale "..."
+<launcher> bakeoff merge --exp <id>
+<launcher> bakeoff resume --exp <id>
+<launcher> bakeoff abandon --exp <id>
+<launcher> brief new <slug> [-b <body> | --from <path> | -] [--force] [--init]
+<launcher> brief epic <slug> --milestone LABEL=TITLE [--base-branch <branch>] [--force]
+<launcher> brief list [--json]
+<launcher> brief show <id-or-path> [--json]
+<launcher> brief search [KW ...] [--all] [--sort path|title|length] [--desc] [--limit N] [--json]
+<launcher> ticket new "title" -b "body"
+<launcher> ticket list [--status <s>] [--tags <t>] [--json]
+<launcher> ticket show <id> [--json]
+<launcher> ticket edit <id> [--title <t>] [--body <b>] [--status <s>]
+<launcher> ticket link <ticket> <epic> [--resolves]
+<launcher> ticket unlink <ticket> <epic>
+<launcher> ticket addressed <id> [--note <n>]
+<launcher> ticket dismiss <id> --reason "..."
+<launcher> ticket reopen <id>
+<launcher> feedback show --plan <name> [--no-edit]
+<launcher> feedback search [--profile <s>] [--repo <s>] [--min-rating N] [--max-rating N] [--stage <name>] [--has-comment] [--all] [--json]
+<launcher> introspect --plan <name> [--json]
+<launcher> trace --plan <name> [--follow] [--format json|pretty|narrative] [--phase <p>] [--since <duration>]
+<launcher> doctor [--plan <name> | --repo]
+<launcher> record-tag --plan <name> --tag <name> --note "..."
 ```
 
 
@@ -320,7 +320,7 @@ megaplan record-tag --plan <name> --tag <name> --note "..."
 This appendix is Claude-specific. It adds a subagent path; subagent mode is the default for Claude.
 
 ### Activation
-- Default to subagent unless an inline override is explicitly set for this run or `megaplan config show` reports `"orchestration": {"mode": "inline"}`.
+- Default to subagent unless an inline override is explicitly set for this run or `<launcher> config show` reports `"orchestration": {"mode": "inline"}`.
 - Per-run override wins over config. If the run explicitly says `inline`, stay inline even when config prefers `subagent`.
 - Use subagent mode for long multi-phase runs where keeping the outer conversation clean matters, especially auto-approve runs.
 - Prefer inline mode for small edits, quick clarifications, or any run where the user wants to watch each phase in the main thread.
@@ -332,14 +332,14 @@ When subagent mode is active, the outer skill becomes a launcher plus breakpoint
 - `run_in_background: true` when `{AUTO_APPROVE}` is true; otherwise foreground is fine
 - Expand `{AUTO_APPROVE_FLAG}` to an empty string when `raw_config.execution.auto_approve` is explicitly set; otherwise expand it to `--auto-approve` for auto-approve runs and an empty string for review runs.
 - Expand `{ROBUSTNESS_FLAG}` to an empty string when `raw_config.execution.robustness` is explicitly set; otherwise expand it to `--robustness {ROBUSTNESS}`.
-- For doc-mode runs, also append `--mode doc --output <relative/path>` to the `megaplan init` call in the subagent's Startup step. Everything else in the template applies unchanged; the workflow phases and breakpoints are identical in doc mode.
-- After editing this source file, rerun `megaplan setup --force` so installed `SKILL.md` files pick up the refreshed appendix.
+- For doc-mode runs, also append `--mode doc --output <relative/path>` to the `<launcher> init` call in the subagent's Startup step. Everything else in the template applies unchanged; the workflow phases and breakpoints are identical in doc mode.
+- After editing this source file, rerun `<launcher> setup --force` so installed `SKILL.md` files pick up the refreshed appendix.
 
 ### Outer Skill Handling
 - Decide inline vs subagent before starting the workflow.
 - In subagent mode, launch the agent, wait for either `BREAKPOINT:` or `COMPLETE:`, and keep the main thread thin.
-- Support inject-after by letting the background subagent continue while the user runs `megaplan override add-note`; the next phase boundary picks it up from `megaplan status`.
-- Support kill-and-inject by stopping the running subagent, appending a note with `megaplan override add-note`, and relaunching a new subagent on the same plan.
+- Support inject-after by letting the background subagent continue while the user runs `<launcher> override add-note`; the next phase boundary picks it up from `<launcher> status`.
+- Support kill-and-inject by stopping the running subagent, appending a note with `<launcher> override add-note`, and relaunching a new subagent on the same plan.
 - When a breakpoint arrives, relay the summary to the user, collect the answer, and resume the same agent with `SendMessage` when possible.
 - Parse only the explicit breakpoint header, not incidental text, when deciding whether the agent stopped intentionally.
 - When completion arrives, report the final result back to the user without replaying every internal phase.
@@ -358,7 +358,7 @@ Your job is to drive the megaplan workflow through the CLI until the run finishe
 
 Always follow these priorities, in order:
 1. The latest user direction relayed through notes or resume messages.
-2. The live CLI state from `megaplan status --plan <name>`.
+2. The live CLI state from `<launcher> status --plan <name>`.
 3. The workflow and breakpoint rules in this template.
 4. Your own memory of earlier turns.
 
@@ -377,12 +377,13 @@ Never do these things:
 
 ## 2. Startup
 Start the run like this:
-1. Use empty-string expansion for `{AUTO_APPROVE_FLAG}` and `{ROBUSTNESS_FLAG}` whenever the corresponding `raw_config.execution` key is explicitly set.
-2. Run `megaplan init --project-dir "{PROJECT_DIR}" {AUTO_APPROVE_FLAG} {ROBUSTNESS_FLAG} "{IDEA}"`.
-3. Capture the returned plan name.
-4. Output `PLAN_NAME: <name>` on its own line immediately after init and before any `BREAKPOINT:` or `COMPLETE:`.
-5. Run `megaplan status --plan <name>`.
-6. From then on, use that plan name for every command.
+1. Resolve and verify a working `<launcher>` with a harmless config call. Prefer `python -m arnold.pipelines.megaplan config show`; do not use the removed `megaplan` module or console entrypoint.
+2. Use empty-string expansion for `{AUTO_APPROVE_FLAG}` and `{ROBUSTNESS_FLAG}` whenever the corresponding `raw_config.execution` key is explicitly set.
+3. Run `<launcher> init --project-dir "{PROJECT_DIR}" {AUTO_APPROVE_FLAG} {ROBUSTNESS_FLAG} "{IDEA}"`.
+4. Capture the returned plan name.
+5. Output `PLAN_NAME: <name>` on its own line immediately after init and before any `BREAKPOINT:` or `COMPLETE:`.
+6. Run `<launcher> status --plan <name>`.
+7. From then on, use that plan name and the same `<launcher>` for every command.
 
 At startup and after every later resume:
 - Read `state`, `next_step`, and `valid_next`.
@@ -427,10 +428,10 @@ Extreme robustness (legacy name: superrobust):
 Gate decision tree for full, thorough, and extreme:
 - Condition 1: `gate_unset`
   Trigger: state is `critiqued` and `valid_next` includes `gate`.
-  Action: run `megaplan gate --plan <name>`.
+  Action: run `<launcher> gate --plan <name>`.
 - Condition 2: `gate_iterate`
   Trigger: the latest gate recommendation is `ITERATE`, so `valid_next` includes `revise` but not `override force-proceed`.
-  Action: run `megaplan revise --plan <name>`, then continue back through `critique` and `gate`.
+  Action: run `<launcher> revise --plan <name>`, then continue back through `critique` and `gate`.
 - Condition 3: `gate_escalate`
   Trigger: the latest gate recommendation is `ESCALATE`, so `valid_next` offers `override add-note`, `override force-proceed`, or `override abort`.
   Action: stop with `BREAKPOINT: GATE_ESCALATE`.
@@ -439,7 +440,7 @@ Gate decision tree for full, thorough, and extreme:
   Action: do not finalize yet. Use `orchestrator_guidance` plus `preflight_results` to fix the blocking checks through `revise`. On iteration 1, the guidance text may stay generic, so inspect `preflight_results` yourself before revising. If the blocker cannot be resolved safely without a user decision, stop with `BREAKPOINT: GATE_BLOCKED`.
 - Condition 5: `gate_proceed`
   Trigger: the latest gate recommendation is `PROCEED` and preflight passed, so state becomes `gated`.
-  Action: run `megaplan finalize --plan <name>`.
+  Action: run `<launcher> finalize --plan <name>`.
 
 Review routing for full, thorough, and extreme:
 - If `review` succeeds, the run is done.
@@ -449,7 +450,7 @@ Review routing for full, thorough, and extreme:
 
 ## 4. After Every Phase
 After every phase command, immediately run:
-`megaplan status --plan <name>`
+`<launcher> status --plan <name>`
 
 Then do all of the following before choosing the next command:
 - Re-read `state`, `next_step`, and `valid_next`.
@@ -460,7 +461,7 @@ Then do all of the following before choosing the next command:
   `Plan passed gate and preflight. Proceed to finalize.`
   `Gate says PROCEED but preflight blocked. Fix: <checks>.`
   `Gate escalated. Ask the user: force-proceed, add-note, or abort.`
-  `Score plateaued with recurring critiques the loop can't fix. Consider force-proceeding: \`megaplan override force-proceed --plan <name>\``
+  `Score plateaued with recurring critiques the loop can't fix. Consider force-proceeding: \`<launcher> override force-proceed --plan <name>\``
   `Score improving (<previous> -> <current>). Continue to revise.`
   `Score worsening (<previous> -> <current>). Investigate; the loop may be diverging.`
   `Gate recommends another iteration. Revise the plan.`
@@ -510,13 +511,13 @@ Review safeguards:
 
 Notes and interruption safeguards:
 - If the outer skill kills and relaunches you, start fresh with no reliable memory from the prior run.
-- After any note injection or relaunch, run `megaplan status --plan <name>` immediately, read the full `notes` array, and treat all notes as context.
+- After any note injection or relaunch, run `<launcher> status --plan <name>` immediately, read the full `notes` array, and treat all notes as context.
 - Treat the most recent note as the relaunch explanation, then resume from `next_step`; the CLI state machine is the source of truth.
 
 ## 7. Resume Protocol
 When the outer conversation resumes you with `SendMessage`, or when a new subagent is launched on an existing plan:
 1. Re-read the message carefully.
-2. Run `megaplan status --plan <name>`.
+2. Run `<launcher> status --plan <name>`.
 3. Read the full `notes` array.
 4. Resume from the current CLI state and `next_step`, not from memory.
 
@@ -527,22 +528,22 @@ Resume rules:
 - After resuming, continue autonomously until the next defined breakpoint or completion.
 
 ## 7A. Note Injection from Outer Skill
-- Use the stored `PLAN_NAME` for note and status calls. If it was not captured, run `megaplan list` and fall back to the most recent plan.
+- Use the stored `PLAN_NAME` for note and status calls. If it was not captured, run `<launcher> list` and fall back to the most recent plan.
 - Classify the user message: "add context for next phase" -> Option A, "change direction NOW" -> Option B, "just a question" -> answer without touching the run. Default to Option A unless the message clearly demands interruption.
-- Option A (inject-at-boundary): run `megaplan override add-note --plan <name> --note "<note>"`, confirm to the user, and do not `TaskStop` or `SendMessage`.
-- Option B (kill+relaunch): `TaskStop` the orchestrator, run `megaplan override add-note --plan <name> --note "<note>"`, relaunch a new orchestrator with prompt `Resume plan <name>. Run megaplan status to get current state, read all notes, and continue from where it left off.`, then confirm to the user.
+- Option A (inject-at-boundary): run `<launcher> override add-note --plan <name> --note "<note>"`, confirm to the user, and do not `TaskStop` or `SendMessage`.
+- Option B (kill+relaunch): `TaskStop` the orchestrator, run `<launcher> override add-note --plan <name> --note "<note>"`, relaunch a new orchestrator with prompt `Resume plan <name>. Run <launcher> status to get current state, read all notes, and continue from where it left off.`, then confirm to the user.
 - Latency: Option A can take up to one phase boundary; if that is not acceptable, the user should ask for Option B.
 
 ## 8. Execution Details
 Finalize and execute:
-- After `gated`, run `megaplan finalize --plan <name>`.
-- In auto-approve mode, run `megaplan execute --plan <name> --confirm-destructive`.
-- In review mode, stop with `BREAKPOINT: EXECUTE_APPROVAL`, then after approval run `megaplan execute --plan <name> --confirm-destructive --user-approved`.
+- After `gated`, run `<launcher> finalize --plan <name>`.
+- In auto-approve mode, run `<launcher> execute --plan <name> --confirm-destructive`.
+- In review mode, stop with `BREAKPOINT: EXECUTE_APPROVAL`, then after approval run `<launcher> execute --plan <name> --confirm-destructive --user-approved`.
 
 Per-batch execution:
 - If the execution briefing or CLI response indicates per-batch execution, continue batch by batch.
 - Batch numbering is global and 1-indexed.
-- Use `megaplan progress --plan <name>` between batch executions.
+- Use `<launcher> progress --plan <name>` between batch executions.
 - Re-run the same batch number after a timeout if needed; the harness will reconcile previously completed work.
 
 Execution loop end conditions:
@@ -551,18 +552,18 @@ Execution loop end conditions:
 
 ## 9. Overrides & Plan Editing
 Override rules:
-- `megaplan override add-note` is safe from any active state when you need to record new user direction without changing state.
-- `megaplan override force-proceed` from `critiqued` moves the run into `gated`. Use it only when the user clearly wants to override the gate.
-- `megaplan override force-proceed` cannot bypass a missing project directory or missing success criteria.
-- `megaplan override force-proceed` from `executed` moves the run to `done`. Use that only when the user explicitly accepts unresolved review issues.
-- `megaplan override abort` ends the run. Use it only when the user clearly wants to stop.
-- `megaplan override replan` is available from `critiqued`, `gated`, or `finalized`. Use it when the orchestrator itself needs to edit the plan directly instead of asking the revise worker to do it.
+- `<launcher> override add-note` is safe from any active state when you need to record new user direction without changing state.
+- `<launcher> override force-proceed` from `critiqued` moves the run into `gated`. Use it only when the user clearly wants to override the gate.
+- `<launcher> override force-proceed` cannot bypass a missing project directory or missing success criteria.
+- `<launcher> override force-proceed` from `executed` moves the run to `done`. Use that only when the user explicitly accepts unresolved review issues.
+- `<launcher> override abort` ends the run. Use it only when the user clearly wants to stop.
+- `<launcher> override replan` is available from `critiqued`, `gated`, or `finalized`. Use it when the orchestrator itself needs to edit the plan directly instead of asking the revise worker to do it.
 
 Replan behavior:
 - After `override replan`, read the latest plan file, edit it directly, then continue with `critique`.
 
 Step editing:
-- `megaplan step add`, `step remove`, and `step move` are available while the run is in `planned`, `critiqued`, `gated`, or `finalized`.
+- `<launcher> step add`, `step remove`, and `step move` are available while the run is in `planned`, `critiqued`, `gated`, or `finalized`.
 - Use them when you need to insert, remove, or reorder step sections without hand-editing the markdown.
 - After a step edit, re-check `status` and continue from the returned state.
 
@@ -578,28 +579,28 @@ When the workflow completes, return exactly this shape:
 
 ## 11. Command Reference
 Core commands:
-- `megaplan status --plan <name>`
-- `megaplan progress --plan <name>`
-- `megaplan audit --plan <name>`
+- `<launcher> status --plan <name>`
+- `<launcher> progress --plan <name>`
+- `<launcher> audit --plan <name>`
 
 Workflow commands:
-- `megaplan prep --plan <name>`
-- `megaplan plan --plan <name>`
-- `megaplan critique --plan <name>`
-- `megaplan gate --plan <name>`
-- `megaplan revise --plan <name>`
-- `megaplan finalize --plan <name>`
-- `megaplan execute --plan <name> --confirm-destructive`
-- `megaplan execute --plan <name> --confirm-destructive --user-approved`
-- `megaplan execute --plan <name> --confirm-destructive --user-approved --batch N`
-- `megaplan review --plan <name>`
+- `<launcher> prep --plan <name>`
+- `<launcher> plan --plan <name>`
+- `<launcher> critique --plan <name>`
+- `<launcher> gate --plan <name>`
+- `<launcher> revise --plan <name>`
+- `<launcher> finalize --plan <name>`
+- `<launcher> execute --plan <name> --confirm-destructive`
+- `<launcher> execute --plan <name> --confirm-destructive --user-approved`
+- `<launcher> execute --plan <name> --confirm-destructive --user-approved --batch N`
+- `<launcher> review --plan <name>`
 
 Override and editing commands:
-- `megaplan override add-note --plan <name> --note "..."`
-- `megaplan override force-proceed --plan <name> --reason "..."`
-- `megaplan override replan --plan <name> --reason "..." [--note "..."]`
-- `megaplan override abort --plan <name> --reason "..."`
-- `megaplan step add --plan <name> --after S<N> "description"`
-- `megaplan step remove --plan <name> S<N>`
-- `megaplan step move --plan <name> S<N> --after S<M>`
+- `<launcher> override add-note --plan <name> --note "..."`
+- `<launcher> override force-proceed --plan <name> --reason "..."`
+- `<launcher> override replan --plan <name> --reason "..." [--note "..."]`
+- `<launcher> override abort --plan <name> --reason "..."`
+- `<launcher> step add --plan <name> --after S<N> "description"`
+- `<launcher> step remove --plan <name> S<N>`
+- `<launcher> step move --plan <name> S<N> --after S<M>`
 ```

--- a/arnold/pipelines/megaplan/data/_composed/codex_skill.md
+++ b/arnold/pipelines/megaplan/data/_composed/codex_skill.md
@@ -5,20 +5,20 @@ description: AI agent harness for coordinating Claude and GPT to make and execut
 
 # Megaplan
 
-> **Before you invoke megaplan, run the `megaplan-prep` skill.** It's the front door for every run: it sizes the work (one plan vs. an epic), shapes the brief, and picks the profile (intelligence tier), robustness level, and thinking depth. Do not run `megaplan init` without it.
+> **Before you invoke megaplan, run the `megaplan-prep` skill.** It's the front door for every run: it sizes the work (one plan vs. an epic), shapes the brief, and picks the profile (intelligence tier), robustness level, and thinking depth. Do not run `<launcher> init` without it.
 
 **Scope:** This skill covers tooling — how to invoke and drive megaplan. For the decisions that come *before* invocation (scoping, brief, profile, robustness, depth), consult the **megaplan-prep** skill. If anything here contradicts megaplan-prep on decision-making content, megaplan-prep wins.
 
-Route every step through the `megaplan` CLI. Never call agents directly.
-Before the first CLI call, resolve a working launcher and reuse it for the whole run. Do not assume `megaplan` itself is on `PATH`; command presence alone is not enough. Prove the launcher works by successfully running a harmless CLI call with it first. In the instructions below, treat `<launcher>` as that verified command.
+Route every step through the Arnold CLI's Megaplan subcommands. Never call agents directly.
+Before the first CLI call, resolve a working launcher and reuse it for the whole run. Do not assume the removed `megaplan` entrypoint is on `PATH`; command presence alone is not enough. Prove the launcher works by successfully running a harmless CLI call with it first. In the instructions below, treat `<launcher>` as that verified command.
 Launcher resolution order:
 1. Try `python -m arnold.pipelines.megaplan config show`.
 2. If that fails, try `./.venv/bin/python -m arnold.pipelines.megaplan config show`.
 3. If that fails, try `uv run python -m arnold.pipelines.megaplan config show`.
-4. If that fails, try a version-selected shim such as `PYENV_VERSION=3.11.11 arnold config show`.
-5. Only use bare `megaplan ...` if that exact form already succeeded during this check.
+4. If those fail, stop and report that the Arnold Megaplan module launcher is unavailable.
+5. Do not use the removed `megaplan` module or console entrypoint; the repo-root `megaplan.py` file is a clean-break guard.
 ## Triage
-Decision-making (scoping, profile, robustness, depth, brief structure) lives in the **megaplan-prep** skill — consult it before running `megaplan init`. **Always run megaplan, even for tiny work** — `bare` robustness is the floor, never skip the harness. The few seconds of overhead pay back in the captured brief, plan, and outcome record.
+Decision-making (scoping, profile, robustness, depth, brief structure) lives in the **megaplan-prep** skill — consult it before running `<launcher> init`. **Always run megaplan, even for tiny work** — `bare` robustness is the floor, never skip the harness. The few seconds of overhead pay back in the captured brief, plan, and outcome record.
 ## Modes
 Megaplan has two output modes, picked with `--mode` at `init`:
 - **`--mode code`** (default): the run produces a code diff. Execute workers emit per-task file changes. Use for features, refactors, bug fixes, migrations — anything whose deliverable is source code.
@@ -90,27 +90,27 @@ At `--robustness extreme`, the loop is the same as thorough but also enables par
 - `review`: judge success against the success criteria and the user's intent, not plan elegance. Only block on `must` criteria failures. `should` failures are flagged but don't require rework. `info` criteria are waived.
 ## Gate Principle
 The gate response tells the orchestrator what to do next. Follow `orchestrator_guidance` unless you have a concrete reason to disagree after investigating the repository or plan artifacts yourself.
-Investigate before disagreeing: read the current plan and critique artifacts, check the project code to verify whether a flagged issue is real, or use `megaplan status --plan <name>` / `megaplan audit --plan <name>`.
+Investigate before disagreeing: read the current plan and critique artifacts, check the project code to verify whether a flagged issue is real, or use `<launcher> status --plan <name>` / `<launcher> audit --plan <name>`.
 If you disagree with the guidance, explain why briefly and use an override. Do not manually reinterpret score trajectory, flag quality, or loop state when the gate already did that work for you.
 ## Execute
-- After a successful gate, run `megaplan finalize` to produce the execution-ready briefing document.
-- In auto-approve mode, run `megaplan execute --confirm-destructive` after finalize.
+- After a successful gate, run `<launcher> finalize` to produce the execution-ready briefing document.
+- In auto-approve mode, run `<launcher> execute --confirm-destructive` after finalize.
 - In review mode, pause at the finalize-to-execute checkpoint and wait for explicit approval before running:
 ```bash
-arnold execute --confirm-destructive --user-approved
+<launcher> execute --confirm-destructive --user-approved
 ```
 ## Long-Running Execution
 For plans with multiple batches, use per-batch mode to drive execution incrementally:
 ```bash
-arnold execute --plan <name> --confirm-destructive --user-approved --batch 1
-arnold execute --plan <name> --confirm-destructive --user-approved --batch 2
+<launcher> execute --plan <name> --confirm-destructive --user-approved --batch 1
+<launcher> execute --plan <name> --confirm-destructive --user-approved --batch 2
 # ... continue until all batches complete
 ```
 Between batches, poll progress:
 ```bash
-megaplan progress --plan <name>
+<launcher> progress --plan <name>
 ```
-Use `megaplan status --plan <name>` for the full plan state, including active-step timing and any `next_step_runtime` guidance from the latest response.
+Use `<launcher> status --plan <name>` for the full plan state, including active-step timing and any `next_step_runtime` guidance from the latest response.
 Per-batch mode uses global batch numbering (1-indexed, computed from ALL tasks). Each `--batch N` call:
 - Validates that batches 1..N-1 are complete
 - Executes only batch N's tasks
@@ -119,23 +119,23 @@ Per-batch mode uses global batch numbering (1-indexed, computed from ALL tasks).
 Timeout recovery: re-run the same `--batch N`. The harness checks prerequisite completion and merges only untracked tasks.
 Note: `progress` shows completed state only (between-batch granularity). With per-batch mode, each batch is a separate CLI call, so the orchestrator has full visibility.
 ## Overrides
-- `megaplan override add-note --plan <name> --note "..."`
-- `megaplan override force-proceed --plan <name> --reason "..."`
-- `megaplan override replan --plan <name> --reason "..." [--note "..."]`
-- `megaplan override abort --plan <name> --reason "..."`
+- `<launcher> override add-note --plan <name> --note "..."`
+- `<launcher> override force-proceed --plan <name> --reason "..."`
+- `<launcher> override replan --plan <name> --reason "..." [--note "..."]`
+- `<launcher> override abort --plan <name> --reason "..."`
 `force-proceed` is available from `critiqued` (routes to finalize, not execute). `replan` is available from `gated`, `finalized`, or `critiqued`. `add-note` is safe from any active state.
 ## Replan
 Use `replan` when the orchestrator itself needs to edit the plan directly instead of asking the revise worker to do it.
 ```bash
-megaplan override replan --plan <name> --reason "expanding scope" --note "Also clean up the display layer"
+<launcher> override replan --plan <name> --reason "expanding scope" --note "Also clean up the display layer"
 ```
-After `replan`, read the returned plan file, edit it directly, then run `megaplan critique`.
+After `replan`, read the returned plan file, edit it directly, then run `<launcher> critique`.
 ## Step Editing
 Use `step` when you need to insert, remove, or reorder step sections (`## Step N:` or `### Step N:`) without hand-editing the markdown.
 ```bash
-megaplan step add --plan <name> --after S3 "Add regression coverage for the parser"
-megaplan step remove --plan <name> S4
-megaplan step move --plan <name> S4 --after S2
+<launcher> step add --plan <name> --after S3 "Add regression coverage for the parser"
+<launcher> step remove --plan <name> S4
+<launcher> step move --plan <name> S4 --after S2
 ```
 Each edit writes a new same-iteration plan artifact, preserves the latest plan meta questions/success criteria/assumptions, and resets the plan to `planned` so it re-enters critique.
 ## Sessions And Autonomy
@@ -146,14 +146,14 @@ Each edit writes a new same-iteration plan artifact, preserves the latest plan m
 - Keep moving and show results at each step.
 - Only pause at finalize to execute in review mode.
 ## Configuration
-View current defaults with `megaplan config show`. Override with `megaplan config set <key> <value>`. Reset with `megaplan config reset`.
-When routing or behavior depends on config, check `megaplan config show` and respect user overrides instead of assuming defaults.
+View current defaults with `<launcher> config show`. Override with `<launcher> config set <key> <value>`. Reset with `<launcher> config reset`.
+When routing or behavior depends on config, check `<launcher> config show` and respect user overrides instead of assuming defaults.
 Settable execution keys: `execution.auto_approve`, `execution.robustness`.
 ## Profiles
 A profile is a named preset that maps each workflow phase to an agent/model spec. Pass `--profile <name>` to any command that accepts `--phase-model` (`init`, `loop-init`, `tiebreaker`, etc.) to apply the preset.
-See **megaplan-prep** for profile selection. Inspect available profiles with `megaplan config profiles list`.
+See **megaplan-prep** for profile selection. Inspect available profiles with `<launcher> config profiles list`.
 Resolution order, later overrides earlier within the same name: built-in (`megaplan/profiles/*.toml`) → user (`~/.config/megaplan/profiles.toml`, or `$XDG_CONFIG_HOME/megaplan/profiles.toml`) → project (`<project_dir>/.megaplan/profiles.toml`).
-Inspect with `megaplan config profiles list` and `megaplan config profiles show <name>`.
+Inspect with `<launcher> config profiles list` and `<launcher> config profiles show <name>`.
 File format: TOML with a `[profiles.<name>]` table. Keys are phase names (`plan`, `prep`, `critique`, `revise`, `gate`, `finalize`, `execute`, `loop_plan`, `loop_execute`, `review`, `tiebreaker_researcher`, `tiebreaker_challenger`); values are agent specs like `"claude"`, `"codex"`, `"hermes:fireworks:accounts/fireworks/models/kimi-k2p6"`, `"hermes:glm-5.1"`. Example:
 ```toml
 [profiles.my-mix]
@@ -166,80 +166,80 @@ review   = "codex"
 ## Bakeoff
 See the **bakeoff** skill for methodology and the **megaplan-prep** skill for when bake-offs earn their cost. This section covers the CLI mechanics once you've decided to run one.
 
-`megaplan bakeoff run` runs the same idea through multiple profiles concurrently, each in its own git worktree, each driven autonomously by `megaplan auto`. Use it when the user wants to compare profiles head-to-head on the same task (e.g., "run this with kimi and the default profile side-by-side").
-Supports `--mode code` (default) and `--mode doc` / `--mode metaplan` (alias). For doc-mode bake-offs, `--output <relative/path>` is required and is threaded into each profile's `megaplan init`; merge brings the chosen profile's doc artifact back to main instead of applying a code patch. Joke mode is not yet supported.
+`<launcher> bakeoff run` runs the same idea through multiple profiles concurrently, each in its own git worktree, each driven autonomously by `<launcher> auto`. Use it when the user wants to compare profiles head-to-head on the same task (e.g., "run this with kimi and the default profile side-by-side").
+Supports `--mode code` (default) and `--mode doc` / `--mode metaplan` (alias). For doc-mode bake-offs, `--output <relative/path>` is required and is threaded into each profile's `<launcher> init`; merge brings the chosen profile's doc artifact back to main instead of applying a code patch. Joke mode is not yet supported.
 Requires a clean main worktree by default — pass `--allow-dirty` when there are unrelated uncommitted changes you want to keep on main. Those changes stay on main and are NOT copied into the worktrees, since worktrees branch off the current commit's SHA.
 The idea must be a file (`--idea-file <path>`), not an inline string. Write the idea to a file first.
-Bakeoff is inherently autonomous (it spawns `megaplan auto`), so the execution-mode question doesn't apply to bakeoff runs. `--robustness` is forwarded to each profile's `init`. When a project-layer `.megaplan/profiles.toml` exists, it's automatically copied into each worktree so project-only profiles resolve.
+Bakeoff is inherently autonomous (it spawns `<launcher> auto`), so the execution-mode question doesn't apply to bakeoff runs. `--robustness` is forwarded to each profile's `init`. When a project-layer `.megaplan/profiles.toml` exists, it's automatically copied into each worktree so project-only profiles resolve.
 Lifecycle:
-- `megaplan bakeoff run --idea-file <path> --profiles <p1> <p2> [--mode code|doc|metaplan] [--output <relative/path>] [--exp-id <id>] [--detach] [--robustness <level>] [--allow-dirty]` — kicks off N concurrent profile runs. Without `--detach` it streams a live status table every 5s and blocks until all profiles finish; with `--detach` it returns immediately and the user polls via `status`. `--output` is required with `--mode doc|metaplan` and rejected with `--mode code`.
-- `megaplan bakeoff status [--exp <id>]` — current state of each profile (running / completed / crashed).
-- `megaplan bakeoff tail [--exp <id>]` — tail the per-profile auto logs.
-- `megaplan bakeoff compare --exp <id> [--judge <model>]` — collect metrics across profiles; with `--judge`, an LLM judge ranks the outputs.
-- `megaplan bakeoff pick --exp <id> --profile <name> --rationale "..."` — record the human-selected winner.
-- `megaplan bakeoff merge --exp <id>` — merge the chosen profile's worktree back to main.
-- `megaplan bakeoff resume --exp <id>` — resume unfinished profile runs.
-- `megaplan bakeoff abandon --exp <id>` — discard worktrees but keep audit data.
+- `<launcher> bakeoff run --idea-file <path> --profiles <p1> <p2> [--mode code|doc|metaplan] [--output <relative/path>] [--exp-id <id>] [--detach] [--robustness <level>] [--allow-dirty]` — kicks off N concurrent profile runs. Without `--detach` it streams a live status table every 5s and blocks until all profiles finish; with `--detach` it returns immediately and the user polls via `status`. `--output` is required with `--mode doc|metaplan` and rejected with `--mode code`.
+- `<launcher> bakeoff status [--exp <id>]` — current state of each profile (running / completed / crashed).
+- `<launcher> bakeoff tail [--exp <id>]` — tail the per-profile auto logs.
+- `<launcher> bakeoff compare --exp <id> [--judge <model>]` — collect metrics across profiles; with `--judge`, an LLM judge ranks the outputs.
+- `<launcher> bakeoff pick --exp <id> --profile <name> --rationale "..."` — record the human-selected winner.
+- `<launcher> bakeoff merge --exp <id>` — merge the chosen profile's worktree back to main.
+- `<launcher> bakeoff resume --exp <id>` — resume unfinished profile runs.
+- `<launcher> bakeoff abandon --exp <id>` — discard worktrees but keep audit data.
 ## Cloud Mode
-`megaplan cloud` runs a plan inside a provider-managed container with a persistent workspace volume, so the run survives the user's terminal session. Suggest it for long-running plans that would outlast a local session, multi-repo work, or when the user wants an isolated persistent sandbox. Sprint 1 ships the `railway` provider only; `ssh` and `local` are planned.
+`<launcher> cloud` runs a plan inside a provider-managed container with a persistent workspace volume, so the run survives the user's terminal session. Suggest it for long-running plans that would outlast a local session, multi-repo work, or when the user wants an isolated persistent sandbox. Sprint 1 ships the `railway` provider only; `ssh` and `local` are planned.
 
-Quick subcommand reference: `init`, `build`, `deploy`, `chain`, `status`, `attach`, `logs`, `exec`, `resume`, `down`, `destroy`. Typical flow: `megaplan cloud init` → edit `cloud.yaml` → export secrets → `megaplan cloud deploy` → `megaplan cloud chain <chain.yaml>`.
+Quick subcommand reference: `init`, `build`, `deploy`, `chain`, `status`, `attach`, `logs`, `exec`, `resume`, `down`, `destroy`. Typical flow: `<launcher> cloud init` → edit `cloud.yaml` → export secrets → `<launcher> cloud deploy` → `<launcher> cloud chain <chain.yaml>`.
 
 For the full reference — `cloud.yaml` fields, the `extra_repos[]` + `chain_session` multi-tenancy model, the operator loop, and the gotchas that wedge fresh runs (committed `chain_state.json`, profile-alias gap, secret-upload behavior, "internal_error" masking credit failures) — see the **megaplan-cloud** skill. Read it before launching the first cloud chain in a new project; the gotchas section will save hours.
 ## Tickets
-`megaplan ticket new` creates a repo-scoped issue ticket. Use it when:
+`<launcher> ticket new` creates a repo-scoped issue ticket. Use it when:
 - During epic/plan work you notice an out-of-scope problem, bug, or rough edge
 - A user explicitly asks you to capture something for later attention
 - You want to log an observation that doesn't block the current task but should be tracked
 
-The command prints only a ULID to stdout on success. Tickets live as `.megaplan/tickets/{ulid}-{slug}.md` files and are auto-discovered by the planner for future epics. Link them to epics with `megaplan ticket link <ticket> <epic> --resolves` so they auto-address when the epic completes.
+The command prints only a ULID to stdout on success. Tickets live as `.megaplan/tickets/{ulid}-{slug}.md` files and are auto-discovered by the planner for future epics. Link them to epics with `<launcher> ticket link <ticket> <epic> --resolves` so they auto-address when the epic completes.
 
 ## Briefs
-`megaplan brief` creates canonical source artifacts for work you intend to run.
+`<launcher> brief` creates canonical source artifacts for work you intend to run.
 Use it when:
 - You are turning an idea into a durable single-plan input
 - You are scaffolding an epic's `chain.yaml` and milestone idea files
-- You want the source document committed before `megaplan init` snapshots it into plan state
+- You want the source document committed before `<launcher> init` snapshots it into plan state
 
 Briefs live as committed files under `.megaplan/briefs/`. Single-plan ideas live
 at `.megaplan/briefs/{slug}.md`; epics live at
 `.megaplan/briefs/{epic-slug}/chain.yaml` with milestone briefs beside the chain
 spec. This is ticket-like in storage and ergonomics, but not in lifecycle:
-briefs feed `megaplan init` / `megaplan chain start`; tickets are open problem
+briefs feed `<launcher> init` / `<launcher> chain start`; tickets are open problem
 notes that can be discovered, linked, and auto-addressed by epics.
 
 Briefs and tickets share the local artifact substrate: common `.megaplan/<kind>/`
 path handling, slug normalization, optional frontmatter parsing, keyword
-filtering, and snippets. Use `megaplan brief list`, `megaplan brief show`, and
-`megaplan brief search` for the brief side of that common read surface.
+filtering, and snippets. Use `<launcher> brief list`, `<launcher> brief show`, and
+`<launcher> brief search` for the brief side of that common read surface.
 
-`megaplan init --idea-file <path>` reads the file and snapshots its text; it does
+`<launcher> init --idea-file <path>` reads the file and snapshots its text; it does
 not move arbitrary files into `.megaplan/briefs/`. If the idea file is a markdown
 artifact with YAML frontmatter, `init` snapshots only the markdown body. Use
-`megaplan brief new --init` to create the canonical source file first and then
+`<launcher> brief new --init` to create the canonical source file first and then
 initialize from it.
 
 ## Feedback
 See **megaplan-prep** for when to add the feedback phase (`--with-feedback`). This section covers the CLI mechanics once you've decided to use it.
 
-`megaplan feedback --plan <name>` scaffolds a `feedback.md` file in the plan directory and opens it in `$EDITOR` (or `$VISUAL`). The file has one section per workflow stage — `prep`, `plan`, `critique`, `revise`, `gate`, `tiebreaker`, `finalize`, `execute`, `review` — plus an `Overall` section. Each section has a `rating:` (integer 0–10) and a free-form `comment:` field; leave any field blank to skip it.
+`<launcher> feedback --plan <name>` scaffolds a `feedback.md` file in the plan directory and opens it in `$EDITOR` (or `$VISUAL`). The file has one section per workflow stage — `prep`, `plan`, `critique`, `revise`, `gate`, `tiebreaker`, `finalize`, `execute`, `review` — plus an `Overall` section. Each section has a `rating:` (integer 0–10) and a free-form `comment:` field; leave any field blank to skip it.
 
-This is **user feedback**, owned by the human after a run finishes — megaplan only scaffolds the template and parses it back on load, it never overwrites edits. Old plans without a `feedback.md` simply have no feedback attached; running `megaplan feedback --plan <name>` on an older plan scaffolds the template on demand (backwards compatible).
+This is **user feedback**, owned by the human after a run finishes — megaplan only scaffolds the template and parses it back on load, it never overwrites edits. Old plans without a `feedback.md` simply have no feedback attached; running `<launcher> feedback --plan <name>` on an older plan scaffolds the template on demand (backwards compatible).
 
-Use `megaplan feedback show --plan <name>` to print the parsed summary, and `--no-edit` to just scaffold the template and print the path without launching an editor. Parsed feedback is exposed on the in-memory `Plan` record as `Plan.feedback` (a dict shaped `{"overall": {...}, "stages": {stage: {...}}}`), so downstream tooling can read it the same way as any other artifact. When `--actor`/`MEGAPLAN_ACTOR_ID` is set, parsed feedback is also written to the `plans.feedback` jsonb column so the DB and file backends stay in sync.
+Use `<launcher> feedback show --plan <name>` to print the parsed summary, and `--no-edit` to just scaffold the template and print the path without launching an editor. Parsed feedback is exposed on the in-memory `Plan` record as `Plan.feedback` (a dict shaped `{"overall": {...}, "stages": {stage: {...}}}`), so downstream tooling can read it the same way as any other artifact. When `--actor`/`MEGAPLAN_ACTOR_ID` is set, parsed feedback is also written to the `plans.feedback` jsonb column so the DB and file backends stay in sync.
 
 ### Filling feedback with subagents
 Recommended process when an agent (rather than the human) is producing the initial assessment:
 
-1. **Scaffold**: run `megaplan feedback --plan <name> --no-edit` to create the empty `feedback.md`. Note the plan directory it prints — that is where the per-stage artifacts live (`plan_v*.md`, `critique*.json`, `gate.json`, `tiebreaker_*.json`, `finalize.json`, `execution*.json`, `review.json`, etc.).
+1. **Scaffold**: run `<launcher> feedback --plan <name> --no-edit` to create the empty `feedback.md`. Note the plan directory it prints — that is where the per-stage artifacts live (`plan_v*.md`, `critique*.json`, `gate.json`, `tiebreaker_*.json`, `finalize.json`, `execution*.json`, `review.json`, etc.).
 2. **Per-stage assessment**: dispatch one read-only subagent per stage that actually ran (skip stages with no artifacts). Brief each subagent narrowly — give it the plan idea, the stage name, and the artifact filenames for that stage only. Ask it to return a 0–10 rating plus a 1–3 sentence comment grounded in what the artifacts show (what worked, what was weak, what was missed). Run these in parallel; they have no dependencies on each other.
 3. **Synthesize Overall**: after the per-stage results come back, *you* (the orchestrating agent, not a subagent) read the per-stage ratings and comments together with the final outcome (`final.md`, `review.json`, any `latest_failure`) and decide an Overall rating and comment. The Overall is a judgment call about whether the run delivered the goal, not an average of stage ratings.
-4. **Write**: edit `feedback.md` with the ratings and comments. Leave a stage blank if it didn't run or you can't form a defensible opinion — empty is better than guessed. Run `megaplan feedback show --plan <name>` to confirm the parser picked everything up.
+4. **Write**: edit `feedback.md` with the ratings and comments. Leave a stage blank if it didn't run or you can't form a defensible opinion — empty is better than guessed. Run `<launcher> feedback show --plan <name>` to confirm the parser picked everything up.
 
 Keep comments grounded in specific artifact evidence ("critique flagged X but reviewer didn't catch the regression in Y") rather than vibes. The point of feedback is signal for future runs, not a participation score.
 
 ### Searching feedback across plans
-`megaplan feedback search` queries every plan with non-empty feedback across both backends — local `feedback.md` files in this project tree plus, when an actor is configured, the `plans.feedback` jsonb column in the DB. Duplicates between backends are de-duped by (plan name, project_dir). Use this to answer "which profile actually scored well on this repo?" or "where did the executor get a 6 or below?". Filters:
+`<launcher> feedback search` queries every plan with non-empty feedback across both backends — local `feedback.md` files in this project tree plus, when an actor is configured, the `plans.feedback` jsonb column in the DB. Duplicates between backends are de-duped by (plan name, project_dir). Use this to answer "which profile actually scored well on this repo?" or "where did the executor get a 6 or below?". Filters:
 - `--profile <substr>` — substring match on the plan's profile (e.g. `--profile claude` matches `all-claude`, `claude-led`, etc.).
 - `--repo <substr>` — substring match on the plan's `project_dir` / repo path.
 - `--min-rating N` / `--max-rating N` — bounds on the Overall rating.
@@ -248,70 +248,70 @@ Keep comments grounded in specific artifact evidence ("critique flagged X but re
 - `--all` — scan every megaplan project root on this machine, not just the current tree.
 - `--json` — emit raw rows instead of a table.
 
-Default output is a compact table (plan, profile, overall rating, backend, repo, plus the first line of the Overall comment). Combine with `megaplan feedback show --plan <name>` to drill into a specific match.
+Default output is a compact table (plan, profile, overall rating, backend, repo, plus the first line of the Overall comment). Combine with `<launcher> feedback show --plan <name>` to drill into a specific match.
 ## Observability
 Plans started after this layer landed write an append-only `events.ndjson` event journal to their plan dir. Four CLI surfaces read from it; reach for them whenever a run is in flight or you need to reconstruct what happened. See the **megaplan-observe** skill for the full failure-mode catalog and worked invocation chains.
 
-- `megaplan introspect --plan <name>` — single structured-JSON snapshot. Always check this first when something looks stuck; the `active_phase.liveness` enum (`progressing | quiet | stalled | timeout-imminent`) and `block_details.recoverable_via` together tell you whether to wait, intervene, or override. Also surfaces `outstanding_flags_count`, useful when a plan is sitting on unresolved critique signals.
-- `megaplan trace --plan <name> [--follow] [--format json|pretty|narrative] [--phase <p>] [--since <duration>]` — stream events. `narrative` format is the agent-facing affordance; `--follow` tails as the plan progresses; `--phase` and `--since` filter. Prints `trace: no events.ndjson for plan <name>` cleanly when a plan predates the journal.
-- `megaplan doctor [--plan <name> | --repo]` — diagnostic. `--repo` catches rubric/binary drift (skill profile names vs `profiles list`) and editable-install dirtiness *before* `megaplan init`, so reach for it after a branch switch / pull / fresh checkout. `--plan` reports lock, phase liveness, LLM liveness, cost-vs-cap, orphan subprocesses, and outstanding flags.
-- `megaplan record-tag --plan <name> --tag <name> --note "..."` — annotate a moment in the journal so later trace/introspect calls can find it. All three args are required.
+- `<launcher> introspect --plan <name>` — single structured-JSON snapshot. Always check this first when something looks stuck; the `active_phase.liveness` enum (`progressing | quiet | stalled | timeout-imminent`) and `block_details.recoverable_via` together tell you whether to wait, intervene, or override. Also surfaces `outstanding_flags_count`, useful when a plan is sitting on unresolved critique signals.
+- `<launcher> trace --plan <name> [--follow] [--format json|pretty|narrative] [--phase <p>] [--since <duration>]` — stream events. `narrative` format is the agent-facing affordance; `--follow` tails as the plan progresses; `--phase` and `--since` filter. Prints `trace: no events.ndjson for plan <name>` cleanly when a plan predates the journal.
+- `<launcher> doctor [--plan <name> | --repo]` — diagnostic. `--repo` catches rubric/binary drift (skill profile names vs `profiles list`) and editable-install dirtiness *before* `<launcher> init`, so reach for it after a branch switch / pull / fresh checkout. `--plan` reports lock, phase liveness, LLM liveness, cost-vs-cap, orphan subprocesses, and outstanding flags.
+- `<launcher> record-tag --plan <name> --tag <name> --note "..."` — annotate a moment in the journal so later trace/introspect calls can find it. All three args are required.
 
 Stale-timestamp inference, opaque blocked state, and "model thinking vs TCP wedged" are the three confusions this layer is designed to kill — if you find yourself running `lsof`, `ps`, or doing manual `ls -lat` time math on a plan dir, you should be running `introspect` or `trace` instead.
 ## Commands
 ```bash
-arnold status --plan <name>
-megaplan progress --plan <name>
-megaplan audit --plan <name>
-megaplan list
-megaplan prep --plan <name>
-megaplan plan --plan <name>
-megaplan critique --plan <name>
-megaplan revise --plan <name>
-megaplan gate --plan <name>
-megaplan finalize --plan <name>
-arnold execute --plan <name> --confirm-destructive [--batch N]
-arnold review --plan <name>
-megaplan step add --plan <name> [--after S<N>] "description"
-megaplan step remove --plan <name> S<N>
-megaplan step move --plan <name> S<N> --after S<M>
-megaplan override add-note --plan <name> --note "..."
-megaplan override force-proceed --plan <name> --reason "..."
-megaplan override replan --plan <name> --reason "..." [--note "..."]
-megaplan override abort --plan <name> --reason "..."
-arnold config show
-arnold config set <key> <value>
-arnold config reset
-arnold config profiles list
-arnold config profiles show <name>
-megaplan bakeoff run --idea-file <path> --profiles <p1> <p2> [--mode code|doc|metaplan] [--output <relative/path>] [--exp-id <id>] [--detach] [--robustness <level>] [--allow-dirty]
-megaplan bakeoff status [--exp <id>]
-megaplan bakeoff tail [--exp <id>]
-megaplan bakeoff compare --exp <id> [--judge <model>]
-megaplan bakeoff pick --exp <id> --profile <name> --rationale "..."
-megaplan bakeoff merge --exp <id>
-megaplan bakeoff resume --exp <id>
-megaplan bakeoff abandon --exp <id>
-megaplan brief new <slug> [-b <body> | --from <path> | -] [--force] [--init]
-megaplan brief epic <slug> --milestone LABEL=TITLE [--base-branch <branch>] [--force]
-megaplan brief list [--json]
-megaplan brief show <id-or-path> [--json]
-megaplan brief search [KW ...] [--all] [--sort path|title|length] [--desc] [--limit N] [--json]
-megaplan ticket new "title" -b "body"
-megaplan ticket list [--status <s>] [--tags <t>] [--json]
-megaplan ticket show <id> [--json]
-megaplan ticket edit <id> [--title <t>] [--body <b>] [--status <s>]
-megaplan ticket link <ticket> <epic> [--resolves]
-megaplan ticket unlink <ticket> <epic>
-megaplan ticket addressed <id> [--note <n>]
-megaplan ticket dismiss <id> --reason "..."
-megaplan ticket reopen <id>
-megaplan feedback show --plan <name> [--no-edit]
-megaplan feedback search [--profile <s>] [--repo <s>] [--min-rating N] [--max-rating N] [--stage <name>] [--has-comment] [--all] [--json]
-megaplan introspect --plan <name> [--json]
-megaplan trace --plan <name> [--follow] [--format json|pretty|narrative] [--phase <p>] [--since <duration>]
-megaplan doctor [--plan <name> | --repo]
-megaplan record-tag --plan <name> --tag <name> --note "..."
+<launcher> status --plan <name>
+<launcher> progress --plan <name>
+<launcher> audit --plan <name>
+<launcher> list
+<launcher> prep --plan <name>
+<launcher> plan --plan <name>
+<launcher> critique --plan <name>
+<launcher> revise --plan <name>
+<launcher> gate --plan <name>
+<launcher> finalize --plan <name>
+<launcher> execute --plan <name> --confirm-destructive [--batch N]
+<launcher> review --plan <name>
+<launcher> step add --plan <name> [--after S<N>] "description"
+<launcher> step remove --plan <name> S<N>
+<launcher> step move --plan <name> S<N> --after S<M>
+<launcher> override add-note --plan <name> --note "..."
+<launcher> override force-proceed --plan <name> --reason "..."
+<launcher> override replan --plan <name> --reason "..." [--note "..."]
+<launcher> override abort --plan <name> --reason "..."
+<launcher> config show
+<launcher> config set <key> <value>
+<launcher> config reset
+<launcher> config profiles list
+<launcher> config profiles show <name>
+<launcher> bakeoff run --idea-file <path> --profiles <p1> <p2> [--mode code|doc|metaplan] [--output <relative/path>] [--exp-id <id>] [--detach] [--robustness <level>] [--allow-dirty]
+<launcher> bakeoff status [--exp <id>]
+<launcher> bakeoff tail [--exp <id>]
+<launcher> bakeoff compare --exp <id> [--judge <model>]
+<launcher> bakeoff pick --exp <id> --profile <name> --rationale "..."
+<launcher> bakeoff merge --exp <id>
+<launcher> bakeoff resume --exp <id>
+<launcher> bakeoff abandon --exp <id>
+<launcher> brief new <slug> [-b <body> | --from <path> | -] [--force] [--init]
+<launcher> brief epic <slug> --milestone LABEL=TITLE [--base-branch <branch>] [--force]
+<launcher> brief list [--json]
+<launcher> brief show <id-or-path> [--json]
+<launcher> brief search [KW ...] [--all] [--sort path|title|length] [--desc] [--limit N] [--json]
+<launcher> ticket new "title" -b "body"
+<launcher> ticket list [--status <s>] [--tags <t>] [--json]
+<launcher> ticket show <id> [--json]
+<launcher> ticket edit <id> [--title <t>] [--body <b>] [--status <s>]
+<launcher> ticket link <ticket> <epic> [--resolves]
+<launcher> ticket unlink <ticket> <epic>
+<launcher> ticket addressed <id> [--note <n>]
+<launcher> ticket dismiss <id> --reason "..."
+<launcher> ticket reopen <id>
+<launcher> feedback show --plan <name> [--no-edit]
+<launcher> feedback search [--profile <s>] [--repo <s>] [--min-rating N] [--max-rating N] [--stage <name>] [--has-comment] [--all] [--json]
+<launcher> introspect --plan <name> [--json]
+<launcher> trace --plan <name> [--follow] [--format json|pretty|narrative] [--phase <p>] [--since <duration>]
+<launcher> doctor [--plan <name> | --repo]
+<launcher> record-tag --plan <name> --tag <name> --note "..."
 ```
 
 

--- a/arnold/pipelines/megaplan/data/_composed/cursor_rule.mdc
+++ b/arnold/pipelines/megaplan/data/_composed/cursor_rule.mdc
@@ -5,20 +5,20 @@ alwaysApply: false
 
 # Megaplan
 
-> **Before you invoke megaplan, run the `megaplan-prep` skill.** It's the front door for every run: it sizes the work (one plan vs. an epic), shapes the brief, and picks the profile (intelligence tier), robustness level, and thinking depth. Do not run `megaplan init` without it.
+> **Before you invoke megaplan, run the `megaplan-prep` skill.** It's the front door for every run: it sizes the work (one plan vs. an epic), shapes the brief, and picks the profile (intelligence tier), robustness level, and thinking depth. Do not run `<launcher> init` without it.
 
 **Scope:** This skill covers tooling — how to invoke and drive megaplan. For the decisions that come *before* invocation (scoping, brief, profile, robustness, depth), consult the **megaplan-prep** skill. If anything here contradicts megaplan-prep on decision-making content, megaplan-prep wins.
 
-Route every step through the `megaplan` CLI. Never call agents directly.
-Before the first CLI call, resolve a working launcher and reuse it for the whole run. Do not assume `megaplan` itself is on `PATH`; command presence alone is not enough. Prove the launcher works by successfully running a harmless CLI call with it first. In the instructions below, treat `<launcher>` as that verified command.
+Route every step through the Arnold CLI's Megaplan subcommands. Never call agents directly.
+Before the first CLI call, resolve a working launcher and reuse it for the whole run. Do not assume the removed `megaplan` entrypoint is on `PATH`; command presence alone is not enough. Prove the launcher works by successfully running a harmless CLI call with it first. In the instructions below, treat `<launcher>` as that verified command.
 Launcher resolution order:
 1. Try `python -m arnold.pipelines.megaplan config show`.
 2. If that fails, try `./.venv/bin/python -m arnold.pipelines.megaplan config show`.
 3. If that fails, try `uv run python -m arnold.pipelines.megaplan config show`.
-4. If that fails, try a version-selected shim such as `PYENV_VERSION=3.11.11 arnold config show`.
-5. Only use bare `megaplan ...` if that exact form already succeeded during this check.
+4. If those fail, stop and report that the Arnold Megaplan module launcher is unavailable.
+5. Do not use the removed `megaplan` module or console entrypoint; the repo-root `megaplan.py` file is a clean-break guard.
 ## Triage
-Decision-making (scoping, profile, robustness, depth, brief structure) lives in the **megaplan-prep** skill — consult it before running `megaplan init`. **Always run megaplan, even for tiny work** — `bare` robustness is the floor, never skip the harness. The few seconds of overhead pay back in the captured brief, plan, and outcome record.
+Decision-making (scoping, profile, robustness, depth, brief structure) lives in the **megaplan-prep** skill — consult it before running `<launcher> init`. **Always run megaplan, even for tiny work** — `bare` robustness is the floor, never skip the harness. The few seconds of overhead pay back in the captured brief, plan, and outcome record.
 ## Modes
 Megaplan has two output modes, picked with `--mode` at `init`:
 - **`--mode code`** (default): the run produces a code diff. Execute workers emit per-task file changes. Use for features, refactors, bug fixes, migrations — anything whose deliverable is source code.
@@ -90,27 +90,27 @@ At `--robustness extreme`, the loop is the same as thorough but also enables par
 - `review`: judge success against the success criteria and the user's intent, not plan elegance. Only block on `must` criteria failures. `should` failures are flagged but don't require rework. `info` criteria are waived.
 ## Gate Principle
 The gate response tells the orchestrator what to do next. Follow `orchestrator_guidance` unless you have a concrete reason to disagree after investigating the repository or plan artifacts yourself.
-Investigate before disagreeing: read the current plan and critique artifacts, check the project code to verify whether a flagged issue is real, or use `megaplan status --plan <name>` / `megaplan audit --plan <name>`.
+Investigate before disagreeing: read the current plan and critique artifacts, check the project code to verify whether a flagged issue is real, or use `<launcher> status --plan <name>` / `<launcher> audit --plan <name>`.
 If you disagree with the guidance, explain why briefly and use an override. Do not manually reinterpret score trajectory, flag quality, or loop state when the gate already did that work for you.
 ## Execute
-- After a successful gate, run `megaplan finalize` to produce the execution-ready briefing document.
-- In auto-approve mode, run `megaplan execute --confirm-destructive` after finalize.
+- After a successful gate, run `<launcher> finalize` to produce the execution-ready briefing document.
+- In auto-approve mode, run `<launcher> execute --confirm-destructive` after finalize.
 - In review mode, pause at the finalize-to-execute checkpoint and wait for explicit approval before running:
 ```bash
-arnold execute --confirm-destructive --user-approved
+<launcher> execute --confirm-destructive --user-approved
 ```
 ## Long-Running Execution
 For plans with multiple batches, use per-batch mode to drive execution incrementally:
 ```bash
-arnold execute --plan <name> --confirm-destructive --user-approved --batch 1
-arnold execute --plan <name> --confirm-destructive --user-approved --batch 2
+<launcher> execute --plan <name> --confirm-destructive --user-approved --batch 1
+<launcher> execute --plan <name> --confirm-destructive --user-approved --batch 2
 # ... continue until all batches complete
 ```
 Between batches, poll progress:
 ```bash
-megaplan progress --plan <name>
+<launcher> progress --plan <name>
 ```
-Use `megaplan status --plan <name>` for the full plan state, including active-step timing and any `next_step_runtime` guidance from the latest response.
+Use `<launcher> status --plan <name>` for the full plan state, including active-step timing and any `next_step_runtime` guidance from the latest response.
 Per-batch mode uses global batch numbering (1-indexed, computed from ALL tasks). Each `--batch N` call:
 - Validates that batches 1..N-1 are complete
 - Executes only batch N's tasks
@@ -119,23 +119,23 @@ Per-batch mode uses global batch numbering (1-indexed, computed from ALL tasks).
 Timeout recovery: re-run the same `--batch N`. The harness checks prerequisite completion and merges only untracked tasks.
 Note: `progress` shows completed state only (between-batch granularity). With per-batch mode, each batch is a separate CLI call, so the orchestrator has full visibility.
 ## Overrides
-- `megaplan override add-note --plan <name> --note "..."`
-- `megaplan override force-proceed --plan <name> --reason "..."`
-- `megaplan override replan --plan <name> --reason "..." [--note "..."]`
-- `megaplan override abort --plan <name> --reason "..."`
+- `<launcher> override add-note --plan <name> --note "..."`
+- `<launcher> override force-proceed --plan <name> --reason "..."`
+- `<launcher> override replan --plan <name> --reason "..." [--note "..."]`
+- `<launcher> override abort --plan <name> --reason "..."`
 `force-proceed` is available from `critiqued` (routes to finalize, not execute). `replan` is available from `gated`, `finalized`, or `critiqued`. `add-note` is safe from any active state.
 ## Replan
 Use `replan` when the orchestrator itself needs to edit the plan directly instead of asking the revise worker to do it.
 ```bash
-megaplan override replan --plan <name> --reason "expanding scope" --note "Also clean up the display layer"
+<launcher> override replan --plan <name> --reason "expanding scope" --note "Also clean up the display layer"
 ```
-After `replan`, read the returned plan file, edit it directly, then run `megaplan critique`.
+After `replan`, read the returned plan file, edit it directly, then run `<launcher> critique`.
 ## Step Editing
 Use `step` when you need to insert, remove, or reorder step sections (`## Step N:` or `### Step N:`) without hand-editing the markdown.
 ```bash
-megaplan step add --plan <name> --after S3 "Add regression coverage for the parser"
-megaplan step remove --plan <name> S4
-megaplan step move --plan <name> S4 --after S2
+<launcher> step add --plan <name> --after S3 "Add regression coverage for the parser"
+<launcher> step remove --plan <name> S4
+<launcher> step move --plan <name> S4 --after S2
 ```
 Each edit writes a new same-iteration plan artifact, preserves the latest plan meta questions/success criteria/assumptions, and resets the plan to `planned` so it re-enters critique.
 ## Sessions And Autonomy
@@ -146,14 +146,14 @@ Each edit writes a new same-iteration plan artifact, preserves the latest plan m
 - Keep moving and show results at each step.
 - Only pause at finalize to execute in review mode.
 ## Configuration
-View current defaults with `megaplan config show`. Override with `megaplan config set <key> <value>`. Reset with `megaplan config reset`.
-When routing or behavior depends on config, check `megaplan config show` and respect user overrides instead of assuming defaults.
+View current defaults with `<launcher> config show`. Override with `<launcher> config set <key> <value>`. Reset with `<launcher> config reset`.
+When routing or behavior depends on config, check `<launcher> config show` and respect user overrides instead of assuming defaults.
 Settable execution keys: `execution.auto_approve`, `execution.robustness`.
 ## Profiles
 A profile is a named preset that maps each workflow phase to an agent/model spec. Pass `--profile <name>` to any command that accepts `--phase-model` (`init`, `loop-init`, `tiebreaker`, etc.) to apply the preset.
-See **megaplan-prep** for profile selection. Inspect available profiles with `megaplan config profiles list`.
+See **megaplan-prep** for profile selection. Inspect available profiles with `<launcher> config profiles list`.
 Resolution order, later overrides earlier within the same name: built-in (`megaplan/profiles/*.toml`) → user (`~/.config/megaplan/profiles.toml`, or `$XDG_CONFIG_HOME/megaplan/profiles.toml`) → project (`<project_dir>/.megaplan/profiles.toml`).
-Inspect with `megaplan config profiles list` and `megaplan config profiles show <name>`.
+Inspect with `<launcher> config profiles list` and `<launcher> config profiles show <name>`.
 File format: TOML with a `[profiles.<name>]` table. Keys are phase names (`plan`, `prep`, `critique`, `revise`, `gate`, `finalize`, `execute`, `loop_plan`, `loop_execute`, `review`, `tiebreaker_researcher`, `tiebreaker_challenger`); values are agent specs like `"claude"`, `"codex"`, `"hermes:fireworks:accounts/fireworks/models/kimi-k2p6"`, `"hermes:glm-5.1"`. Example:
 ```toml
 [profiles.my-mix]
@@ -166,80 +166,80 @@ review   = "codex"
 ## Bakeoff
 See the **bakeoff** skill for methodology and the **megaplan-prep** skill for when bake-offs earn their cost. This section covers the CLI mechanics once you've decided to run one.
 
-`megaplan bakeoff run` runs the same idea through multiple profiles concurrently, each in its own git worktree, each driven autonomously by `megaplan auto`. Use it when the user wants to compare profiles head-to-head on the same task (e.g., "run this with kimi and the default profile side-by-side").
-Supports `--mode code` (default) and `--mode doc` / `--mode metaplan` (alias). For doc-mode bake-offs, `--output <relative/path>` is required and is threaded into each profile's `megaplan init`; merge brings the chosen profile's doc artifact back to main instead of applying a code patch. Joke mode is not yet supported.
+`<launcher> bakeoff run` runs the same idea through multiple profiles concurrently, each in its own git worktree, each driven autonomously by `<launcher> auto`. Use it when the user wants to compare profiles head-to-head on the same task (e.g., "run this with kimi and the default profile side-by-side").
+Supports `--mode code` (default) and `--mode doc` / `--mode metaplan` (alias). For doc-mode bake-offs, `--output <relative/path>` is required and is threaded into each profile's `<launcher> init`; merge brings the chosen profile's doc artifact back to main instead of applying a code patch. Joke mode is not yet supported.
 Requires a clean main worktree by default — pass `--allow-dirty` when there are unrelated uncommitted changes you want to keep on main. Those changes stay on main and are NOT copied into the worktrees, since worktrees branch off the current commit's SHA.
 The idea must be a file (`--idea-file <path>`), not an inline string. Write the idea to a file first.
-Bakeoff is inherently autonomous (it spawns `megaplan auto`), so the execution-mode question doesn't apply to bakeoff runs. `--robustness` is forwarded to each profile's `init`. When a project-layer `.megaplan/profiles.toml` exists, it's automatically copied into each worktree so project-only profiles resolve.
+Bakeoff is inherently autonomous (it spawns `<launcher> auto`), so the execution-mode question doesn't apply to bakeoff runs. `--robustness` is forwarded to each profile's `init`. When a project-layer `.megaplan/profiles.toml` exists, it's automatically copied into each worktree so project-only profiles resolve.
 Lifecycle:
-- `megaplan bakeoff run --idea-file <path> --profiles <p1> <p2> [--mode code|doc|metaplan] [--output <relative/path>] [--exp-id <id>] [--detach] [--robustness <level>] [--allow-dirty]` — kicks off N concurrent profile runs. Without `--detach` it streams a live status table every 5s and blocks until all profiles finish; with `--detach` it returns immediately and the user polls via `status`. `--output` is required with `--mode doc|metaplan` and rejected with `--mode code`.
-- `megaplan bakeoff status [--exp <id>]` — current state of each profile (running / completed / crashed).
-- `megaplan bakeoff tail [--exp <id>]` — tail the per-profile auto logs.
-- `megaplan bakeoff compare --exp <id> [--judge <model>]` — collect metrics across profiles; with `--judge`, an LLM judge ranks the outputs.
-- `megaplan bakeoff pick --exp <id> --profile <name> --rationale "..."` — record the human-selected winner.
-- `megaplan bakeoff merge --exp <id>` — merge the chosen profile's worktree back to main.
-- `megaplan bakeoff resume --exp <id>` — resume unfinished profile runs.
-- `megaplan bakeoff abandon --exp <id>` — discard worktrees but keep audit data.
+- `<launcher> bakeoff run --idea-file <path> --profiles <p1> <p2> [--mode code|doc|metaplan] [--output <relative/path>] [--exp-id <id>] [--detach] [--robustness <level>] [--allow-dirty]` — kicks off N concurrent profile runs. Without `--detach` it streams a live status table every 5s and blocks until all profiles finish; with `--detach` it returns immediately and the user polls via `status`. `--output` is required with `--mode doc|metaplan` and rejected with `--mode code`.
+- `<launcher> bakeoff status [--exp <id>]` — current state of each profile (running / completed / crashed).
+- `<launcher> bakeoff tail [--exp <id>]` — tail the per-profile auto logs.
+- `<launcher> bakeoff compare --exp <id> [--judge <model>]` — collect metrics across profiles; with `--judge`, an LLM judge ranks the outputs.
+- `<launcher> bakeoff pick --exp <id> --profile <name> --rationale "..."` — record the human-selected winner.
+- `<launcher> bakeoff merge --exp <id>` — merge the chosen profile's worktree back to main.
+- `<launcher> bakeoff resume --exp <id>` — resume unfinished profile runs.
+- `<launcher> bakeoff abandon --exp <id>` — discard worktrees but keep audit data.
 ## Cloud Mode
-`megaplan cloud` runs a plan inside a provider-managed container with a persistent workspace volume, so the run survives the user's terminal session. Suggest it for long-running plans that would outlast a local session, multi-repo work, or when the user wants an isolated persistent sandbox. Sprint 1 ships the `railway` provider only; `ssh` and `local` are planned.
+`<launcher> cloud` runs a plan inside a provider-managed container with a persistent workspace volume, so the run survives the user's terminal session. Suggest it for long-running plans that would outlast a local session, multi-repo work, or when the user wants an isolated persistent sandbox. Sprint 1 ships the `railway` provider only; `ssh` and `local` are planned.
 
-Quick subcommand reference: `init`, `build`, `deploy`, `chain`, `status`, `attach`, `logs`, `exec`, `resume`, `down`, `destroy`. Typical flow: `megaplan cloud init` → edit `cloud.yaml` → export secrets → `megaplan cloud deploy` → `megaplan cloud chain <chain.yaml>`.
+Quick subcommand reference: `init`, `build`, `deploy`, `chain`, `status`, `attach`, `logs`, `exec`, `resume`, `down`, `destroy`. Typical flow: `<launcher> cloud init` → edit `cloud.yaml` → export secrets → `<launcher> cloud deploy` → `<launcher> cloud chain <chain.yaml>`.
 
 For the full reference — `cloud.yaml` fields, the `extra_repos[]` + `chain_session` multi-tenancy model, the operator loop, and the gotchas that wedge fresh runs (committed `chain_state.json`, profile-alias gap, secret-upload behavior, "internal_error" masking credit failures) — see the **megaplan-cloud** skill. Read it before launching the first cloud chain in a new project; the gotchas section will save hours.
 ## Tickets
-`megaplan ticket new` creates a repo-scoped issue ticket. Use it when:
+`<launcher> ticket new` creates a repo-scoped issue ticket. Use it when:
 - During epic/plan work you notice an out-of-scope problem, bug, or rough edge
 - A user explicitly asks you to capture something for later attention
 - You want to log an observation that doesn't block the current task but should be tracked
 
-The command prints only a ULID to stdout on success. Tickets live as `.megaplan/tickets/{ulid}-{slug}.md` files and are auto-discovered by the planner for future epics. Link them to epics with `megaplan ticket link <ticket> <epic> --resolves` so they auto-address when the epic completes.
+The command prints only a ULID to stdout on success. Tickets live as `.megaplan/tickets/{ulid}-{slug}.md` files and are auto-discovered by the planner for future epics. Link them to epics with `<launcher> ticket link <ticket> <epic> --resolves` so they auto-address when the epic completes.
 
 ## Briefs
-`megaplan brief` creates canonical source artifacts for work you intend to run.
+`<launcher> brief` creates canonical source artifacts for work you intend to run.
 Use it when:
 - You are turning an idea into a durable single-plan input
 - You are scaffolding an epic's `chain.yaml` and milestone idea files
-- You want the source document committed before `megaplan init` snapshots it into plan state
+- You want the source document committed before `<launcher> init` snapshots it into plan state
 
 Briefs live as committed files under `.megaplan/briefs/`. Single-plan ideas live
 at `.megaplan/briefs/{slug}.md`; epics live at
 `.megaplan/briefs/{epic-slug}/chain.yaml` with milestone briefs beside the chain
 spec. This is ticket-like in storage and ergonomics, but not in lifecycle:
-briefs feed `megaplan init` / `megaplan chain start`; tickets are open problem
+briefs feed `<launcher> init` / `<launcher> chain start`; tickets are open problem
 notes that can be discovered, linked, and auto-addressed by epics.
 
 Briefs and tickets share the local artifact substrate: common `.megaplan/<kind>/`
 path handling, slug normalization, optional frontmatter parsing, keyword
-filtering, and snippets. Use `megaplan brief list`, `megaplan brief show`, and
-`megaplan brief search` for the brief side of that common read surface.
+filtering, and snippets. Use `<launcher> brief list`, `<launcher> brief show`, and
+`<launcher> brief search` for the brief side of that common read surface.
 
-`megaplan init --idea-file <path>` reads the file and snapshots its text; it does
+`<launcher> init --idea-file <path>` reads the file and snapshots its text; it does
 not move arbitrary files into `.megaplan/briefs/`. If the idea file is a markdown
 artifact with YAML frontmatter, `init` snapshots only the markdown body. Use
-`megaplan brief new --init` to create the canonical source file first and then
+`<launcher> brief new --init` to create the canonical source file first and then
 initialize from it.
 
 ## Feedback
 See **megaplan-prep** for when to add the feedback phase (`--with-feedback`). This section covers the CLI mechanics once you've decided to use it.
 
-`megaplan feedback --plan <name>` scaffolds a `feedback.md` file in the plan directory and opens it in `$EDITOR` (or `$VISUAL`). The file has one section per workflow stage — `prep`, `plan`, `critique`, `revise`, `gate`, `tiebreaker`, `finalize`, `execute`, `review` — plus an `Overall` section. Each section has a `rating:` (integer 0–10) and a free-form `comment:` field; leave any field blank to skip it.
+`<launcher> feedback --plan <name>` scaffolds a `feedback.md` file in the plan directory and opens it in `$EDITOR` (or `$VISUAL`). The file has one section per workflow stage — `prep`, `plan`, `critique`, `revise`, `gate`, `tiebreaker`, `finalize`, `execute`, `review` — plus an `Overall` section. Each section has a `rating:` (integer 0–10) and a free-form `comment:` field; leave any field blank to skip it.
 
-This is **user feedback**, owned by the human after a run finishes — megaplan only scaffolds the template and parses it back on load, it never overwrites edits. Old plans without a `feedback.md` simply have no feedback attached; running `megaplan feedback --plan <name>` on an older plan scaffolds the template on demand (backwards compatible).
+This is **user feedback**, owned by the human after a run finishes — megaplan only scaffolds the template and parses it back on load, it never overwrites edits. Old plans without a `feedback.md` simply have no feedback attached; running `<launcher> feedback --plan <name>` on an older plan scaffolds the template on demand (backwards compatible).
 
-Use `megaplan feedback show --plan <name>` to print the parsed summary, and `--no-edit` to just scaffold the template and print the path without launching an editor. Parsed feedback is exposed on the in-memory `Plan` record as `Plan.feedback` (a dict shaped `{"overall": {...}, "stages": {stage: {...}}}`), so downstream tooling can read it the same way as any other artifact. When `--actor`/`MEGAPLAN_ACTOR_ID` is set, parsed feedback is also written to the `plans.feedback` jsonb column so the DB and file backends stay in sync.
+Use `<launcher> feedback show --plan <name>` to print the parsed summary, and `--no-edit` to just scaffold the template and print the path without launching an editor. Parsed feedback is exposed on the in-memory `Plan` record as `Plan.feedback` (a dict shaped `{"overall": {...}, "stages": {stage: {...}}}`), so downstream tooling can read it the same way as any other artifact. When `--actor`/`MEGAPLAN_ACTOR_ID` is set, parsed feedback is also written to the `plans.feedback` jsonb column so the DB and file backends stay in sync.
 
 ### Filling feedback with subagents
 Recommended process when an agent (rather than the human) is producing the initial assessment:
 
-1. **Scaffold**: run `megaplan feedback --plan <name> --no-edit` to create the empty `feedback.md`. Note the plan directory it prints — that is where the per-stage artifacts live (`plan_v*.md`, `critique*.json`, `gate.json`, `tiebreaker_*.json`, `finalize.json`, `execution*.json`, `review.json`, etc.).
+1. **Scaffold**: run `<launcher> feedback --plan <name> --no-edit` to create the empty `feedback.md`. Note the plan directory it prints — that is where the per-stage artifacts live (`plan_v*.md`, `critique*.json`, `gate.json`, `tiebreaker_*.json`, `finalize.json`, `execution*.json`, `review.json`, etc.).
 2. **Per-stage assessment**: dispatch one read-only subagent per stage that actually ran (skip stages with no artifacts). Brief each subagent narrowly — give it the plan idea, the stage name, and the artifact filenames for that stage only. Ask it to return a 0–10 rating plus a 1–3 sentence comment grounded in what the artifacts show (what worked, what was weak, what was missed). Run these in parallel; they have no dependencies on each other.
 3. **Synthesize Overall**: after the per-stage results come back, *you* (the orchestrating agent, not a subagent) read the per-stage ratings and comments together with the final outcome (`final.md`, `review.json`, any `latest_failure`) and decide an Overall rating and comment. The Overall is a judgment call about whether the run delivered the goal, not an average of stage ratings.
-4. **Write**: edit `feedback.md` with the ratings and comments. Leave a stage blank if it didn't run or you can't form a defensible opinion — empty is better than guessed. Run `megaplan feedback show --plan <name>` to confirm the parser picked everything up.
+4. **Write**: edit `feedback.md` with the ratings and comments. Leave a stage blank if it didn't run or you can't form a defensible opinion — empty is better than guessed. Run `<launcher> feedback show --plan <name>` to confirm the parser picked everything up.
 
 Keep comments grounded in specific artifact evidence ("critique flagged X but reviewer didn't catch the regression in Y") rather than vibes. The point of feedback is signal for future runs, not a participation score.
 
 ### Searching feedback across plans
-`megaplan feedback search` queries every plan with non-empty feedback across both backends — local `feedback.md` files in this project tree plus, when an actor is configured, the `plans.feedback` jsonb column in the DB. Duplicates between backends are de-duped by (plan name, project_dir). Use this to answer "which profile actually scored well on this repo?" or "where did the executor get a 6 or below?". Filters:
+`<launcher> feedback search` queries every plan with non-empty feedback across both backends — local `feedback.md` files in this project tree plus, when an actor is configured, the `plans.feedback` jsonb column in the DB. Duplicates between backends are de-duped by (plan name, project_dir). Use this to answer "which profile actually scored well on this repo?" or "where did the executor get a 6 or below?". Filters:
 - `--profile <substr>` — substring match on the plan's profile (e.g. `--profile claude` matches `all-claude`, `claude-led`, etc.).
 - `--repo <substr>` — substring match on the plan's `project_dir` / repo path.
 - `--min-rating N` / `--max-rating N` — bounds on the Overall rating.
@@ -248,68 +248,68 @@ Keep comments grounded in specific artifact evidence ("critique flagged X but re
 - `--all` — scan every megaplan project root on this machine, not just the current tree.
 - `--json` — emit raw rows instead of a table.
 
-Default output is a compact table (plan, profile, overall rating, backend, repo, plus the first line of the Overall comment). Combine with `megaplan feedback show --plan <name>` to drill into a specific match.
+Default output is a compact table (plan, profile, overall rating, backend, repo, plus the first line of the Overall comment). Combine with `<launcher> feedback show --plan <name>` to drill into a specific match.
 ## Observability
 Plans started after this layer landed write an append-only `events.ndjson` event journal to their plan dir. Four CLI surfaces read from it; reach for them whenever a run is in flight or you need to reconstruct what happened. See the **megaplan-observe** skill for the full failure-mode catalog and worked invocation chains.
 
-- `megaplan introspect --plan <name>` — single structured-JSON snapshot. Always check this first when something looks stuck; the `active_phase.liveness` enum (`progressing | quiet | stalled | timeout-imminent`) and `block_details.recoverable_via` together tell you whether to wait, intervene, or override. Also surfaces `outstanding_flags_count`, useful when a plan is sitting on unresolved critique signals.
-- `megaplan trace --plan <name> [--follow] [--format json|pretty|narrative] [--phase <p>] [--since <duration>]` — stream events. `narrative` format is the agent-facing affordance; `--follow` tails as the plan progresses; `--phase` and `--since` filter. Prints `trace: no events.ndjson for plan <name>` cleanly when a plan predates the journal.
-- `megaplan doctor [--plan <name> | --repo]` — diagnostic. `--repo` catches rubric/binary drift (skill profile names vs `profiles list`) and editable-install dirtiness *before* `megaplan init`, so reach for it after a branch switch / pull / fresh checkout. `--plan` reports lock, phase liveness, LLM liveness, cost-vs-cap, orphan subprocesses, and outstanding flags.
-- `megaplan record-tag --plan <name> --tag <name> --note "..."` — annotate a moment in the journal so later trace/introspect calls can find it. All three args are required.
+- `<launcher> introspect --plan <name>` — single structured-JSON snapshot. Always check this first when something looks stuck; the `active_phase.liveness` enum (`progressing | quiet | stalled | timeout-imminent`) and `block_details.recoverable_via` together tell you whether to wait, intervene, or override. Also surfaces `outstanding_flags_count`, useful when a plan is sitting on unresolved critique signals.
+- `<launcher> trace --plan <name> [--follow] [--format json|pretty|narrative] [--phase <p>] [--since <duration>]` — stream events. `narrative` format is the agent-facing affordance; `--follow` tails as the plan progresses; `--phase` and `--since` filter. Prints `trace: no events.ndjson for plan <name>` cleanly when a plan predates the journal.
+- `<launcher> doctor [--plan <name> | --repo]` — diagnostic. `--repo` catches rubric/binary drift (skill profile names vs `profiles list`) and editable-install dirtiness *before* `<launcher> init`, so reach for it after a branch switch / pull / fresh checkout. `--plan` reports lock, phase liveness, LLM liveness, cost-vs-cap, orphan subprocesses, and outstanding flags.
+- `<launcher> record-tag --plan <name> --tag <name> --note "..."` — annotate a moment in the journal so later trace/introspect calls can find it. All three args are required.
 
 Stale-timestamp inference, opaque blocked state, and "model thinking vs TCP wedged" are the three confusions this layer is designed to kill — if you find yourself running `lsof`, `ps`, or doing manual `ls -lat` time math on a plan dir, you should be running `introspect` or `trace` instead.
 ## Commands
 ```bash
-arnold status --plan <name>
-megaplan progress --plan <name>
-megaplan audit --plan <name>
-megaplan list
-megaplan prep --plan <name>
-megaplan plan --plan <name>
-megaplan critique --plan <name>
-megaplan revise --plan <name>
-megaplan gate --plan <name>
-megaplan finalize --plan <name>
-arnold execute --plan <name> --confirm-destructive [--batch N]
-arnold review --plan <name>
-megaplan step add --plan <name> [--after S<N>] "description"
-megaplan step remove --plan <name> S<N>
-megaplan step move --plan <name> S<N> --after S<M>
-megaplan override add-note --plan <name> --note "..."
-megaplan override force-proceed --plan <name> --reason "..."
-megaplan override replan --plan <name> --reason "..." [--note "..."]
-megaplan override abort --plan <name> --reason "..."
-arnold config show
-arnold config set <key> <value>
-arnold config reset
-arnold config profiles list
-arnold config profiles show <name>
-megaplan bakeoff run --idea-file <path> --profiles <p1> <p2> [--mode code|doc|metaplan] [--output <relative/path>] [--exp-id <id>] [--detach] [--robustness <level>] [--allow-dirty]
-megaplan bakeoff status [--exp <id>]
-megaplan bakeoff tail [--exp <id>]
-megaplan bakeoff compare --exp <id> [--judge <model>]
-megaplan bakeoff pick --exp <id> --profile <name> --rationale "..."
-megaplan bakeoff merge --exp <id>
-megaplan bakeoff resume --exp <id>
-megaplan bakeoff abandon --exp <id>
-megaplan brief new <slug> [-b <body> | --from <path> | -] [--force] [--init]
-megaplan brief epic <slug> --milestone LABEL=TITLE [--base-branch <branch>] [--force]
-megaplan brief list [--json]
-megaplan brief show <id-or-path> [--json]
-megaplan brief search [KW ...] [--all] [--sort path|title|length] [--desc] [--limit N] [--json]
-megaplan ticket new "title" -b "body"
-megaplan ticket list [--status <s>] [--tags <t>] [--json]
-megaplan ticket show <id> [--json]
-megaplan ticket edit <id> [--title <t>] [--body <b>] [--status <s>]
-megaplan ticket link <ticket> <epic> [--resolves]
-megaplan ticket unlink <ticket> <epic>
-megaplan ticket addressed <id> [--note <n>]
-megaplan ticket dismiss <id> --reason "..."
-megaplan ticket reopen <id>
-megaplan feedback show --plan <name> [--no-edit]
-megaplan feedback search [--profile <s>] [--repo <s>] [--min-rating N] [--max-rating N] [--stage <name>] [--has-comment] [--all] [--json]
-megaplan introspect --plan <name> [--json]
-megaplan trace --plan <name> [--follow] [--format json|pretty|narrative] [--phase <p>] [--since <duration>]
-megaplan doctor [--plan <name> | --repo]
-megaplan record-tag --plan <name> --tag <name> --note "..."
+<launcher> status --plan <name>
+<launcher> progress --plan <name>
+<launcher> audit --plan <name>
+<launcher> list
+<launcher> prep --plan <name>
+<launcher> plan --plan <name>
+<launcher> critique --plan <name>
+<launcher> revise --plan <name>
+<launcher> gate --plan <name>
+<launcher> finalize --plan <name>
+<launcher> execute --plan <name> --confirm-destructive [--batch N]
+<launcher> review --plan <name>
+<launcher> step add --plan <name> [--after S<N>] "description"
+<launcher> step remove --plan <name> S<N>
+<launcher> step move --plan <name> S<N> --after S<M>
+<launcher> override add-note --plan <name> --note "..."
+<launcher> override force-proceed --plan <name> --reason "..."
+<launcher> override replan --plan <name> --reason "..." [--note "..."]
+<launcher> override abort --plan <name> --reason "..."
+<launcher> config show
+<launcher> config set <key> <value>
+<launcher> config reset
+<launcher> config profiles list
+<launcher> config profiles show <name>
+<launcher> bakeoff run --idea-file <path> --profiles <p1> <p2> [--mode code|doc|metaplan] [--output <relative/path>] [--exp-id <id>] [--detach] [--robustness <level>] [--allow-dirty]
+<launcher> bakeoff status [--exp <id>]
+<launcher> bakeoff tail [--exp <id>]
+<launcher> bakeoff compare --exp <id> [--judge <model>]
+<launcher> bakeoff pick --exp <id> --profile <name> --rationale "..."
+<launcher> bakeoff merge --exp <id>
+<launcher> bakeoff resume --exp <id>
+<launcher> bakeoff abandon --exp <id>
+<launcher> brief new <slug> [-b <body> | --from <path> | -] [--force] [--init]
+<launcher> brief epic <slug> --milestone LABEL=TITLE [--base-branch <branch>] [--force]
+<launcher> brief list [--json]
+<launcher> brief show <id-or-path> [--json]
+<launcher> brief search [KW ...] [--all] [--sort path|title|length] [--desc] [--limit N] [--json]
+<launcher> ticket new "title" -b "body"
+<launcher> ticket list [--status <s>] [--tags <t>] [--json]
+<launcher> ticket show <id> [--json]
+<launcher> ticket edit <id> [--title <t>] [--body <b>] [--status <s>]
+<launcher> ticket link <ticket> <epic> [--resolves]
+<launcher> ticket unlink <ticket> <epic>
+<launcher> ticket addressed <id> [--note <n>]
+<launcher> ticket dismiss <id> --reason "..."
+<launcher> ticket reopen <id>
+<launcher> feedback show --plan <name> [--no-edit]
+<launcher> feedback search [--profile <s>] [--repo <s>] [--min-rating N] [--max-rating N] [--stage <name>] [--has-comment] [--all] [--json]
+<launcher> introspect --plan <name> [--json]
+<launcher> trace --plan <name> [--follow] [--format json|pretty|narrative] [--phase <p>] [--since <duration>]
+<launcher> doctor [--plan <name> | --repo]
+<launcher> record-tag --plan <name> --tag <name> --note "..."
 ```

--- a/arnold/pipelines/megaplan/data/claude_subagent_appendix.md
+++ b/arnold/pipelines/megaplan/data/claude_subagent_appendix.md
@@ -3,7 +3,7 @@
 This appendix is Claude-specific. It adds a subagent path; subagent mode is the default for Claude.
 
 ### Activation
-- Default to subagent unless an inline override is explicitly set for this run or `megaplan config show` reports `"orchestration": {"mode": "inline"}`.
+- Default to subagent unless an inline override is explicitly set for this run or `<launcher> config show` reports `"orchestration": {"mode": "inline"}`.
 - Per-run override wins over config. If the run explicitly says `inline`, stay inline even when config prefers `subagent`.
 - Use subagent mode for long multi-phase runs where keeping the outer conversation clean matters, especially auto-approve runs.
 - Prefer inline mode for small edits, quick clarifications, or any run where the user wants to watch each phase in the main thread.
@@ -15,14 +15,14 @@ When subagent mode is active, the outer skill becomes a launcher plus breakpoint
 - `run_in_background: true` when `{AUTO_APPROVE}` is true; otherwise foreground is fine
 - Expand `{AUTO_APPROVE_FLAG}` to an empty string when `raw_config.execution.auto_approve` is explicitly set; otherwise expand it to `--auto-approve` for auto-approve runs and an empty string for review runs.
 - Expand `{ROBUSTNESS_FLAG}` to an empty string when `raw_config.execution.robustness` is explicitly set; otherwise expand it to `--robustness {ROBUSTNESS}`.
-- For doc-mode runs, also append `--mode doc --output <relative/path>` to the `megaplan init` call in the subagent's Startup step. Everything else in the template applies unchanged; the workflow phases and breakpoints are identical in doc mode.
-- After editing this source file, rerun `megaplan setup --force` so installed `SKILL.md` files pick up the refreshed appendix.
+- For doc-mode runs, also append `--mode doc --output <relative/path>` to the `<launcher> init` call in the subagent's Startup step. Everything else in the template applies unchanged; the workflow phases and breakpoints are identical in doc mode.
+- After editing this source file, rerun `<launcher> setup --force` so installed `SKILL.md` files pick up the refreshed appendix.
 
 ### Outer Skill Handling
 - Decide inline vs subagent before starting the workflow.
 - In subagent mode, launch the agent, wait for either `BREAKPOINT:` or `COMPLETE:`, and keep the main thread thin.
-- Support inject-after by letting the background subagent continue while the user runs `megaplan override add-note`; the next phase boundary picks it up from `megaplan status`.
-- Support kill-and-inject by stopping the running subagent, appending a note with `megaplan override add-note`, and relaunching a new subagent on the same plan.
+- Support inject-after by letting the background subagent continue while the user runs `<launcher> override add-note`; the next phase boundary picks it up from `<launcher> status`.
+- Support kill-and-inject by stopping the running subagent, appending a note with `<launcher> override add-note`, and relaunching a new subagent on the same plan.
 - When a breakpoint arrives, relay the summary to the user, collect the answer, and resume the same agent with `SendMessage` when possible.
 - Parse only the explicit breakpoint header, not incidental text, when deciding whether the agent stopped intentionally.
 - When completion arrives, report the final result back to the user without replaying every internal phase.
@@ -41,7 +41,7 @@ Your job is to drive the megaplan workflow through the CLI until the run finishe
 
 Always follow these priorities, in order:
 1. The latest user direction relayed through notes or resume messages.
-2. The live CLI state from `megaplan status --plan <name>`.
+2. The live CLI state from `<launcher> status --plan <name>`.
 3. The workflow and breakpoint rules in this template.
 4. Your own memory of earlier turns.
 
@@ -60,12 +60,13 @@ Never do these things:
 
 ## 2. Startup
 Start the run like this:
-1. Use empty-string expansion for `{AUTO_APPROVE_FLAG}` and `{ROBUSTNESS_FLAG}` whenever the corresponding `raw_config.execution` key is explicitly set.
-2. Run `megaplan init --project-dir "{PROJECT_DIR}" {AUTO_APPROVE_FLAG} {ROBUSTNESS_FLAG} "{IDEA}"`.
-3. Capture the returned plan name.
-4. Output `PLAN_NAME: <name>` on its own line immediately after init and before any `BREAKPOINT:` or `COMPLETE:`.
-5. Run `megaplan status --plan <name>`.
-6. From then on, use that plan name for every command.
+1. Resolve and verify a working `<launcher>` with a harmless config call. Prefer `python -m arnold.pipelines.megaplan config show`; do not use the removed `megaplan` module or console entrypoint.
+2. Use empty-string expansion for `{AUTO_APPROVE_FLAG}` and `{ROBUSTNESS_FLAG}` whenever the corresponding `raw_config.execution` key is explicitly set.
+3. Run `<launcher> init --project-dir "{PROJECT_DIR}" {AUTO_APPROVE_FLAG} {ROBUSTNESS_FLAG} "{IDEA}"`.
+4. Capture the returned plan name.
+5. Output `PLAN_NAME: <name>` on its own line immediately after init and before any `BREAKPOINT:` or `COMPLETE:`.
+6. Run `<launcher> status --plan <name>`.
+7. From then on, use that plan name and the same `<launcher>` for every command.
 
 At startup and after every later resume:
 - Read `state`, `next_step`, and `valid_next`.
@@ -110,10 +111,10 @@ Extreme robustness (legacy name: superrobust):
 Gate decision tree for full, thorough, and extreme:
 - Condition 1: `gate_unset`
   Trigger: state is `critiqued` and `valid_next` includes `gate`.
-  Action: run `megaplan gate --plan <name>`.
+  Action: run `<launcher> gate --plan <name>`.
 - Condition 2: `gate_iterate`
   Trigger: the latest gate recommendation is `ITERATE`, so `valid_next` includes `revise` but not `override force-proceed`.
-  Action: run `megaplan revise --plan <name>`, then continue back through `critique` and `gate`.
+  Action: run `<launcher> revise --plan <name>`, then continue back through `critique` and `gate`.
 - Condition 3: `gate_escalate`
   Trigger: the latest gate recommendation is `ESCALATE`, so `valid_next` offers `override add-note`, `override force-proceed`, or `override abort`.
   Action: stop with `BREAKPOINT: GATE_ESCALATE`.
@@ -122,7 +123,7 @@ Gate decision tree for full, thorough, and extreme:
   Action: do not finalize yet. Use `orchestrator_guidance` plus `preflight_results` to fix the blocking checks through `revise`. On iteration 1, the guidance text may stay generic, so inspect `preflight_results` yourself before revising. If the blocker cannot be resolved safely without a user decision, stop with `BREAKPOINT: GATE_BLOCKED`.
 - Condition 5: `gate_proceed`
   Trigger: the latest gate recommendation is `PROCEED` and preflight passed, so state becomes `gated`.
-  Action: run `megaplan finalize --plan <name>`.
+  Action: run `<launcher> finalize --plan <name>`.
 
 Review routing for full, thorough, and extreme:
 - If `review` succeeds, the run is done.
@@ -132,7 +133,7 @@ Review routing for full, thorough, and extreme:
 
 ## 4. After Every Phase
 After every phase command, immediately run:
-`megaplan status --plan <name>`
+`<launcher> status --plan <name>`
 
 Then do all of the following before choosing the next command:
 - Re-read `state`, `next_step`, and `valid_next`.
@@ -143,7 +144,7 @@ Then do all of the following before choosing the next command:
   `Plan passed gate and preflight. Proceed to finalize.`
   `Gate says PROCEED but preflight blocked. Fix: <checks>.`
   `Gate escalated. Ask the user: force-proceed, add-note, or abort.`
-  `Score plateaued with recurring critiques the loop can't fix. Consider force-proceeding: \`megaplan override force-proceed --plan <name>\``
+  `Score plateaued with recurring critiques the loop can't fix. Consider force-proceeding: \`<launcher> override force-proceed --plan <name>\``
   `Score improving (<previous> -> <current>). Continue to revise.`
   `Score worsening (<previous> -> <current>). Investigate; the loop may be diverging.`
   `Gate recommends another iteration. Revise the plan.`
@@ -193,13 +194,13 @@ Review safeguards:
 
 Notes and interruption safeguards:
 - If the outer skill kills and relaunches you, start fresh with no reliable memory from the prior run.
-- After any note injection or relaunch, run `megaplan status --plan <name>` immediately, read the full `notes` array, and treat all notes as context.
+- After any note injection or relaunch, run `<launcher> status --plan <name>` immediately, read the full `notes` array, and treat all notes as context.
 - Treat the most recent note as the relaunch explanation, then resume from `next_step`; the CLI state machine is the source of truth.
 
 ## 7. Resume Protocol
 When the outer conversation resumes you with `SendMessage`, or when a new subagent is launched on an existing plan:
 1. Re-read the message carefully.
-2. Run `megaplan status --plan <name>`.
+2. Run `<launcher> status --plan <name>`.
 3. Read the full `notes` array.
 4. Resume from the current CLI state and `next_step`, not from memory.
 
@@ -210,22 +211,22 @@ Resume rules:
 - After resuming, continue autonomously until the next defined breakpoint or completion.
 
 ## 7A. Note Injection from Outer Skill
-- Use the stored `PLAN_NAME` for note and status calls. If it was not captured, run `megaplan list` and fall back to the most recent plan.
+- Use the stored `PLAN_NAME` for note and status calls. If it was not captured, run `<launcher> list` and fall back to the most recent plan.
 - Classify the user message: "add context for next phase" -> Option A, "change direction NOW" -> Option B, "just a question" -> answer without touching the run. Default to Option A unless the message clearly demands interruption.
-- Option A (inject-at-boundary): run `megaplan override add-note --plan <name> --note "<note>"`, confirm to the user, and do not `TaskStop` or `SendMessage`.
-- Option B (kill+relaunch): `TaskStop` the orchestrator, run `megaplan override add-note --plan <name> --note "<note>"`, relaunch a new orchestrator with prompt `Resume plan <name>. Run megaplan status to get current state, read all notes, and continue from where it left off.`, then confirm to the user.
+- Option A (inject-at-boundary): run `<launcher> override add-note --plan <name> --note "<note>"`, confirm to the user, and do not `TaskStop` or `SendMessage`.
+- Option B (kill+relaunch): `TaskStop` the orchestrator, run `<launcher> override add-note --plan <name> --note "<note>"`, relaunch a new orchestrator with prompt `Resume plan <name>. Run <launcher> status to get current state, read all notes, and continue from where it left off.`, then confirm to the user.
 - Latency: Option A can take up to one phase boundary; if that is not acceptable, the user should ask for Option B.
 
 ## 8. Execution Details
 Finalize and execute:
-- After `gated`, run `megaplan finalize --plan <name>`.
-- In auto-approve mode, run `megaplan execute --plan <name> --confirm-destructive`.
-- In review mode, stop with `BREAKPOINT: EXECUTE_APPROVAL`, then after approval run `megaplan execute --plan <name> --confirm-destructive --user-approved`.
+- After `gated`, run `<launcher> finalize --plan <name>`.
+- In auto-approve mode, run `<launcher> execute --plan <name> --confirm-destructive`.
+- In review mode, stop with `BREAKPOINT: EXECUTE_APPROVAL`, then after approval run `<launcher> execute --plan <name> --confirm-destructive --user-approved`.
 
 Per-batch execution:
 - If the execution briefing or CLI response indicates per-batch execution, continue batch by batch.
 - Batch numbering is global and 1-indexed.
-- Use `megaplan progress --plan <name>` between batch executions.
+- Use `<launcher> progress --plan <name>` between batch executions.
 - Re-run the same batch number after a timeout if needed; the harness will reconcile previously completed work.
 
 Execution loop end conditions:
@@ -234,18 +235,18 @@ Execution loop end conditions:
 
 ## 9. Overrides & Plan Editing
 Override rules:
-- `megaplan override add-note` is safe from any active state when you need to record new user direction without changing state.
-- `megaplan override force-proceed` from `critiqued` moves the run into `gated`. Use it only when the user clearly wants to override the gate.
-- `megaplan override force-proceed` cannot bypass a missing project directory or missing success criteria.
-- `megaplan override force-proceed` from `executed` moves the run to `done`. Use that only when the user explicitly accepts unresolved review issues.
-- `megaplan override abort` ends the run. Use it only when the user clearly wants to stop.
-- `megaplan override replan` is available from `critiqued`, `gated`, or `finalized`. Use it when the orchestrator itself needs to edit the plan directly instead of asking the revise worker to do it.
+- `<launcher> override add-note` is safe from any active state when you need to record new user direction without changing state.
+- `<launcher> override force-proceed` from `critiqued` moves the run into `gated`. Use it only when the user clearly wants to override the gate.
+- `<launcher> override force-proceed` cannot bypass a missing project directory or missing success criteria.
+- `<launcher> override force-proceed` from `executed` moves the run to `done`. Use that only when the user explicitly accepts unresolved review issues.
+- `<launcher> override abort` ends the run. Use it only when the user clearly wants to stop.
+- `<launcher> override replan` is available from `critiqued`, `gated`, or `finalized`. Use it when the orchestrator itself needs to edit the plan directly instead of asking the revise worker to do it.
 
 Replan behavior:
 - After `override replan`, read the latest plan file, edit it directly, then continue with `critique`.
 
 Step editing:
-- `megaplan step add`, `step remove`, and `step move` are available while the run is in `planned`, `critiqued`, `gated`, or `finalized`.
+- `<launcher> step add`, `step remove`, and `step move` are available while the run is in `planned`, `critiqued`, `gated`, or `finalized`.
 - Use them when you need to insert, remove, or reorder step sections without hand-editing the markdown.
 - After a step edit, re-check `status` and continue from the returned state.
 
@@ -261,28 +262,28 @@ When the workflow completes, return exactly this shape:
 
 ## 11. Command Reference
 Core commands:
-- `megaplan status --plan <name>`
-- `megaplan progress --plan <name>`
-- `megaplan audit --plan <name>`
+- `<launcher> status --plan <name>`
+- `<launcher> progress --plan <name>`
+- `<launcher> audit --plan <name>`
 
 Workflow commands:
-- `megaplan prep --plan <name>`
-- `megaplan plan --plan <name>`
-- `megaplan critique --plan <name>`
-- `megaplan gate --plan <name>`
-- `megaplan revise --plan <name>`
-- `megaplan finalize --plan <name>`
-- `megaplan execute --plan <name> --confirm-destructive`
-- `megaplan execute --plan <name> --confirm-destructive --user-approved`
-- `megaplan execute --plan <name> --confirm-destructive --user-approved --batch N`
-- `megaplan review --plan <name>`
+- `<launcher> prep --plan <name>`
+- `<launcher> plan --plan <name>`
+- `<launcher> critique --plan <name>`
+- `<launcher> gate --plan <name>`
+- `<launcher> revise --plan <name>`
+- `<launcher> finalize --plan <name>`
+- `<launcher> execute --plan <name> --confirm-destructive`
+- `<launcher> execute --plan <name> --confirm-destructive --user-approved`
+- `<launcher> execute --plan <name> --confirm-destructive --user-approved --batch N`
+- `<launcher> review --plan <name>`
 
 Override and editing commands:
-- `megaplan override add-note --plan <name> --note "..."`
-- `megaplan override force-proceed --plan <name> --reason "..."`
-- `megaplan override replan --plan <name> --reason "..." [--note "..."]`
-- `megaplan override abort --plan <name> --reason "..."`
-- `megaplan step add --plan <name> --after S<N> "description"`
-- `megaplan step remove --plan <name> S<N>`
-- `megaplan step move --plan <name> S<N> --after S<M>`
+- `<launcher> override add-note --plan <name> --note "..."`
+- `<launcher> override force-proceed --plan <name> --reason "..."`
+- `<launcher> override replan --plan <name> --reason "..." [--note "..."]`
+- `<launcher> override abort --plan <name> --reason "..."`
+- `<launcher> step add --plan <name> --after S<N> "description"`
+- `<launcher> step remove --plan <name> S<N>`
+- `<launcher> step move --plan <name> S<N> --after S<M>`
 ```

--- a/arnold/pipelines/megaplan/data/instructions.md
+++ b/arnold/pipelines/megaplan/data/instructions.md
@@ -1,19 +1,19 @@
 # Megaplan
 
-> **Before you invoke megaplan, run the `megaplan-prep` skill.** It's the front door for every run: it sizes the work (one plan vs. an epic), shapes the brief, and picks the profile (intelligence tier), robustness level, and thinking depth. Do not run `megaplan init` without it.
+> **Before you invoke megaplan, run the `megaplan-prep` skill.** It's the front door for every run: it sizes the work (one plan vs. an epic), shapes the brief, and picks the profile (intelligence tier), robustness level, and thinking depth. Do not run `<launcher> init` without it.
 
 **Scope:** This skill covers tooling — how to invoke and drive megaplan. For the decisions that come *before* invocation (scoping, brief, profile, robustness, depth), consult the **megaplan-prep** skill. If anything here contradicts megaplan-prep on decision-making content, megaplan-prep wins.
 
-Route every step through the `megaplan` CLI. Never call agents directly.
-Before the first CLI call, resolve a working launcher and reuse it for the whole run. Do not assume `megaplan` itself is on `PATH`; command presence alone is not enough. Prove the launcher works by successfully running a harmless CLI call with it first. In the instructions below, treat `<launcher>` as that verified command.
+Route every step through the Arnold CLI's Megaplan subcommands. Never call agents directly.
+Before the first CLI call, resolve a working launcher and reuse it for the whole run. Do not assume the removed `megaplan` entrypoint is on `PATH`; command presence alone is not enough. Prove the launcher works by successfully running a harmless CLI call with it first. In the instructions below, treat `<launcher>` as that verified command.
 Launcher resolution order:
 1. Try `python -m arnold.pipelines.megaplan config show`.
 2. If that fails, try `./.venv/bin/python -m arnold.pipelines.megaplan config show`.
 3. If that fails, try `uv run python -m arnold.pipelines.megaplan config show`.
-4. If that fails, try a version-selected shim such as `PYENV_VERSION=3.11.11 arnold config show`.
-5. Only use bare `megaplan ...` if that exact form already succeeded during this check.
+4. If those fail, stop and report that the Arnold Megaplan module launcher is unavailable.
+5. Do not use the removed `megaplan` module or console entrypoint; the repo-root `megaplan.py` file is a clean-break guard.
 ## Triage
-Decision-making (scoping, profile, robustness, depth, brief structure) lives in the **megaplan-prep** skill — consult it before running `megaplan init`. **Always run megaplan, even for tiny work** — `bare` robustness is the floor, never skip the harness. The few seconds of overhead pay back in the captured brief, plan, and outcome record.
+Decision-making (scoping, profile, robustness, depth, brief structure) lives in the **megaplan-prep** skill — consult it before running `<launcher> init`. **Always run megaplan, even for tiny work** — `bare` robustness is the floor, never skip the harness. The few seconds of overhead pay back in the captured brief, plan, and outcome record.
 ## Modes
 Megaplan has two output modes, picked with `--mode` at `init`:
 - **`--mode code`** (default): the run produces a code diff. Execute workers emit per-task file changes. Use for features, refactors, bug fixes, migrations — anything whose deliverable is source code.
@@ -85,27 +85,27 @@ At `--robustness extreme`, the loop is the same as thorough but also enables par
 - `review`: judge success against the success criteria and the user's intent, not plan elegance. Only block on `must` criteria failures. `should` failures are flagged but don't require rework. `info` criteria are waived.
 ## Gate Principle
 The gate response tells the orchestrator what to do next. Follow `orchestrator_guidance` unless you have a concrete reason to disagree after investigating the repository or plan artifacts yourself.
-Investigate before disagreeing: read the current plan and critique artifacts, check the project code to verify whether a flagged issue is real, or use `megaplan status --plan <name>` / `megaplan audit --plan <name>`.
+Investigate before disagreeing: read the current plan and critique artifacts, check the project code to verify whether a flagged issue is real, or use `<launcher> status --plan <name>` / `<launcher> audit --plan <name>`.
 If you disagree with the guidance, explain why briefly and use an override. Do not manually reinterpret score trajectory, flag quality, or loop state when the gate already did that work for you.
 ## Execute
-- After a successful gate, run `megaplan finalize` to produce the execution-ready briefing document.
-- In auto-approve mode, run `megaplan execute --confirm-destructive` after finalize.
+- After a successful gate, run `<launcher> finalize` to produce the execution-ready briefing document.
+- In auto-approve mode, run `<launcher> execute --confirm-destructive` after finalize.
 - In review mode, pause at the finalize-to-execute checkpoint and wait for explicit approval before running:
 ```bash
-arnold execute --confirm-destructive --user-approved
+<launcher> execute --confirm-destructive --user-approved
 ```
 ## Long-Running Execution
 For plans with multiple batches, use per-batch mode to drive execution incrementally:
 ```bash
-arnold execute --plan <name> --confirm-destructive --user-approved --batch 1
-arnold execute --plan <name> --confirm-destructive --user-approved --batch 2
+<launcher> execute --plan <name> --confirm-destructive --user-approved --batch 1
+<launcher> execute --plan <name> --confirm-destructive --user-approved --batch 2
 # ... continue until all batches complete
 ```
 Between batches, poll progress:
 ```bash
-megaplan progress --plan <name>
+<launcher> progress --plan <name>
 ```
-Use `megaplan status --plan <name>` for the full plan state, including active-step timing and any `next_step_runtime` guidance from the latest response.
+Use `<launcher> status --plan <name>` for the full plan state, including active-step timing and any `next_step_runtime` guidance from the latest response.
 Per-batch mode uses global batch numbering (1-indexed, computed from ALL tasks). Each `--batch N` call:
 - Validates that batches 1..N-1 are complete
 - Executes only batch N's tasks
@@ -114,23 +114,23 @@ Per-batch mode uses global batch numbering (1-indexed, computed from ALL tasks).
 Timeout recovery: re-run the same `--batch N`. The harness checks prerequisite completion and merges only untracked tasks.
 Note: `progress` shows completed state only (between-batch granularity). With per-batch mode, each batch is a separate CLI call, so the orchestrator has full visibility.
 ## Overrides
-- `megaplan override add-note --plan <name> --note "..."`
-- `megaplan override force-proceed --plan <name> --reason "..."`
-- `megaplan override replan --plan <name> --reason "..." [--note "..."]`
-- `megaplan override abort --plan <name> --reason "..."`
+- `<launcher> override add-note --plan <name> --note "..."`
+- `<launcher> override force-proceed --plan <name> --reason "..."`
+- `<launcher> override replan --plan <name> --reason "..." [--note "..."]`
+- `<launcher> override abort --plan <name> --reason "..."`
 `force-proceed` is available from `critiqued` (routes to finalize, not execute). `replan` is available from `gated`, `finalized`, or `critiqued`. `add-note` is safe from any active state.
 ## Replan
 Use `replan` when the orchestrator itself needs to edit the plan directly instead of asking the revise worker to do it.
 ```bash
-megaplan override replan --plan <name> --reason "expanding scope" --note "Also clean up the display layer"
+<launcher> override replan --plan <name> --reason "expanding scope" --note "Also clean up the display layer"
 ```
-After `replan`, read the returned plan file, edit it directly, then run `megaplan critique`.
+After `replan`, read the returned plan file, edit it directly, then run `<launcher> critique`.
 ## Step Editing
 Use `step` when you need to insert, remove, or reorder step sections (`## Step N:` or `### Step N:`) without hand-editing the markdown.
 ```bash
-megaplan step add --plan <name> --after S3 "Add regression coverage for the parser"
-megaplan step remove --plan <name> S4
-megaplan step move --plan <name> S4 --after S2
+<launcher> step add --plan <name> --after S3 "Add regression coverage for the parser"
+<launcher> step remove --plan <name> S4
+<launcher> step move --plan <name> S4 --after S2
 ```
 Each edit writes a new same-iteration plan artifact, preserves the latest plan meta questions/success criteria/assumptions, and resets the plan to `planned` so it re-enters critique.
 ## Sessions And Autonomy
@@ -141,14 +141,14 @@ Each edit writes a new same-iteration plan artifact, preserves the latest plan m
 - Keep moving and show results at each step.
 - Only pause at finalize to execute in review mode.
 ## Configuration
-View current defaults with `megaplan config show`. Override with `megaplan config set <key> <value>`. Reset with `megaplan config reset`.
-When routing or behavior depends on config, check `megaplan config show` and respect user overrides instead of assuming defaults.
+View current defaults with `<launcher> config show`. Override with `<launcher> config set <key> <value>`. Reset with `<launcher> config reset`.
+When routing or behavior depends on config, check `<launcher> config show` and respect user overrides instead of assuming defaults.
 Settable execution keys: `execution.auto_approve`, `execution.robustness`.
 ## Profiles
 A profile is a named preset that maps each workflow phase to an agent/model spec. Pass `--profile <name>` to any command that accepts `--phase-model` (`init`, `loop-init`, `tiebreaker`, etc.) to apply the preset.
-See **megaplan-prep** for profile selection. Inspect available profiles with `megaplan config profiles list`.
+See **megaplan-prep** for profile selection. Inspect available profiles with `<launcher> config profiles list`.
 Resolution order, later overrides earlier within the same name: built-in (`megaplan/profiles/*.toml`) → user (`~/.config/megaplan/profiles.toml`, or `$XDG_CONFIG_HOME/megaplan/profiles.toml`) → project (`<project_dir>/.megaplan/profiles.toml`).
-Inspect with `megaplan config profiles list` and `megaplan config profiles show <name>`.
+Inspect with `<launcher> config profiles list` and `<launcher> config profiles show <name>`.
 File format: TOML with a `[profiles.<name>]` table. Keys are phase names (`plan`, `prep`, `critique`, `revise`, `gate`, `finalize`, `execute`, `loop_plan`, `loop_execute`, `review`, `tiebreaker_researcher`, `tiebreaker_challenger`); values are agent specs like `"claude"`, `"codex"`, `"hermes:fireworks:accounts/fireworks/models/kimi-k2p6"`, `"hermes:glm-5.1"`. Example:
 ```toml
 [profiles.my-mix]
@@ -161,80 +161,80 @@ review   = "codex"
 ## Bakeoff
 See the **bakeoff** skill for methodology and the **megaplan-prep** skill for when bake-offs earn their cost. This section covers the CLI mechanics once you've decided to run one.
 
-`megaplan bakeoff run` runs the same idea through multiple profiles concurrently, each in its own git worktree, each driven autonomously by `megaplan auto`. Use it when the user wants to compare profiles head-to-head on the same task (e.g., "run this with kimi and the default profile side-by-side").
-Supports `--mode code` (default) and `--mode doc` / `--mode metaplan` (alias). For doc-mode bake-offs, `--output <relative/path>` is required and is threaded into each profile's `megaplan init`; merge brings the chosen profile's doc artifact back to main instead of applying a code patch. Joke mode is not yet supported.
+`<launcher> bakeoff run` runs the same idea through multiple profiles concurrently, each in its own git worktree, each driven autonomously by `<launcher> auto`. Use it when the user wants to compare profiles head-to-head on the same task (e.g., "run this with kimi and the default profile side-by-side").
+Supports `--mode code` (default) and `--mode doc` / `--mode metaplan` (alias). For doc-mode bake-offs, `--output <relative/path>` is required and is threaded into each profile's `<launcher> init`; merge brings the chosen profile's doc artifact back to main instead of applying a code patch. Joke mode is not yet supported.
 Requires a clean main worktree by default — pass `--allow-dirty` when there are unrelated uncommitted changes you want to keep on main. Those changes stay on main and are NOT copied into the worktrees, since worktrees branch off the current commit's SHA.
 The idea must be a file (`--idea-file <path>`), not an inline string. Write the idea to a file first.
-Bakeoff is inherently autonomous (it spawns `megaplan auto`), so the execution-mode question doesn't apply to bakeoff runs. `--robustness` is forwarded to each profile's `init`. When a project-layer `.megaplan/profiles.toml` exists, it's automatically copied into each worktree so project-only profiles resolve.
+Bakeoff is inherently autonomous (it spawns `<launcher> auto`), so the execution-mode question doesn't apply to bakeoff runs. `--robustness` is forwarded to each profile's `init`. When a project-layer `.megaplan/profiles.toml` exists, it's automatically copied into each worktree so project-only profiles resolve.
 Lifecycle:
-- `megaplan bakeoff run --idea-file <path> --profiles <p1> <p2> [--mode code|doc|metaplan] [--output <relative/path>] [--exp-id <id>] [--detach] [--robustness <level>] [--allow-dirty]` — kicks off N concurrent profile runs. Without `--detach` it streams a live status table every 5s and blocks until all profiles finish; with `--detach` it returns immediately and the user polls via `status`. `--output` is required with `--mode doc|metaplan` and rejected with `--mode code`.
-- `megaplan bakeoff status [--exp <id>]` — current state of each profile (running / completed / crashed).
-- `megaplan bakeoff tail [--exp <id>]` — tail the per-profile auto logs.
-- `megaplan bakeoff compare --exp <id> [--judge <model>]` — collect metrics across profiles; with `--judge`, an LLM judge ranks the outputs.
-- `megaplan bakeoff pick --exp <id> --profile <name> --rationale "..."` — record the human-selected winner.
-- `megaplan bakeoff merge --exp <id>` — merge the chosen profile's worktree back to main.
-- `megaplan bakeoff resume --exp <id>` — resume unfinished profile runs.
-- `megaplan bakeoff abandon --exp <id>` — discard worktrees but keep audit data.
+- `<launcher> bakeoff run --idea-file <path> --profiles <p1> <p2> [--mode code|doc|metaplan] [--output <relative/path>] [--exp-id <id>] [--detach] [--robustness <level>] [--allow-dirty]` — kicks off N concurrent profile runs. Without `--detach` it streams a live status table every 5s and blocks until all profiles finish; with `--detach` it returns immediately and the user polls via `status`. `--output` is required with `--mode doc|metaplan` and rejected with `--mode code`.
+- `<launcher> bakeoff status [--exp <id>]` — current state of each profile (running / completed / crashed).
+- `<launcher> bakeoff tail [--exp <id>]` — tail the per-profile auto logs.
+- `<launcher> bakeoff compare --exp <id> [--judge <model>]` — collect metrics across profiles; with `--judge`, an LLM judge ranks the outputs.
+- `<launcher> bakeoff pick --exp <id> --profile <name> --rationale "..."` — record the human-selected winner.
+- `<launcher> bakeoff merge --exp <id>` — merge the chosen profile's worktree back to main.
+- `<launcher> bakeoff resume --exp <id>` — resume unfinished profile runs.
+- `<launcher> bakeoff abandon --exp <id>` — discard worktrees but keep audit data.
 ## Cloud Mode
-`megaplan cloud` runs a plan inside a provider-managed container with a persistent workspace volume, so the run survives the user's terminal session. Suggest it for long-running plans that would outlast a local session, multi-repo work, or when the user wants an isolated persistent sandbox. Sprint 1 ships the `railway` provider only; `ssh` and `local` are planned.
+`<launcher> cloud` runs a plan inside a provider-managed container with a persistent workspace volume, so the run survives the user's terminal session. Suggest it for long-running plans that would outlast a local session, multi-repo work, or when the user wants an isolated persistent sandbox. Sprint 1 ships the `railway` provider only; `ssh` and `local` are planned.
 
-Quick subcommand reference: `init`, `build`, `deploy`, `chain`, `status`, `attach`, `logs`, `exec`, `resume`, `down`, `destroy`. Typical flow: `megaplan cloud init` → edit `cloud.yaml` → export secrets → `megaplan cloud deploy` → `megaplan cloud chain <chain.yaml>`.
+Quick subcommand reference: `init`, `build`, `deploy`, `chain`, `status`, `attach`, `logs`, `exec`, `resume`, `down`, `destroy`. Typical flow: `<launcher> cloud init` → edit `cloud.yaml` → export secrets → `<launcher> cloud deploy` → `<launcher> cloud chain <chain.yaml>`.
 
 For the full reference — `cloud.yaml` fields, the `extra_repos[]` + `chain_session` multi-tenancy model, the operator loop, and the gotchas that wedge fresh runs (committed `chain_state.json`, profile-alias gap, secret-upload behavior, "internal_error" masking credit failures) — see the **megaplan-cloud** skill. Read it before launching the first cloud chain in a new project; the gotchas section will save hours.
 ## Tickets
-`megaplan ticket new` creates a repo-scoped issue ticket. Use it when:
+`<launcher> ticket new` creates a repo-scoped issue ticket. Use it when:
 - During epic/plan work you notice an out-of-scope problem, bug, or rough edge
 - A user explicitly asks you to capture something for later attention
 - You want to log an observation that doesn't block the current task but should be tracked
 
-The command prints only a ULID to stdout on success. Tickets live as `.megaplan/tickets/{ulid}-{slug}.md` files and are auto-discovered by the planner for future epics. Link them to epics with `megaplan ticket link <ticket> <epic> --resolves` so they auto-address when the epic completes.
+The command prints only a ULID to stdout on success. Tickets live as `.megaplan/tickets/{ulid}-{slug}.md` files and are auto-discovered by the planner for future epics. Link them to epics with `<launcher> ticket link <ticket> <epic> --resolves` so they auto-address when the epic completes.
 
 ## Briefs
-`megaplan brief` creates canonical source artifacts for work you intend to run.
+`<launcher> brief` creates canonical source artifacts for work you intend to run.
 Use it when:
 - You are turning an idea into a durable single-plan input
 - You are scaffolding an epic's `chain.yaml` and milestone idea files
-- You want the source document committed before `megaplan init` snapshots it into plan state
+- You want the source document committed before `<launcher> init` snapshots it into plan state
 
 Briefs live as committed files under `.megaplan/briefs/`. Single-plan ideas live
 at `.megaplan/briefs/{slug}.md`; epics live at
 `.megaplan/briefs/{epic-slug}/chain.yaml` with milestone briefs beside the chain
 spec. This is ticket-like in storage and ergonomics, but not in lifecycle:
-briefs feed `megaplan init` / `megaplan chain start`; tickets are open problem
+briefs feed `<launcher> init` / `<launcher> chain start`; tickets are open problem
 notes that can be discovered, linked, and auto-addressed by epics.
 
 Briefs and tickets share the local artifact substrate: common `.megaplan/<kind>/`
 path handling, slug normalization, optional frontmatter parsing, keyword
-filtering, and snippets. Use `megaplan brief list`, `megaplan brief show`, and
-`megaplan brief search` for the brief side of that common read surface.
+filtering, and snippets. Use `<launcher> brief list`, `<launcher> brief show`, and
+`<launcher> brief search` for the brief side of that common read surface.
 
-`megaplan init --idea-file <path>` reads the file and snapshots its text; it does
+`<launcher> init --idea-file <path>` reads the file and snapshots its text; it does
 not move arbitrary files into `.megaplan/briefs/`. If the idea file is a markdown
 artifact with YAML frontmatter, `init` snapshots only the markdown body. Use
-`megaplan brief new --init` to create the canonical source file first and then
+`<launcher> brief new --init` to create the canonical source file first and then
 initialize from it.
 
 ## Feedback
 See **megaplan-prep** for when to add the feedback phase (`--with-feedback`). This section covers the CLI mechanics once you've decided to use it.
 
-`megaplan feedback --plan <name>` scaffolds a `feedback.md` file in the plan directory and opens it in `$EDITOR` (or `$VISUAL`). The file has one section per workflow stage — `prep`, `plan`, `critique`, `revise`, `gate`, `tiebreaker`, `finalize`, `execute`, `review` — plus an `Overall` section. Each section has a `rating:` (integer 0–10) and a free-form `comment:` field; leave any field blank to skip it.
+`<launcher> feedback --plan <name>` scaffolds a `feedback.md` file in the plan directory and opens it in `$EDITOR` (or `$VISUAL`). The file has one section per workflow stage — `prep`, `plan`, `critique`, `revise`, `gate`, `tiebreaker`, `finalize`, `execute`, `review` — plus an `Overall` section. Each section has a `rating:` (integer 0–10) and a free-form `comment:` field; leave any field blank to skip it.
 
-This is **user feedback**, owned by the human after a run finishes — megaplan only scaffolds the template and parses it back on load, it never overwrites edits. Old plans without a `feedback.md` simply have no feedback attached; running `megaplan feedback --plan <name>` on an older plan scaffolds the template on demand (backwards compatible).
+This is **user feedback**, owned by the human after a run finishes — megaplan only scaffolds the template and parses it back on load, it never overwrites edits. Old plans without a `feedback.md` simply have no feedback attached; running `<launcher> feedback --plan <name>` on an older plan scaffolds the template on demand (backwards compatible).
 
-Use `megaplan feedback show --plan <name>` to print the parsed summary, and `--no-edit` to just scaffold the template and print the path without launching an editor. Parsed feedback is exposed on the in-memory `Plan` record as `Plan.feedback` (a dict shaped `{"overall": {...}, "stages": {stage: {...}}}`), so downstream tooling can read it the same way as any other artifact. When `--actor`/`MEGAPLAN_ACTOR_ID` is set, parsed feedback is also written to the `plans.feedback` jsonb column so the DB and file backends stay in sync.
+Use `<launcher> feedback show --plan <name>` to print the parsed summary, and `--no-edit` to just scaffold the template and print the path without launching an editor. Parsed feedback is exposed on the in-memory `Plan` record as `Plan.feedback` (a dict shaped `{"overall": {...}, "stages": {stage: {...}}}`), so downstream tooling can read it the same way as any other artifact. When `--actor`/`MEGAPLAN_ACTOR_ID` is set, parsed feedback is also written to the `plans.feedback` jsonb column so the DB and file backends stay in sync.
 
 ### Filling feedback with subagents
 Recommended process when an agent (rather than the human) is producing the initial assessment:
 
-1. **Scaffold**: run `megaplan feedback --plan <name> --no-edit` to create the empty `feedback.md`. Note the plan directory it prints — that is where the per-stage artifacts live (`plan_v*.md`, `critique*.json`, `gate.json`, `tiebreaker_*.json`, `finalize.json`, `execution*.json`, `review.json`, etc.).
+1. **Scaffold**: run `<launcher> feedback --plan <name> --no-edit` to create the empty `feedback.md`. Note the plan directory it prints — that is where the per-stage artifacts live (`plan_v*.md`, `critique*.json`, `gate.json`, `tiebreaker_*.json`, `finalize.json`, `execution*.json`, `review.json`, etc.).
 2. **Per-stage assessment**: dispatch one read-only subagent per stage that actually ran (skip stages with no artifacts). Brief each subagent narrowly — give it the plan idea, the stage name, and the artifact filenames for that stage only. Ask it to return a 0–10 rating plus a 1–3 sentence comment grounded in what the artifacts show (what worked, what was weak, what was missed). Run these in parallel; they have no dependencies on each other.
 3. **Synthesize Overall**: after the per-stage results come back, *you* (the orchestrating agent, not a subagent) read the per-stage ratings and comments together with the final outcome (`final.md`, `review.json`, any `latest_failure`) and decide an Overall rating and comment. The Overall is a judgment call about whether the run delivered the goal, not an average of stage ratings.
-4. **Write**: edit `feedback.md` with the ratings and comments. Leave a stage blank if it didn't run or you can't form a defensible opinion — empty is better than guessed. Run `megaplan feedback show --plan <name>` to confirm the parser picked everything up.
+4. **Write**: edit `feedback.md` with the ratings and comments. Leave a stage blank if it didn't run or you can't form a defensible opinion — empty is better than guessed. Run `<launcher> feedback show --plan <name>` to confirm the parser picked everything up.
 
 Keep comments grounded in specific artifact evidence ("critique flagged X but reviewer didn't catch the regression in Y") rather than vibes. The point of feedback is signal for future runs, not a participation score.
 
 ### Searching feedback across plans
-`megaplan feedback search` queries every plan with non-empty feedback across both backends — local `feedback.md` files in this project tree plus, when an actor is configured, the `plans.feedback` jsonb column in the DB. Duplicates between backends are de-duped by (plan name, project_dir). Use this to answer "which profile actually scored well on this repo?" or "where did the executor get a 6 or below?". Filters:
+`<launcher> feedback search` queries every plan with non-empty feedback across both backends — local `feedback.md` files in this project tree plus, when an actor is configured, the `plans.feedback` jsonb column in the DB. Duplicates between backends are de-duped by (plan name, project_dir). Use this to answer "which profile actually scored well on this repo?" or "where did the executor get a 6 or below?". Filters:
 - `--profile <substr>` — substring match on the plan's profile (e.g. `--profile claude` matches `all-claude`, `claude-led`, etc.).
 - `--repo <substr>` — substring match on the plan's `project_dir` / repo path.
 - `--min-rating N` / `--max-rating N` — bounds on the Overall rating.
@@ -243,68 +243,68 @@ Keep comments grounded in specific artifact evidence ("critique flagged X but re
 - `--all` — scan every megaplan project root on this machine, not just the current tree.
 - `--json` — emit raw rows instead of a table.
 
-Default output is a compact table (plan, profile, overall rating, backend, repo, plus the first line of the Overall comment). Combine with `megaplan feedback show --plan <name>` to drill into a specific match.
+Default output is a compact table (plan, profile, overall rating, backend, repo, plus the first line of the Overall comment). Combine with `<launcher> feedback show --plan <name>` to drill into a specific match.
 ## Observability
 Plans started after this layer landed write an append-only `events.ndjson` event journal to their plan dir. Four CLI surfaces read from it; reach for them whenever a run is in flight or you need to reconstruct what happened. See the **megaplan-observe** skill for the full failure-mode catalog and worked invocation chains.
 
-- `megaplan introspect --plan <name>` — single structured-JSON snapshot. Always check this first when something looks stuck; the `active_phase.liveness` enum (`progressing | quiet | stalled | timeout-imminent`) and `block_details.recoverable_via` together tell you whether to wait, intervene, or override. Also surfaces `outstanding_flags_count`, useful when a plan is sitting on unresolved critique signals.
-- `megaplan trace --plan <name> [--follow] [--format json|pretty|narrative] [--phase <p>] [--since <duration>]` — stream events. `narrative` format is the agent-facing affordance; `--follow` tails as the plan progresses; `--phase` and `--since` filter. Prints `trace: no events.ndjson for plan <name>` cleanly when a plan predates the journal.
-- `megaplan doctor [--plan <name> | --repo]` — diagnostic. `--repo` catches rubric/binary drift (skill profile names vs `profiles list`) and editable-install dirtiness *before* `megaplan init`, so reach for it after a branch switch / pull / fresh checkout. `--plan` reports lock, phase liveness, LLM liveness, cost-vs-cap, orphan subprocesses, and outstanding flags.
-- `megaplan record-tag --plan <name> --tag <name> --note "..."` — annotate a moment in the journal so later trace/introspect calls can find it. All three args are required.
+- `<launcher> introspect --plan <name>` — single structured-JSON snapshot. Always check this first when something looks stuck; the `active_phase.liveness` enum (`progressing | quiet | stalled | timeout-imminent`) and `block_details.recoverable_via` together tell you whether to wait, intervene, or override. Also surfaces `outstanding_flags_count`, useful when a plan is sitting on unresolved critique signals.
+- `<launcher> trace --plan <name> [--follow] [--format json|pretty|narrative] [--phase <p>] [--since <duration>]` — stream events. `narrative` format is the agent-facing affordance; `--follow` tails as the plan progresses; `--phase` and `--since` filter. Prints `trace: no events.ndjson for plan <name>` cleanly when a plan predates the journal.
+- `<launcher> doctor [--plan <name> | --repo]` — diagnostic. `--repo` catches rubric/binary drift (skill profile names vs `profiles list`) and editable-install dirtiness *before* `<launcher> init`, so reach for it after a branch switch / pull / fresh checkout. `--plan` reports lock, phase liveness, LLM liveness, cost-vs-cap, orphan subprocesses, and outstanding flags.
+- `<launcher> record-tag --plan <name> --tag <name> --note "..."` — annotate a moment in the journal so later trace/introspect calls can find it. All three args are required.
 
 Stale-timestamp inference, opaque blocked state, and "model thinking vs TCP wedged" are the three confusions this layer is designed to kill — if you find yourself running `lsof`, `ps`, or doing manual `ls -lat` time math on a plan dir, you should be running `introspect` or `trace` instead.
 ## Commands
 ```bash
-arnold status --plan <name>
-megaplan progress --plan <name>
-megaplan audit --plan <name>
-megaplan list
-megaplan prep --plan <name>
-megaplan plan --plan <name>
-megaplan critique --plan <name>
-megaplan revise --plan <name>
-megaplan gate --plan <name>
-megaplan finalize --plan <name>
-arnold execute --plan <name> --confirm-destructive [--batch N]
-arnold review --plan <name>
-megaplan step add --plan <name> [--after S<N>] "description"
-megaplan step remove --plan <name> S<N>
-megaplan step move --plan <name> S<N> --after S<M>
-megaplan override add-note --plan <name> --note "..."
-megaplan override force-proceed --plan <name> --reason "..."
-megaplan override replan --plan <name> --reason "..." [--note "..."]
-megaplan override abort --plan <name> --reason "..."
-arnold config show
-arnold config set <key> <value>
-arnold config reset
-arnold config profiles list
-arnold config profiles show <name>
-megaplan bakeoff run --idea-file <path> --profiles <p1> <p2> [--mode code|doc|metaplan] [--output <relative/path>] [--exp-id <id>] [--detach] [--robustness <level>] [--allow-dirty]
-megaplan bakeoff status [--exp <id>]
-megaplan bakeoff tail [--exp <id>]
-megaplan bakeoff compare --exp <id> [--judge <model>]
-megaplan bakeoff pick --exp <id> --profile <name> --rationale "..."
-megaplan bakeoff merge --exp <id>
-megaplan bakeoff resume --exp <id>
-megaplan bakeoff abandon --exp <id>
-megaplan brief new <slug> [-b <body> | --from <path> | -] [--force] [--init]
-megaplan brief epic <slug> --milestone LABEL=TITLE [--base-branch <branch>] [--force]
-megaplan brief list [--json]
-megaplan brief show <id-or-path> [--json]
-megaplan brief search [KW ...] [--all] [--sort path|title|length] [--desc] [--limit N] [--json]
-megaplan ticket new "title" -b "body"
-megaplan ticket list [--status <s>] [--tags <t>] [--json]
-megaplan ticket show <id> [--json]
-megaplan ticket edit <id> [--title <t>] [--body <b>] [--status <s>]
-megaplan ticket link <ticket> <epic> [--resolves]
-megaplan ticket unlink <ticket> <epic>
-megaplan ticket addressed <id> [--note <n>]
-megaplan ticket dismiss <id> --reason "..."
-megaplan ticket reopen <id>
-megaplan feedback show --plan <name> [--no-edit]
-megaplan feedback search [--profile <s>] [--repo <s>] [--min-rating N] [--max-rating N] [--stage <name>] [--has-comment] [--all] [--json]
-megaplan introspect --plan <name> [--json]
-megaplan trace --plan <name> [--follow] [--format json|pretty|narrative] [--phase <p>] [--since <duration>]
-megaplan doctor [--plan <name> | --repo]
-megaplan record-tag --plan <name> --tag <name> --note "..."
+<launcher> status --plan <name>
+<launcher> progress --plan <name>
+<launcher> audit --plan <name>
+<launcher> list
+<launcher> prep --plan <name>
+<launcher> plan --plan <name>
+<launcher> critique --plan <name>
+<launcher> revise --plan <name>
+<launcher> gate --plan <name>
+<launcher> finalize --plan <name>
+<launcher> execute --plan <name> --confirm-destructive [--batch N]
+<launcher> review --plan <name>
+<launcher> step add --plan <name> [--after S<N>] "description"
+<launcher> step remove --plan <name> S<N>
+<launcher> step move --plan <name> S<N> --after S<M>
+<launcher> override add-note --plan <name> --note "..."
+<launcher> override force-proceed --plan <name> --reason "..."
+<launcher> override replan --plan <name> --reason "..." [--note "..."]
+<launcher> override abort --plan <name> --reason "..."
+<launcher> config show
+<launcher> config set <key> <value>
+<launcher> config reset
+<launcher> config profiles list
+<launcher> config profiles show <name>
+<launcher> bakeoff run --idea-file <path> --profiles <p1> <p2> [--mode code|doc|metaplan] [--output <relative/path>] [--exp-id <id>] [--detach] [--robustness <level>] [--allow-dirty]
+<launcher> bakeoff status [--exp <id>]
+<launcher> bakeoff tail [--exp <id>]
+<launcher> bakeoff compare --exp <id> [--judge <model>]
+<launcher> bakeoff pick --exp <id> --profile <name> --rationale "..."
+<launcher> bakeoff merge --exp <id>
+<launcher> bakeoff resume --exp <id>
+<launcher> bakeoff abandon --exp <id>
+<launcher> brief new <slug> [-b <body> | --from <path> | -] [--force] [--init]
+<launcher> brief epic <slug> --milestone LABEL=TITLE [--base-branch <branch>] [--force]
+<launcher> brief list [--json]
+<launcher> brief show <id-or-path> [--json]
+<launcher> brief search [KW ...] [--all] [--sort path|title|length] [--desc] [--limit N] [--json]
+<launcher> ticket new "title" -b "body"
+<launcher> ticket list [--status <s>] [--tags <t>] [--json]
+<launcher> ticket show <id> [--json]
+<launcher> ticket edit <id> [--title <t>] [--body <b>] [--status <s>]
+<launcher> ticket link <ticket> <epic> [--resolves]
+<launcher> ticket unlink <ticket> <epic>
+<launcher> ticket addressed <id> [--note <n>]
+<launcher> ticket dismiss <id> --reason "..."
+<launcher> ticket reopen <id>
+<launcher> feedback show --plan <name> [--no-edit]
+<launcher> feedback search [--profile <s>] [--repo <s>] [--min-rating N] [--max-rating N] [--stage <name>] [--has-comment] [--all] [--json]
+<launcher> introspect --plan <name> [--json]
+<launcher> trace --plan <name> [--follow] [--format json|pretty|narrative] [--phase <p>] [--since <duration>]
+<launcher> doctor [--plan <name> | --repo]
+<launcher> record-tag --plan <name> --tag <name> --note "..."
 ```

--- a/arnold/pipelines/megaplan/data/pre-commit-hook.sh
+++ b/arnold/pipelines/megaplan/data/pre-commit-hook.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 # Regenerate composed bundles; fail if any changed.
 #
 # Launcher resolution mirrors the megaplan SKILL.md order so the hook works
-# regardless of how python is exposed on this machine (pyenv shim, venv,
+# regardless of how python is exposed on this machine (pyenv, venv,
 # uv, etc.). The first launcher whose `setup --regen-composed` returns
 # 0 or 1 wins; an error like `command not found` falls through to the next.
 LAUNCHERS=(
@@ -16,7 +16,7 @@ LAUNCHERS=(
 run_regen() {
   local cmd="$1"
   # shellcheck disable=SC2086
-  eval "$cmd -m megaplan setup --regen-composed"
+  eval "$cmd -m arnold.pipelines.megaplan setup --regen-composed"
 }
 
 rc=127
@@ -36,7 +36,7 @@ for launcher in "${LAUNCHERS[@]}"; do
 done
 
 if [ "$rc" = "1" ]; then
-  git add megaplan/data/_composed/
+  git add arnold/pipelines/megaplan/data/_composed/
   echo 'megaplan: regenerated composed bundles — re-run git commit' >&2
   exit 1
 fi

--- a/docs/arnold/authoring-guide.md
+++ b/docs/arnold/authoring-guide.md
@@ -82,6 +82,9 @@ up logic. Copy the `_template` package (at `arnold/pipelines/_template/`) as a
 starting point — it comes pre-wired with the full contract surface and a
 `SKILL.md` quickstart.
 
+For custom graph wiring, start from `Pipeline.builder("my-module")`, add typed
+stages and edges through the builder, then call `.build()` from `build_pipeline()`.
+
 ### Typed Ports
 
 When stages produce or consume typed data, declare ports via the ``produces``

--- a/docs/cloud.md
+++ b/docs/cloud.md
@@ -1,8 +1,8 @@
 # Megaplan Cloud
 
-`megaplan cloud` keeps cloud orchestration thin. Core megaplan owns plan, auto, and chain behavior; cloud subcommands stage files, pick a transport, and run the core commands remotely.
+`python -m arnold.pipelines.megaplan cloud` keeps cloud orchestration thin. Core megaplan owns plan, auto, and chain behavior; cloud subcommands stage files, pick a transport, and run the core commands remotely.
 
-Examples below use `megaplan ...`; in this repo run `./.venv/bin/python -m megaplan ...`. Add `--cloud-yaml /path/to/cloud.yaml` when `cloud.yaml` is not at the project root.
+Examples below use `python -m arnold.pipelines.megaplan ...`; reuse that verified module launcher for every cloud command. Add `--cloud-yaml /path/to/cloud.yaml` when `cloud.yaml` is not at the project root.
 
 ## Providers
 
@@ -19,7 +19,7 @@ Examples below use `megaplan ...`; in this repo run `./.venv/bin/python -m megap
 1. Scaffold:
 
 ```bash
-megaplan cloud init
+python -m arnold.pipelines.megaplan cloud init
 ```
 
 2. Edit `cloud.yaml` for repo, provider, mode, secrets, and optional toolchains.
@@ -37,24 +37,24 @@ export ANTHROPIC_API_KEY=...   # optional
 4. Build and deploy:
 
 ```bash
-megaplan cloud build
-megaplan cloud deploy
+python -m arnold.pipelines.megaplan cloud build
+python -m arnold.pipelines.megaplan cloud deploy
 ```
 
 5. Start work remotely:
 
 ```bash
-megaplan cloud bootstrap .megaplan/briefs/tiny-plan.md
-megaplan cloud chain .megaplan/briefs/my-epic/chain.yaml
+python -m arnold.pipelines.megaplan cloud bootstrap .megaplan/briefs/tiny-plan.md
+python -m arnold.pipelines.megaplan cloud chain .megaplan/briefs/my-epic/chain.yaml
 ```
 
 6. Inspect and connect:
 
 ```bash
-megaplan cloud status
-megaplan cloud status --chain
-megaplan cloud logs
-megaplan cloud attach
+python -m arnold.pipelines.megaplan cloud status
+python -m arnold.pipelines.megaplan cloud status --chain
+python -m arnold.pipelines.megaplan cloud logs
+python -m arnold.pipelines.megaplan cloud attach
 ```
 
 ## `cloud.yaml` Reference
@@ -65,7 +65,7 @@ megaplan cloud attach
 |---|---|---:|---|
 | `provider` | no | `railway` | One of `railway`, `local`, or `ssh`. |
 | `mode` | no | `idle` | Runner mode: `auto`, `chain`, or `idle`. |
-| `secrets` | no | `[]` | Local env var names uploaded during `megaplan cloud deploy` and redacted from cloud log output where possible. |
+| `secrets` | no | `[]` | Local env var names uploaded during `python -m arnold.pipelines.megaplan cloud deploy` and redacted from cloud log output where possible. |
 | `toolchains` | no | `[]` | Extra language toolchains layered into the image. Use aliases `rust`, `go`, `java`, or `{name, install}` mappings. |
 
 ### `repo`
@@ -99,7 +99,7 @@ Used only when `mode: auto`.
 
 | Field | Required in `auto` mode | Default | Meaning |
 |---|---|---:|---|
-| `auto.plan_name` | yes | none | Remote plan name for boot-time `megaplan auto --plan ...`. |
+| `auto.plan_name` | yes | none | Remote plan name for boot-time `python -m arnold.pipelines.megaplan auto --plan ...`. |
 | `auto.idea_file` | yes | none | Absolute remote path to the idea file already staged on the workspace volume. |
 | `auto.robustness` | no | `standard` | Robustness for the boot-time init fallback. |
 
@@ -166,17 +166,17 @@ toolchains:
 
 ## Wrapper Workflows
 
-### `megaplan cloud bootstrap <idea-file>`
+### `python -m arnold.pipelines.megaplan cloud bootstrap <idea-file>`
 
 `cloud bootstrap` uploads a local idea file to `<repo.workspace>/idea.txt`, then runs:
 
 ```bash
-megaplan init --project-dir <workspace> --idea-file <workspace>/idea.txt --auto-start --robustness <level>
+python -m arnold.pipelines.megaplan init --project-dir <workspace> --idea-file <workspace>/idea.txt --auto-start --robustness <level>
 ```
 
 `--plan-name` is optional. If omitted, cloud does **not** pass `--name`; core megaplan chooses the default slug from the idea text.
 
-### `megaplan cloud chain <spec> [--idea-dir <dir>]`
+### `python -m arnold.pipelines.megaplan cloud chain <spec> [--idea-dir <dir>]`
 
 `cloud chain` is the preferred path for remote chain runs. It:
 
@@ -184,7 +184,7 @@ megaplan init --project-dir <workspace> --idea-file <workspace>/idea.txt --auto-
 2. Resolves each milestone idea file from `--idea-dir` or, by default, the local spec's parent directory.
 3. Uploads each idea file to the remote path named in the chain spec.
 4. Uploads the chain spec to `<repo.workspace>/chain.yaml`.
-5. Starts remote `megaplan chain start --spec <repo.workspace>/chain.yaml` in tmux session `megaplan-chain`, logging to `<repo.workspace>/.megaplan/cloud-chain.log`.
+5. Starts remote `python -m arnold.pipelines.megaplan chain start --spec <repo.workspace>/chain.yaml` in tmux session `megaplan-chain`, logging to `<repo.workspace>/.megaplan/cloud-chain.log`.
 
 After upload + dispatch, cloud writes a provider-independent marker:
 
@@ -194,7 +194,7 @@ After upload + dispatch, cloud writes a provider-independent marker:
 
 That marker survives Railway's ephemeral deploy dir and is used by `cloud status --chain`.
 
-### `megaplan cloud status --chain`
+### `python -m arnold.pipelines.megaplan cloud status --chain`
 
 `cloud status --chain` fetches remote `chain_state.json`, then reuses core chain status formatting. Remote spec resolution precedence is:
 
@@ -203,13 +203,13 @@ That marker survives Railway's ephemeral deploy dir and is used by `cloud status
 3. `spec.chain.spec` from `cloud.yaml` when `mode: chain`
 4. Otherwise `missing_remote_spec`
 
-The command prints the structured payload on stdout and the same human-readable chain summary block that local `megaplan chain status --spec ...` prints on stderr.
+The command prints the structured payload on stdout and the same human-readable chain summary block that local `python -m arnold.pipelines.megaplan chain status --spec ...` prints on stderr.
 
-### `megaplan cloud status`
+### `python -m arnold.pipelines.megaplan cloud status`
 
-Without `--chain`, `cloud status` still runs remote `megaplan status` and prints that JSON payload unchanged.
+Without `--chain`, `cloud status` still runs remote `python -m arnold.pipelines.megaplan status` and prints that JSON payload unchanged.
 
-### `megaplan cloud supervise --chain`
+### `python -m arnold.pipelines.megaplan cloud supervise --chain`
 
 `cloud supervise --chain` runs a **one-shot supervisor tick** against the remote chain. It observes the chain, refreshes branch/PR sync state, and makes safe progress decisions. It never invents approvals, bypasses quality gates, or runs destructive git operations.
 
@@ -261,7 +261,7 @@ Same resolution order as `cloud status --chain`:
 
 #### Canonical session
 
-The supervisor targets the same `megaplan-chain` tmux session used by `cloud chain`. All mutations use the canonical `MEGAPLAN_TRUSTED_CONTAINER=1 megaplan chain start --spec <path> --one` command, appending to `<workspace>/.megaplan/cloud-chain.log`.
+The supervisor targets the same `megaplan-chain` tmux session used by `cloud chain`. All mutations use the canonical `MEGAPLAN_TRUSTED_CONTAINER=1 python -m arnold.pipelines.megaplan chain start --spec <path> --one` command, appending to `<workspace>/.megaplan/cloud-chain.log`.
 
 #### Safe actions
 
@@ -278,7 +278,7 @@ The supervisor **refuses to act** and returns `acted: false` with a `refused_rea
 |---|---|
 | `running` | Chain is running; nothing to do. |
 | `complete` | All milestones processed; chain is done. |
-| `human_prerequisite` | Prerequisite policy is `required` and unmet; requires human operator resolution via `megaplan user-action resolve` or `megaplan chain override`. |
+| `human_prerequisite` | Prerequisite policy is `required` and unmet; requires human operator resolution via `python -m arnold.pipelines.megaplan user-action resolve` or `python -m arnold.pipelines.megaplan chain override`. |
 | `quality_gate` | Validation policy is `required` and quality gate is failing; requires human operator resolution. |
 | `awaiting_pr_merge` (PR unmerged) | PR is still open; supervisor will not advance until merged. |
 | `stale_bookkeeping` (runner alive) | Bookkeeping is stale but runner is alive; supervisor will not force-restart a live runner. |
@@ -288,7 +288,7 @@ The supervisor **refuses to act** and returns `acted: false` with a `refused_rea
 
 The supervisor is **not** a destructive repair tool and does **not** replace:
 
-- **Human approval** of prerequisites — use `megaplan user-action resolve` or `megaplan chain override`.
+- **Human approval** of prerequisites — use `python -m arnold.pipelines.megaplan user-action resolve` or `python -m arnold.pipelines.megaplan chain override`.
 - **PR review** — the supervisor only advances when the PR is already merged.
 - **Quality-gate resolution** — failing gates must be resolved by a human operator.
 
@@ -302,7 +302,7 @@ Use `cloud bootstrap` and `cloud chain` when you want cloud to stage the local i
 
 ## Logs, Redaction, And Attach
 
-`megaplan cloud logs` redacts:
+`python -m arnold.pipelines.megaplan cloud logs` redacts:
 
 - literal values for secret names listed under `secrets:` when those values are present locally
 - `NAME=value` and `NAME: value` patterns for those secret names
@@ -310,11 +310,11 @@ Use `cloud bootstrap` and `cloud chain` when you want cloud to stage the local i
 
 This redaction applies to:
 
-- `megaplan cloud logs`
-- `megaplan cloud exec`
+- `python -m arnold.pipelines.megaplan cloud logs`
+- `python -m arnold.pipelines.megaplan cloud exec`
 - wrapper-dispatched output from `cloud bootstrap`, `cloud chain`, and `cloud resume`
 
-`megaplan cloud attach` is different. It opens a raw interactive PTY, so line-buffered redaction is not applied there. Treat attach sessions as trusted terminals.
+`python -m arnold.pipelines.megaplan cloud attach` is different. It opens a raw interactive PTY, so line-buffered redaction is not applied there. Treat attach sessions as trusted terminals.
 
 ## Provider Notes
 

--- a/docs/megaplan-prep.md
+++ b/docs/megaplan-prep.md
@@ -1,6 +1,6 @@
 ---
 name: megaplan-prep
-description: Set up a megaplan run before invoking it — size the work, write the brief, and pick the profile (intelligence tier), robustness level, and thinking depth. For both Codex and Claude harnesses. Consult before every `megaplan init`.
+description: Set up a megaplan run before invoking it — size the work, write the brief, and pick the profile (intelligence tier), robustness level, and thinking depth. For both Codex and Claude harnesses. Consult before every `python -m arnold.pipelines.megaplan init`.
 ---
 
 # Megaplan Setup
@@ -33,7 +33,7 @@ Two decisions come before the three dials: **how many megaplans you need**, and 
 
 A megaplan should fit roughly **two weeks of human work** — the time a skilled engineer would take to plan, build, and review the same scope. Wall-clock for the harness itself is unrelated; this is about scope, not duration.
 
-If the work is bigger, **split it into an epic** — a chain of sprint-sized megaplans driven sequentially by `megaplan chain`. Each sprint in the chain gets its own brief, its own profile, its own retrospective. See the **megaplan-epic** skill for spec format, per-milestone rubric, and end-to-end usage. Cramming a month of work into one plan means the brief drifts, the critique loses focus, and the review can't hold the whole shape in one pass.
+If the work is bigger, **split it into an epic** — a chain of sprint-sized megaplans driven sequentially by `python -m arnold.pipelines.megaplan chain`. Each sprint in the chain gets its own brief, its own profile, its own retrospective. See the **megaplan-epic** skill for spec format, per-milestone rubric, and end-to-end usage. Cramming a month of work into one plan means the brief drifts, the critique loses focus, and the review can't hold the whole shape in one pass.
 
 Signs you should split:
 
@@ -51,7 +51,7 @@ When you split, structure the dependency graph explicitly. Each handoff is a wri
 
 **The brief must be locked in before init** — fully self-contained so the model can run end-to-end without coming back for clarification. The harness snapshots the brief at `init`; later edits to the idea-file are not re-read. If you find yourself wanting to "ask the model" what to do, write that decision down first.
 
-**Store durable briefs in `.megaplan/briefs/`.** Single-plan ideas live at `.megaplan/briefs/<slug>.md`. Epics live at `.megaplan/briefs/<epic-slug>/chain.yaml` with their milestone briefs in the same directory. `.megaplan/plans/` is generated run state; `.megaplan/briefs/` is the committed input material you hand to `megaplan init` or `megaplan chain start`. Use `megaplan brief new` or `megaplan brief epic` to create the canonical files.
+**Store durable briefs in `.megaplan/briefs/`.** Single-plan ideas live at `.megaplan/briefs/<slug>.md`. Epics live at `.megaplan/briefs/<epic-slug>/chain.yaml` with their milestone briefs in the same directory. `.megaplan/plans/` is generated run state; `.megaplan/briefs/` is the committed input material you hand to `python -m arnold.pipelines.megaplan init` or `python -m arnold.pipelines.megaplan chain start`. Use `python -m arnold.pipelines.megaplan brief new` or `python -m arnold.pipelines.megaplan brief epic` to create the canonical files.
 
 A good brief covers:
 
@@ -178,10 +178,10 @@ Default to `low`; only spend on depth when you can name the specific reason the 
 
 **If a run is struggling, escalate mid-flight rather than letting it grind.** Common signals: the plan keeps missing concerns critique surfaces; revise doesn't resolve the critique's flags; the executor produces work review can't accept; iteration cycles through the same defects without converging. Don't sit through a degenerate run — one wasted phase costs much less than restarting the sprint.
 
-- `megaplan override set-profile --profile NAME --plan ID` — swap tier mid-run. Started on `partnered`, hit something gnarlier, escalate to `premium` for the remainder.
-- `megaplan override set-robustness --robustness LEVEL --plan ID` — same for the planning-complexity dial.
-- `megaplan override replan --plan ID` — back up to planning and redo with whatever models / robustness are now active.
-- `megaplan override add-note --plan ID --note "..."` — inject guidance into an active plan without restarting any phase. Read by every subsequent phase. The brief is snapshotted at `init`; later edits to the idea-file are NOT re-read, so this is the verb for "I missed something." **`megaplan feedback` is end-of-run rating, not in-flight guidance** — common confusion.
+- `python -m arnold.pipelines.megaplan override set-profile --profile NAME --plan ID` — swap tier mid-run. Started on `partnered`, hit something gnarlier, escalate to `premium` for the remainder.
+- `python -m arnold.pipelines.megaplan override set-robustness --robustness LEVEL --plan ID` — same for the planning-complexity dial.
+- `python -m arnold.pipelines.megaplan override replan --plan ID` — back up to planning and redo with whatever models / robustness are now active.
+- `python -m arnold.pipelines.megaplan override add-note --plan ID --note "..."` — inject guidance into an active plan without restarting any phase. Read by every subsequent phase. The brief is snapshotted at `init`; later edits to the idea-file are NOT re-read, so this is the verb for "I missed something." **`python -m arnold.pipelines.megaplan feedback` is end-of-run rating, not in-flight guidance** — common confusion.
 
 Lean on these instead of inventing new profile names. If you find yourself thinking "I want a profile that's *like* `partnered` but with X" — the answer is almost always `partnered` plus an override, not a new profile.
 
@@ -207,7 +207,7 @@ Two narrower levers orthogonal to the three dials. Both off by default.
 
 "Prep just in case" doesn't earn its cost. Redundant at `thorough` and `extreme` (those already include prep); the flag's value is at `light` and `full`, where prep is normally skipped.
 
-**Steering prep with `--prep-direction`.** When prep runs (either via `--with-prep` or because robustness is `thorough`/`extreme`), you can hand it explicit guidance about *what* to explore: `megaplan init … --prep-direction "focus on the worker shutdown path; ignore CLI plumbing"`. It's shown to the prep worker as a distinct "User direction for prep" section — steering, not a replacement for the task. Use it when prep would otherwise wander (broad codebase, multiple plausible entry points) or when you want it to skip the obvious file and trace a specific call chain. You can also set or replace it after init with `megaplan prep --direction "…"` before the phase runs, and chain milestones accept `prep_direction:` per milestone. Has no effect if prep is skipped.
+**Steering prep with `--prep-direction`.** When prep runs (either via `--with-prep` or because robustness is `thorough`/`extreme`), you can hand it explicit guidance about *what* to explore: `python -m arnold.pipelines.megaplan init … --prep-direction "focus on the worker shutdown path; ignore CLI plumbing"`. It's shown to the prep worker as a distinct "User direction for prep" section — steering, not a replacement for the task. Use it when prep would otherwise wander (broad codebase, multiple plausible entry points) or when you want it to skip the obvious file and trace a specific call chain. You can also set or replace it after init with `python -m arnold.pipelines.megaplan prep --direction "…"` before the phase runs, and chain milestones accept `prep_direction:` per milestone. Has no effect if prep is skipped.
 
 ### Feedback (`--with-feedback`)
 
@@ -240,7 +240,7 @@ Write `profile/robustness/depth`, omit defaults, append modifiers. Order is fixe
 
 Modifier conventions: `@<vendor>` for vendor override, `, critic=<kind>` for critic override, `+prep` to enable prep, `+feedback` to enable feedback. Append modifiers without disturbing the spine.
 
-The shorthand is for recording (sprint notes, brief headers, commit messages), not for the CLI. The actual invocation is still `megaplan init --profile … --robustness … --depth …` — see "Running it" below.
+The shorthand is for recording (sprint notes, brief headers, commit messages), not for the CLI. The actual invocation is still `python -m arnold.pipelines.megaplan init --profile … --robustness … --depth …` — see "Running it" below.
 
 ---
 
@@ -260,14 +260,14 @@ The invocation has three layers: three flags for the dials, four modifiers for o
 - **`--critic cross`** — overrides the critique+review pair to the other premium vendor relative to `--vendor`. Silently ignored at tier 5.
 - **`--deepseek-provider fireworks|direct`** — swaps canonical DeepSeek v4-pro slots between Fireworks and DeepSeek's direct API. Defaults to `direct`; use `fireworks` as the explicit secondary/fallback route.
 - **`--with-prep`** — force the `prep` research phase into the workflow regardless of `--robustness`. Off by default; no-op at `thorough`/`extreme`. See "Optional phases" above.
-- **`--prep-direction "…"`** — steering text shown to the prep worker (when prep runs) as a "User direction for prep" section. Points prep at specific files / subsystems / questions to explore. Can also be set or replaced later with `megaplan prep --direction "…"` before the phase runs. No-op if prep is skipped. See "Optional phases" above.
+- **`--prep-direction "…"`** — steering text shown to the prep worker (when prep runs) as a "User direction for prep" section. Points prep at specific files / subsystems / questions to explore. Can also be set or replaced later with `python -m arnold.pipelines.megaplan prep --direction "…"` before the phase runs. No-op if prep is skipped. See "Optional phases" above.
 - **`--with-feedback`** — force the `feedback` phase into the workflow regardless of `--robustness`. Scaffolds `feedback.md` (a per-stage ratings template) between `review` and `done`, then completes the plan non-interactively. Off by default. See "Optional phases" above.
 
 ### The escape hatch
 
 **`--phase-model phase=spec`**, repeatable. For when `--depth` is too coarse — e.g. bump just `critique` without touching the rest. Most runs don't need it.
 
-For an in-flight plan, `megaplan override set-model --phase PHASE --model MODEL`
+For an in-flight plan, `python -m arnold.pipelines.megaplan override set-model --phase PHASE --model MODEL`
 updates that phase's persisted `phase_model` entry. If you are switching premium
 vendors, pass a full premium spec such as `--model claude:sonnet` or
 `--model codex:gpt-5.5`; passing only `--model sonnet` keeps the phase's
@@ -292,7 +292,7 @@ The model that critiques the plan also reviews the executed work — same mind p
 
 ### Worktree isolation — `--in-worktree`
 
-`megaplan init --in-worktree NAME` spins up a dedicated git worktree at `~/Documents/.megaplan-worktrees/<NAME>/` on a new branch, so each sprint lives in its own checkout. Use it for multi-PR migrations, or when concurrent work on `main` shouldn't be disturbed. Substitutes for `--project-dir`.
+`python -m arnold.pipelines.megaplan init --in-worktree NAME` spins up a dedicated git worktree at `~/Documents/.megaplan-worktrees/<NAME>/` on a new branch, so each sprint lives in its own checkout. Use it for multi-PR migrations, or when concurrent work on `main` shouldn't be disturbed. Substitutes for `--project-dir`.
 
 - **`--worktree-from GITREF`** — fork from a specific branch/tag/SHA instead of `HEAD`.
 - **`--clean-worktree`** — fork from a clean base. By default, uncommitted state in the invoking repo is replicated into the new worktree (the source repo's working tree is never touched).
@@ -304,22 +304,22 @@ Skip `--in-worktree` for small one-shot plans, bakeoff runs (orchestrator manage
 ### Worked invocations
 
 > *"Schema migration, step ordering intricate but each step mechanical."*
-> `megaplan init <brief> --profile directed`
+> `python -m arnold.pipelines.megaplan init <brief> --profile directed`
 
 > *"Novel cross-cutting feature, long brief, unfamiliar codebase."*
-> `megaplan init <brief> --profile partnered --depth high`
+> `python -m arnold.pipelines.megaplan init <brief> --profile partnered --depth high`
 
 > *"Novel feature against an external API we haven't used."*
-> `megaplan init <brief> --profile partnered --with-prep`
+> `python -m arnold.pipelines.megaplan init <brief> --profile partnered --with-prep`
 
 > *"Migration logic against production data."*
-> `megaplan init <brief> --profile premium --robustness thorough --depth high`
+> `python -m arnold.pipelines.megaplan init <brief> --profile premium --robustness thorough --depth high`
 
 > *"Schema everyone downstream will build on — concurrency primitive, cascading consequences."*
-> `megaplan init <brief> --profile apex --robustness thorough --depth high`
+> `python -m arnold.pipelines.megaplan init <brief> --profile apex --robustness thorough --depth high`
 
 > *"Tier 3, brief is clear, but I want the critic specifically to deliberate more — leave the planner alone."*
-> `megaplan init <brief> --profile partnered --phase-model critique=claude:medium --phase-model review=claude:medium` *(surgical: bumps just the critic+review pair — preserving the critique==review invariant — and leaves plan/revise at the profile's default. `--depth` can't express this because it's by-phase-name, not by-author-vs-critic.)*
+> `python -m arnold.pipelines.megaplan init <brief> --profile partnered --phase-model critique=claude:medium --phase-model review=claude:medium` *(surgical: bumps just the critic+review pair — preserving the critique==review invariant — and leaves plan/revise at the profile's default. `--depth` can't express this because it's by-phase-name, not by-author-vs-critic.)*
 
 Three pieces of intent → three flags (`--profile`, `--robustness`, `--depth`), plus `--vendor` / `--critic` / `--with-prep` / `--with-feedback` / `--in-worktree` when you need them.
 
@@ -346,7 +346,7 @@ Default to a single profile. Only run a multi-arm bake-off when (a) the user ask
 
 This skill covers profile/robustness/depth selection *before* a run. Once a plan is in flight, switch to the **`megaplan-observe`** skill — same author, complementary focus:
 
-- **Pull-mode observation**: `megaplan introspect` / `trace` / `doctor` for on-demand inspection, blockage diagnosis, drift detection. Read it before reaching for `override` so you don't guess at an `invalid_transition`.
+- **Pull-mode observation**: `python -m arnold.pipelines.megaplan introspect` / `trace` / `doctor` for on-demand inspection, blockage diagnosis, drift detection. Read it before reaching for `override` so you don't guess at an `invalid_transition`.
 - **Push-mode observation**: `watcher.sh` (bundled in the same skill) is a bash polling loop that streams phase-transition notifications. Wire it through Claude Code's `Monitor` tool to get told when phases start/end, when cost climbs, and when the plan reaches a terminal state — no manual polling.
 
 When something looks wrong during a run (cost spiking, phase not advancing, iteration counter stuck), `megaplan-observe` is the next stop, not `--max-cost-usd`. The cost-cap and rework-cap flags exist for narrow recovery cases; they are not a default. Trust the defaults; intervene with `override` + tests if a phase fixates.

--- a/docs/reference/arnold-projections.md
+++ b/docs/reference/arnold-projections.md
@@ -123,25 +123,31 @@ content type declared on a producing port.
 
 | content_type | schema_sha256 |
 | --- | --- |
+| application/x-astrid-timeline | 910065449e15a116f873cfdd08adffa70baad910c0ae70d0059b7efa865dd3c5 |
 | application/x-evaluand-record+json | 41e8baf38e205a533cd32fc65204aeef28fd685ca4a38587bdde09bf1dfe95fc |
 | application/x-fanout-results+json | 19663a02cff4b115bb0fcf6d41c4ef5bcb021fbf65ebfeae09756f8b8b83d721 |
 | application/x-git-diff | 3be30e684bcc8910867e5b222bda78f845acec4a1e5f8ae4965c8c03211d3765 |
 | application/x-routing-key+json | 554b679b7485e0b5b4259e44782493d6173a1cbacab752b971aa6999da0d585c |
 | application/x-verdict+json | c7286b1c7bee27a49c1ef632ab8f0624a3df16051e8a809c02a5bdc604f54560 |
+| audio/wav | 6728ebbad1351c6e1113453564b398de3d1b9c4ae7f51f0f2434d6b9b0e3eac0 |
 | image/png | 25372230efe3fabc582b1e1444f21ece5077786a8cefcc6fcc25a59e25556ec8 |
 | text/markdown | 5600d1618be629635191ff0aa5c4282327e870a1290da6f9c2319ef69b934e58 |
+| video/mp4 | e805e721029bfddd9b3a37c35cf845ea2e47215d2fea1964cb8e063d1938b9ac |
 
 ### Legal Content-Type Coercions
 
 | from | to | kind |
 | --- | --- | --- |
+| application/x-astrid-timeline | application/x-astrid-timeline | identity |
 | application/x-evaluand-record+json | application/x-evaluand-record+json | identity |
 | application/x-fanout-results+json | application/x-fanout-results+json | identity |
 | application/x-git-diff | application/x-git-diff | identity |
 | application/x-routing-key+json | application/x-routing-key+json | identity |
 | application/x-verdict+json | application/x-verdict+json | identity |
+| audio/wav | audio/wav | identity |
 | image/png | image/png | identity |
 | text/markdown | text/markdown | identity |
+| video/mp4 | video/mp4 | identity |
 
 ## Checker Defect Surfaces
 
@@ -275,11 +281,11 @@ content type declared on a producing port.
 
 | vocabulary | value | source |
 | --- | --- | --- |
-| RunOutcome | awaiting_human | arnold/pipelines/megaplan/run_outcome.py |
-| RunOutcome | blocked | arnold/pipelines/megaplan/run_outcome.py |
-| RunOutcome | escalated | arnold/pipelines/megaplan/run_outcome.py |
-| RunOutcome | failed | arnold/pipelines/megaplan/run_outcome.py |
-| RunOutcome | succeeded | arnold/pipelines/megaplan/run_outcome.py |
+| RunOutcome | awaiting_human | arnold/runtime/outcome.py |
+| RunOutcome | blocked | arnold/runtime/outcome.py |
+| RunOutcome | escalated | arnold/runtime/outcome.py |
+| RunOutcome | failed | arnold/runtime/outcome.py |
+| RunOutcome | succeeded | arnold/runtime/outcome.py |
 | ControlTarget | abort | arnold/pipelines/megaplan/control_interface.py |
 | ControlTarget | force-advance | arnold/pipelines/megaplan/control_interface.py |
 | ControlTarget | re-route | arnold/pipelines/megaplan/control_interface.py |

--- a/docs/shannon-stream-testing.md
+++ b/docs/shannon-stream-testing.md
@@ -22,7 +22,7 @@ MEGAPLAN_SHANNON_STREAM_CONFORMANCE=1 python -m pytest tests/test_shannon_stream
 ```
 
 If both pass, the channel is good. Everything below is for proving the *integration* (a real
-megaplan phase flowing through the new worker) and exercising the cap / shadow / cutover knobs.
+python -m arnold.pipelines.megaplan phase flowing through the new worker) and exercising the cap / shadow / cutover knobs.
 
 ---
 
@@ -47,7 +47,7 @@ Expected: all pass. `test_shannon_stream_conformance.py` **skips** here by desig
 you opt in — see Level 2).
 
 > Note: a *full* `pytest` run in a bare checkout shows ~27 unrelated failures — tests that spawn
-> `python -m megaplan ...` as a subprocess fail with `ModuleNotFoundError` because the checkout
+> `python -m arnold ...` as a subprocess fail with `ModuleNotFoundError` because the checkout
 > isn't pip-installed. Those are environmental, not this change. Either run the scoped list above,
 > or `pip install -e .` first to make the subprocess tests pass.
 
@@ -94,11 +94,11 @@ Then run a tiny plan on the Claude vendor and watch how it executes:
 ```bash
 # a trivial single-file task is enough to exercise the channel
 PYENV_VERSION=3.11.11 MEGAPLAN_SHANNON_STREAM_WORKER=1 \
-  megaplan init "Add a one-line docstring to <some small file>" \
+  python -m arnold.pipelines.megaplan init "Add a one-line docstring to <some small file>" \
   --profile solo --robustness bare --vendor claude --in-worktree sstest
 
 PYENV_VERSION=3.11.11 MEGAPLAN_SHANNON_STREAM_WORKER=1 \
-  megaplan auto --project-dir ~/Documents/.megaplan-worktrees/sstest
+  python -m arnold.pipelines.megaplan auto --project-dir ~/Documents/.megaplan-worktrees/sstest
 ```
 
 **While it runs, confirm the channel — two checks:**
@@ -121,7 +121,7 @@ If you just want to see the worker handle a single turn without spinning a whole
 directly from a Python shell:
 
 ```python
-from megaplan.workers.shannon_stream import run_shannon_stream_step   # see its signature
+from arnold.pipelines.megaplan.workers.shannon_stream import run_shannon_stream_step   # see its signature
 # build a minimal step/state per the existing call site in megaplan/workers/_impl.py (~line 3076)
 ```
 
@@ -135,7 +135,7 @@ from megaplan.workers.shannon_stream import run_shannon_stream_step   # see its 
 |---|---|---|
 | **Concurrency cap** | `MEGAPLAN_WORKER_TURN_CAP=2` | start 3+ Claude turns at once; only 2 run concurrently, the rest queue (slot files under `MEGAPLAN_WORKER_TURN_CAP_DIR`). |
 | **Auth channel** | `MEGAPLAN_SHANNON_STREAM_AUTH_CHANNEL=subscription` (default) or `api_key` | with `api_key`, set `ANTHROPIC_API_KEY`/`MEGAPLAN_SHANNON_STREAM_API_KEY` to bill the API instead of the subscription (the "validated flip"). |
-| **Sampled shadow** | `MEGAPLAN_CHANNEL_SHADOW_SAMPLE_RATE=0.1` | runs the tmux + stream channels on a ≤10% sample and records deterministic-artifact parity (reuses the bakeoff harness; see `megaplan/bakeoff/channel_shadow.py`). |
+| **Sampled shadow** | `MEGAPLAN_CHANNEL_SHADOW_SAMPLE_RATE=0.1` | runs the tmux + stream channels on a ≤10% sample and records deterministic-artifact parity (reuses the bakeoff harness; see `arnold/pipelines/megaplan/bakeoff/channel_shadow.py`). |
 | **Idle / execute timeouts** | `MEGAPLAN_SHANNON_STREAM_IDLE_TIMEOUT_SECONDS`, `..._EXECUTE_TIMEOUT_SECONDS` | tune liveness bounds. |
 
 The API-adapter proof is recorded at `docs/shannon-stream-api-proof-record.json` (a dry-run in the
@@ -156,7 +156,7 @@ it's actually testing for.
 
 The honest end-to-end test isn't a docstring — it's "does the new channel produce equivalent results
 to tmux on *real* phases?" That's what shadow mode is for. Turn it on against an actual running
-megaplan chain (not a toy):
+python -m arnold.pipelines.megaplan chain (not a toy):
 
 ```bash
 export MEGAPLAN_SHANNON_STREAM_WORKER=1
@@ -166,7 +166,7 @@ export MEGAPLAN_CHANNEL_SHADOW_SAMPLE_RATE=0.1   # run BOTH channels on ~10% of 
 
 It runs the stream channel alongside tmux on a sampled fraction of real phases and records
 **deterministic-artifact parity** (exit-kind class, payload schema validity, landed-diff status,
-worker-did-work) via the bakeoff harness (`megaplan/bakeoff/channel_shadow.py`). After a handful of
+worker-did-work) via the bakeoff harness (`arnold/pipelines/megaplan/bakeoff/channel_shadow.py`). After a handful of
 real phases, inspect the recorded parity:
 
 ```bash
@@ -228,7 +228,7 @@ Level 3's docstring may use no tools. Run a task that genuinely needs **Bash + E
 worker actually executes tools headlessly:
 
 ```bash
-MEGAPLAN_SHANNON_STREAM_WORKER=1 megaplan init \
+MEGAPLAN_SHANNON_STREAM_WORKER=1 python -m arnold.pipelines.megaplan init \
   "Create scripts/hello.sh that echoes hi, chmod +x it, run it, and capture output to out.txt" \
   --profile solo --robustness bare --vendor claude --in-worktree sstools
 # then drive it and confirm the files were actually created + the commands ran

--- a/tests/arnold/pipeline/test_validator.py
+++ b/tests/arnold/pipeline/test_validator.py
@@ -22,7 +22,7 @@ from typing import Any
 import pytest
 
 from arnold.pipeline.builder import PipelineBuilder
-from arnold.pipeline.types import Edge, Pipeline, Port, PortRef, ReadRef, Stage, StepContext, StepResult, WriteRef
+from arnold.pipeline.types import Edge, ParallelStage, Pipeline, Port, PortRef, ReadRef, Stage, StepContext, StepResult, WriteRef
 from arnold.pipeline.step_invocation import (
     StepInvocation,
     StepInvocationAdapterRegistry,
@@ -34,11 +34,11 @@ from arnold.pipeline.validator import (
     MISSING_BINDING_CODE,
     UNKNOWN_ADAPTER_CODE,
     UNSATISFIED_CAPABILITY_CODE,
+    _decision_enum_from_suspension_schema,
     _step_prompt_key,
     contract_diagnostic_code,
     validate,
     validate_dataflow_paths,
-    validate_resource_dependencies,
 )
 
 
@@ -175,6 +175,367 @@ class TestDeterministicOrdering:
         assert len(prompt_defects) >= 2, f"expected >=2 prompt_key defects, got: {prompt_defects}"
         assert prompt_defects[0].startswith("stage 'aaa'"), prompt_defects[0]
         assert prompt_defects[1].startswith("stage 'zzz'"), prompt_defects[1]
+
+
+# ── Decision-route validation ─────────────────────────────────────────────
+
+
+class TestDecisionRouteValidation:
+    """T4: Focused decision-route validator tests covering route targets,
+    terminal None routes, absent routes, metadata-only stages, and
+    ParallelStage behaviour."""
+
+    # ── Valid route targets ──────────────────────────────────────────
+
+    def test_valid_route_targets_match_edge_labels(self) -> None:
+        """Decision routes whose targets match outgoing edge labels pass."""
+        stage = Stage(
+            name="review",
+            step=_PromptStep(name="review"),
+            edges=(
+                Edge(label="next", target="next_stage"),
+                Edge(label="halt", target="halt"),
+            ),
+            decision_routes={"approved": "next", "rejected": "halt"},
+        )
+        diag = validate(_pipeline(stages={"review": stage}, entry="review"))
+        route_defects = [d for d in diag.defects if "decision_route" in d]
+        assert route_defects == [], f"expected no route defects, got: {route_defects}"
+
+    # ── Unknown non-None route target ───────────────────────────────
+
+    def test_unknown_route_target_flagged_with_details(self) -> None:
+        """A decision_route targeting an edge label that does not exist is flagged."""
+        stage = Stage(
+            name="review",
+            step=_PromptStep(name="review"),
+            edges=(
+                Edge(label="next", target="next_stage"),
+                Edge(label="halt", target="halt"),
+            ),
+            decision_routes={"approved": "unknown_label"},
+        )
+        diag = validate(_pipeline(stages={"review": stage}, entry="review"))
+        _assert_issue(
+            diag,
+            code="decision_route_target_unknown",
+            stage="review",
+            detail_items={
+                "decision_key": "approved",
+                "route_target": "unknown_label",
+                "available_edge_labels": ["halt", "next"],
+            },
+            message_contains="targets unknown edge label",
+        )
+
+    # ── Terminal None routes ─────────────────────────────────────────
+
+    def test_terminal_none_route_passes(self) -> None:
+        """A decision_route with value None (terminal decision) passes validation."""
+        stage = Stage(
+            name="review",
+            step=_PromptStep(name="review"),
+            edges=(
+                Edge(label="next", target="next_stage"),
+                Edge(label="halt", target="halt"),
+            ),
+            decision_routes={"approved": "next", "abort": None},
+        )
+        diag = validate(_pipeline(stages={"review": stage}, entry="review"))
+        route_defects = [d for d in diag.defects if "decision_route" in d]
+        assert route_defects == [], f"None route should pass: {route_defects}"
+
+    # ── Absent / empty decision_routes ───────────────────────────────
+
+    def test_no_decision_routes_passes(self) -> None:
+        """A stage with empty decision_routes dict passes silently."""
+        stage = Stage(
+            name="review",
+            step=_PromptStep(name="review"),
+            edges=(
+                Edge(label="next", target="next_stage"),
+                Edge(label="halt", target="halt"),
+            ),
+            decision_routes={},
+        )
+        diag = validate(_pipeline(stages={"review": stage}, entry="review"))
+        route_defects = [d for d in diag.defects if "decision_route" in d]
+        assert route_defects == [], f"empty decision_routes should pass: {route_defects}"
+
+    def test_default_decision_routes_empty_dict_passes(self) -> None:
+        """A stage with the default decision_routes (empty dict, from dataclass default) passes silently."""
+        # Stage created without explicit decision_routes gets default empty dict
+        stage = Stage(
+            name="review",
+            step=_PromptStep(name="review"),
+            edges=(
+                Edge(label="next", target="next_stage"),
+                Edge(label="halt", target="halt"),
+            ),
+        )
+        assert stage.decision_routes == {}
+        diag = validate(_pipeline(stages={"review": stage}, entry="review"))
+        route_defects = [d for d in diag.defects if "decision_route" in d]
+        assert route_defects == [], f"default empty decision_routes should pass: {route_defects}"
+
+    # ── Metadata-only / non-suspending stage ─────────────────────────
+
+    def test_metadata_only_stage_valid_targets_no_schema(self) -> None:
+        """Stage with decision_routes but no suspension_schema passes route validation."""
+        stage = Stage(
+            name="review",
+            step=_PromptStep(name="review"),
+            edges=(
+                Edge(label="next", target="next_stage"),
+                Edge(label="halt", target="halt"),
+            ),
+            decision_routes={"proceed": "next", "stop": "halt"},
+            suspension_schema=None,
+        )
+        diag = validate(_pipeline(stages={"review": stage}, entry="review"))
+        route_defects = [d for d in diag.defects if "decision_route" in d]
+        assert route_defects == [], f"valid targets without schema: {route_defects}"
+
+    # ── ParallelStage cheap behaviour ────────────────────────────────
+
+    def test_parallel_stage_decision_routes(self) -> None:
+        """ParallelStage with valid decision_routes passes validation."""
+
+        def _join(results: list, ctx: Any) -> StepResult:
+            return StepResult(next="halt")
+
+        pstage = ParallelStage(
+            name="fanout",
+            steps=(_PromptStep(name="fanout"),),
+            join=_join,
+            edges=(
+                Edge(label="next", target="next_stage"),
+                Edge(label="halt", target="halt"),
+            ),
+            decision_routes={"ok": "next", "fail": "halt"},
+        )
+        diag = validate(_pipeline(stages={"fanout": pstage}, entry="fanout"))
+        route_defects = [d for d in diag.defects if "decision_route" in d]
+        assert route_defects == [], f"ParallelStage routes: {route_defects}"
+
+    def test_parallel_stage_bad_route_flagged(self) -> None:
+        """ParallelStage with an unknown route target is flagged."""
+
+        def _join(results: list, ctx: Any) -> StepResult:
+            return StepResult(next="halt")
+
+        pstage = ParallelStage(
+            name="fanout",
+            steps=(_PromptStep(name="fanout"),),
+            join=_join,
+            edges=(
+                Edge(label="next", target="next_stage"),
+                Edge(label="halt", target="halt"),
+            ),
+            decision_routes={"ok": "bad_label"},
+        )
+        diag = validate(_pipeline(stages={"fanout": pstage}, entry="fanout"))
+        _assert_issue(
+            diag,
+            code="decision_route_target_unknown",
+            stage="fanout",
+            detail_items={
+                "decision_key": "ok",
+                "route_target": "bad_label",
+                "available_edge_labels": ["halt", "next"],
+            },
+            message_contains="targets unknown edge label",
+        )
+
+
+# ── Simple-schema and JSON Schema compatibility ───────────────────────────
+
+
+class TestDecisionRouteSchemaCompatibility:
+    """T4: Schema compatibility tests for decision-route validation.
+    Covers simple key-value maps, JSON Schema choice.enum, and ambiguous
+    schemas that should be silently ignored."""
+
+    def test_simple_schema_outside_route_key_still_passes_route_validation(self) -> None:
+        """Decision key not in simple KV schema still passes route-target validation
+        when its route_target matches an edge label."""
+        stage = Stage(
+            name="review",
+            step=_PromptStep(name="review"),
+            edges=(
+                Edge(label="next", target="next_stage"),
+                Edge(label="halt", target="halt"),
+            ),
+            decision_routes={
+                "approved": "next",
+                "rejected": "halt",
+                "pending": "next",  # not in schema but valid route
+            },
+            suspension_schema={"approved": "str", "rejected": "str"},
+        )
+        diag = validate(_pipeline(stages={"review": stage}, entry="review"))
+        route_target_defects = [
+            d for d in diag.defects if "decision_route_target_unknown" in d
+        ]
+        assert route_target_defects == [], (
+            f"outside-schema key should not break route validation: {route_target_defects}"
+        )
+
+    def test_simple_schema_x_extension_excluded_from_enum(self) -> None:
+        """Schema with x- extension key is not treated as a simple KV enum."""
+        enum = _decision_enum_from_suspension_schema(
+            {"approved": "str", "x-arnold-resume": "bool"}
+        )
+        assert enum is None, f"x- key should exclude schema, got {enum!r}"
+
+    def test_json_schema_choice_enum_compatible(self) -> None:
+        """Stage with JSON Schema choice.enum and matching routes passes validation."""
+        stage = Stage(
+            name="review",
+            step=_PromptStep(name="review"),
+            edges=(
+                Edge(label="next", target="next_stage"),
+                Edge(label="halt", target="halt"),
+            ),
+            decision_routes={"selected": "next", "declined": "halt"},
+            suspension_schema={
+                "type": "object",
+                "properties": {
+                    "choice": {
+                        "type": "string",
+                        "enum": ["selected", "declined"],
+                    }
+                },
+            },
+        )
+        diag = validate(_pipeline(stages={"review": stage}, entry="review"))
+        route_defects = [d for d in diag.defects if "decision_route" in d]
+        assert route_defects == [], f"JSON Schema choice.enum: {route_defects}"
+
+    def test_json_schema_other_property_enum_ignored(self) -> None:
+        """Enum on a non-choice property is silently ignored (no false positives)."""
+        stage = Stage(
+            name="review",
+            step=_PromptStep(name="review"),
+            edges=(
+                Edge(label="next", target="next_stage"),
+                Edge(label="halt", target="halt"),
+            ),
+            decision_routes={"go": "next"},
+            suspension_schema={
+                "type": "object",
+                "properties": {
+                    "note": {
+                        "type": "string",
+                        "enum": ["hello", "world"],
+                    }
+                },
+            },
+        )
+        diag = validate(_pipeline(stages={"review": stage}, entry="review"))
+        route_defects = [d for d in diag.defects if "decision_route" in d]
+        assert route_defects == [], (
+            f"unrelated property enum should not cause defects: {route_defects}"
+        )
+
+    def test_ambiguous_schema_ignored_no_false_positives(self) -> None:
+        """Loose/ambiguous suspension_schema is silently skipped."""
+        stage = Stage(
+            name="review",
+            step=_PromptStep(name="review"),
+            edges=(
+                Edge(label="next", target="next_stage"),
+                Edge(label="halt", target="halt"),
+            ),
+            decision_routes={"go": "next"},
+            suspension_schema={
+                "type": "object",
+                "properties": {
+                    "note": {"type": "string"},
+                },
+            },
+        )
+        diag = validate(_pipeline(stages={"review": stage}, entry="review"))
+        route_defects = [d for d in diag.defects if "decision_route" in d]
+        assert route_defects == [], (
+            f"ambiguous schema should not cause defects: {route_defects}"
+        )
+
+
+# ── Suspension-schema enum extraction unit tests ──────────────────────────
+
+
+class TestSuspensionSchemaEnumExtraction:
+    """T4: Unit tests for _decision_enum_from_suspension_schema helper."""
+
+    def test_simple_kv_map_extracts_keys(self) -> None:
+        """Simple string key/value map returns frozenset of keys."""
+        result = _decision_enum_from_suspension_schema(
+            {"approved": "str", "rejected": "str"}
+        )
+        assert result == frozenset({"approved", "rejected"})
+
+    def test_simple_kv_map_non_string_value_returns_none(self) -> None:
+        """Any non-string value disqualifies the simple KV map."""
+        result = _decision_enum_from_suspension_schema(
+            {"approved": "str", "count": 42}
+        )
+        assert result is None
+
+    def test_json_schema_choice_enum_extraction(self) -> None:
+        """properties.choice.enum is extracted from valid JSON Schema shape."""
+        result = _decision_enum_from_suspension_schema({
+            "type": "object",
+            "properties": {
+                "choice": {
+                    "type": "string",
+                    "enum": ["proceed", "retry", "abort"],
+                }
+            },
+        })
+        assert result == frozenset({"proceed", "retry", "abort"})
+
+    def test_json_schema_empty_enum_returns_none(self) -> None:
+        """An empty choice.enum returns None."""
+        result = _decision_enum_from_suspension_schema({
+            "type": "object",
+            "properties": {
+                "choice": {
+                    "type": "string",
+                    "enum": [],
+                }
+            },
+        })
+        assert result is None
+
+    def test_json_schema_non_string_choice_type_returns_none(self) -> None:
+        """choice.type != 'string' returns None."""
+        result = _decision_enum_from_suspension_schema({
+            "type": "object",
+            "properties": {
+                "choice": {
+                    "type": "integer",
+                    "enum": [1, 2, 3],
+                }
+            },
+        })
+        assert result is None
+
+    def test_none_schema_returns_none(self) -> None:
+        """None input returns None."""
+        assert _decision_enum_from_suspension_schema(None) is None
+
+    def test_non_mapping_schema_returns_none(self) -> None:
+        """Non-Mapping input returns None."""
+        assert _decision_enum_from_suspension_schema("not a mapping") is None
+
+    def test_x_extension_only_schema_returns_none(self) -> None:
+        """Schema with only x- extension keys returns None."""
+        assert _decision_enum_from_suspension_schema({"x-arnold-resume": "str"}) is None
+
+    def test_empty_dict_returns_none(self) -> None:
+        """Empty dict returns None."""
+        assert _decision_enum_from_suspension_schema({}) is None
 
 
 # ── Full integration tests ─────────────────────────────────────────────────

--- a/tests/test_cloud_chain_wrapper.py
+++ b/tests/test_cloud_chain_wrapper.py
@@ -117,7 +117,7 @@ def test_cloud_chain_no_git_refresh_reaches_remote_chain_start() -> None:
 
     assert args.no_git_refresh is True
     assert (
-        "MEGAPLAN_TRUSTED_CONTAINER=1 arnold chain start "
+        "MEGAPLAN_TRUSTED_CONTAINER=1 python -m arnold.pipelines.megaplan chain start "
         "--spec /workspace/app/chain.yaml --no-git-refresh"
     ) in command
 
@@ -198,7 +198,7 @@ def test_cloud_chain_uploads_files_and_writes_marker_for_railway_and_local(
         assert "git -C \"$SRC\" pull --ff-only" in commands[4]
         assert "pip install -e \"$SRC\"" in commands[4]
         assert "/usr/local/bin/mp-refresh-megaplan" not in commands[4]
-        assert "MEGAPLAN_TRUSTED_CONTAINER=1 arnold chain start --spec /workspace/chain-8fb6734d/app/chain.yaml" in commands[4]
+        assert "MEGAPLAN_TRUSTED_CONTAINER=1 python -m arnold.pipelines.megaplan chain start --spec /workspace/chain-8fb6734d/app/chain.yaml" in commands[4]
         assert "python3 - <<'MEGAPLAN_VERIFY'" in commands[5]
         marker_payload = json.loads((_marker_dir(cloud_yaml_path) / "last_chain.json").read_text(encoding="utf-8"))
         assert marker_payload["remote_spec"] == "/workspace/chain-8fb6734d/app/chain.yaml"
@@ -262,7 +262,7 @@ def test_cloud_chain_three_sprint_smoke_dispatches_trusted_container_command(
     assert "/workspace/cloud-chain-smoke-4bb0e3d6/app" in commands[0]
     assert "command -v" in commands[1]
     assert "git -C /workspace/cloud-chain-smoke-4bb0e3d6/app rev-parse --abbrev-ref HEAD" in commands[2]
-    assert "MEGAPLAN_TRUSTED_CONTAINER=1 arnold chain start --spec /workspace/cloud-chain-smoke-4bb0e3d6/app/chain.yaml" in commands[4]
+    assert "MEGAPLAN_TRUSTED_CONTAINER=1 python -m arnold.pipelines.megaplan chain start --spec /workspace/cloud-chain-smoke-4bb0e3d6/app/chain.yaml" in commands[4]
 
 
 def test_cloud_chain_prints_launch_provenance_after_success(
@@ -937,26 +937,27 @@ def test_cloud_bootstrap_fails_before_upload_when_ensure_repo_fails(
 def test_mp_chain_wrapper_matches_canonical_command(tmp_path: Path) -> None:
     """The wrapper's effective command matches _chain_start_command() output.
 
-    We replace ``arnold`` with a stub that records its arguments and env,
-    then verify that the wrapper produces the same command as the canonical
-    ``_chain_start_command()`` helper for both normal and --one modes.
+    We replace ``python`` with a stub that records its arguments and env,
+    then verify that the wrapper produces the same direct module command as
+    the canonical ``_chain_start_command()`` helper for both normal and
+    --one modes.
     """
     wrapper_path = (
         Path(__file__).parent.parent / "arnold" / "pipelines" / "megaplan" / "cloud" / "wrappers" / "mp-chain"
     )
     spec_path = "/workspace/app/chain.yaml"
 
-    # Stub arnold: records its arguments + env var to a known file.
+    # Stub python: records its arguments + env var to a known file.
     stub_output_file = tmp_path / "stub-output.txt"
-    arnold_stub = tmp_path / "arnold"
-    arnold_stub.write_text(
+    python_stub = tmp_path / "python"
+    python_stub.write_text(
         "#!/bin/bash\n"
         f'echo "ARGS=$*" >> {shlex.quote(str(stub_output_file))}'
         "\n"
         f'echo "MEGAPLAN_TRUSTED_CONTAINER=${{MEGAPLAN_TRUSTED_CONTAINER:-unset}}" >> {shlex.quote(str(stub_output_file))}'
         "\n"
     )
-    arnold_stub.chmod(0o755)
+    python_stub.chmod(0o755)
 
     # Include standard bin directories so bash builtins and env are available.
     env = {
@@ -985,8 +986,8 @@ def test_mp_chain_wrapper_matches_canonical_command(tmp_path: Path) -> None:
     env_line = stub_lines[1]   # MEGAPLAN_TRUSTED_CONTAINER=1
 
     assert "MEGAPLAN_TRUSTED_CONTAINER=1" in env_line
-    # The wrapper must emit the same Arnold arguments as the canonical helper.
-    expected_args = "chain start --spec " + spec_path
+    # The wrapper must emit the same direct module arguments as the canonical helper.
+    expected_args = "-m arnold.pipelines.megaplan chain start --spec " + spec_path
     assert expected_args in args_line, (
         f"expected args {expected_args!r} in {args_line!r}"
     )
@@ -1014,7 +1015,7 @@ def test_mp_chain_wrapper_matches_canonical_command(tmp_path: Path) -> None:
     args_line_one = stub_lines_one[0]
 
     assert "MEGAPLAN_TRUSTED_CONTAINER=1" in stub_lines_one[1]
-    expected_args_one = "chain start --spec " + spec_path + " --one"
+    expected_args_one = "-m arnold.pipelines.megaplan chain start --spec " + spec_path + " --one"
     assert expected_args_one in args_line_one, (
         f"expected args {expected_args_one!r} in {args_line_one!r}"
     )
@@ -1029,7 +1030,7 @@ def test_tmux_chain_restart_refreshes_megaplan_before_one_shot_start() -> None:
 
     assert "/usr/local/bin/mp-refresh-megaplan" not in command
     assert "source clone missing at $SRC; skipping editable install" in command
-    assert "MEGAPLAN_TRUSTED_CONTAINER=1 arnold chain start --spec /workspace/app/chain.yaml --one" in command
+    assert "MEGAPLAN_TRUSTED_CONTAINER=1 python -m arnold.pipelines.megaplan chain start --spec /workspace/app/chain.yaml --one" in command
     assert ">> .megaplan/cloud-chain.log 2>&1" in command
     assert "refusing restart" in command
 


### PR DESCRIPTION
## Summary

- Adds build-time `decision_routes` and `suspension_schema` metadata to neutral `Stage` and `ParallelStage`.
- Validates decision route targets and conservative suspension-schema decision enums in `validate_control_flow`.
- Adds focused validator coverage for route targets, schema coverage, terminal decisions, and parallel stages.
- Removes shim-style launcher guidance from touched Megaplan docs/skill bundles and cloud wrapper commands, using `python -m arnold.pipelines.megaplan` directly.
- Updates the pre-commit hook template to regenerate composed bundles through the subpipeline module path.

## Validation

- `python -m pytest tests/arnold/pipeline/test_validator.py tests/arnold/pipeline/test_contract_result.py tests/test_pipeline_subloop.py -q` — 195 passed, 1 existing warning.
- `python -m pytest tests/test_cloud_chain_wrapper.py tests/test_cloud_template.py tests/test_cloud_spec.py -q` — 87 passed.
- `python -m pytest tests/test_prep_no_shadow_skills.py tests/test_cloud_chain_wrapper.py tests/arnold/pipeline/test_validator.py tests/arnold/pipeline/test_contract_result.py tests/test_pipeline_subloop.py -q` — 229 passed, 1 existing warning.
- No-shim scan across touched docs/cloud surfaces passed.

## Notes

The Megaplan execute phase reported scope drift because the launcher/docs cleanup was intentionally done outside the original decision-route task. Those changes are included here because they satisfy the operator instruction that Megaplan should run as an Arnold subpipeline without shim commands.
