### PR TITLE
Fix Codex one-shot result contract

### DIFF
--- a/arnold/agent/adapters/_oneshot.py
+++ b/arnold/agent/adapters/_oneshot.py
@@ -227,5 +227,6 @@ def project_worker_result(request: AgentRequest, worker_result: Any) -> Any:
         completion_tokens=int(getattr(agent_result, "completion_tokens", 0) or 0),
         total_tokens=int(getattr(agent_result, "total_tokens", 0) or 0),
         shannon_plan=getattr(agent_result, "shannon_plan", None),
+        rate_limit=getattr(agent_result, "rate_limit", None),
         provenance=provenance,
     )

--- a/arnold/agent/adapters/codex.py
+++ b/arnold/agent/adapters/codex.py
@@ -60,5 +60,6 @@ class CodexAdapter:
                 model=ctx["model"],
                 read_only=ctx["read_only"],
                 output_path=ctx["output_path"],
+                free_text=ctx["free_text"],
             )
             return _oneshot.project_worker_result(request, worker_result)

--- a/arnold/agent/contracts.py
+++ b/arnold/agent/contracts.py
@@ -333,6 +333,7 @@ class AgentResult:
     completion_tokens: int = 0
     total_tokens: int = 0
     shannon_plan: dict[str, Any] | None = None
+    rate_limit: dict[str, Any] | None = None
     provenance: ResultProvenance | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
 

--- a/tests/test_codex_adapter.py
+++ b/tests/test_codex_adapter.py
@@ -47,6 +47,7 @@ def _fake_worker_result(**overrides):
         prompt_tokens=11,
         completion_tokens=3,
         total_tokens=14,
+        rate_limit={"provider": "codex", "remaining": 42},
     )
     base.update(overrides)
     return WorkerResult(**base)
@@ -79,6 +80,7 @@ def test_codex_adapter_projects_worker_result_to_agent_result() -> None:
     assert result.tokens.completion_tokens == 3
     assert result.tokens.total_tokens == 14
     assert result.duration_ms == 1234
+    assert result.rate_limit == {"provider": "codex", "remaining": 42}
     # Provenance carries the request triple.
     assert result.provenance is not None
     assert result.provenance.agent == "codex"
@@ -108,6 +110,7 @@ def test_codex_adapter_synthesizes_oneshot_context() -> None:
     assert captured["kwargs"]["read_only"] is True
     assert captured["kwargs"]["model"] == "gpt-5.5"
     assert captured["kwargs"]["effort"] == "low"
+    assert captured["kwargs"]["free_text"] is True
     # system_prompt is folded into the override prompt.
     assert "You are a calculator." in captured["kwargs"]["prompt_override"]
     assert "What is 2 + 2?" in captured["kwargs"]["prompt_override"]


### PR DESCRIPTION
## Summary
- add `rate_limit` to the canonical Arnold `AgentResult` contract
- preserve `rate_limit` through one-shot worker projection
- forward free-text mode from the Codex adapter into `run_codex_step`

## Verification
- `python -m pytest tests/test_codex_adapter.py tests/test_agent_runtime_contracts.py -q`

This lets VibeComfy install Arnold from GitHub instead of relying on a local checkout while keeping `openai-codex` agent-edit turns working.