### PR TITLE
Fetch push base for behavioral golden guard

### DIFF
--- a/tests/arnold/conformance/workflow_manifest_runtime/test_existing_behavioral_goldens.py
+++ b/tests/arnold/conformance/workflow_manifest_runtime/test_existing_behavioral_goldens.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 from pathlib import Path
@@ -15,15 +16,32 @@ BEHAVIORAL_GOLDENS = (
 )
 
 
+def _push_base_ref() -> str:
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    if event_path:
+        try:
+            before = json.loads(Path(event_path).read_text(encoding="utf-8")).get("before")
+        except (OSError, json.JSONDecodeError):
+            before = None
+        if before and set(before) != {"0"}:
+            subprocess.run(
+                ["git", "fetch", "--depth=1", "origin", before],
+                check=False,
+                capture_output=True,
+            )
+            return before
+    return "origin/main"
+
+
 def _base_ref() -> str:
     # In PR CI, compare against the target branch; locally fall back to origin/main.
-    # Push CI does not set GITHUB_BASE_REF, so compare against the previous commit.
+    # Push CI does not set GITHUB_BASE_REF, so compare against the pushed-from SHA.
     base = os.environ.get("GITHUB_BASE_REF")
     if base:
         subprocess.run(["git", "fetch", "origin", base], check=False, capture_output=True)
         return f"origin/{base}"
     if os.environ.get("GITHUB_EVENT_NAME") == "push":
-        return "HEAD^"
+        return _push_base_ref()
     return "origin/main"
 
 


### PR DESCRIPTION
## Summary
- read the push event `before` SHA when `GITHUB_BASE_REF` is unavailable
- fetch that exact commit so the behavioral golden guard works under shallow `actions/checkout`
- keep local fallback as `origin/main`

## Validation
- `event_file=$(mktemp); printf '{"before":"55b53a640799d7609c98f1c9bc13640785ad1c26"}' > "$event_file"; GITHUB_EVENT_NAME=push GITHUB_BASE_REF= GITHUB_EVENT_PATH="$event_file" python -m pytest tests/characterization/test_import_surface.py tests/test_chain_done_gate.py tests/arnold/workflow/test_m5_inventory_scanners.py tests/cli/test_m5_workflow_cli.py tests/arnold/conformance -q; rc=$?; rm -f "$event_file"; exit $rc` (287 passed)
- `event_file=$(mktemp); printf '{"before":"55b53a640799d7609c98f1c9bc13640785ad1c26"}' > "$event_file"; GITHUB_EVENT_NAME=push GITHUB_BASE_REF= GITHUB_EVENT_PATH="$event_file" python -m pytest tests/arnold/conformance/workflow_manifest_runtime/test_existing_behavioral_goldens.py -q; rc=$?; rm -f "$event_file"; exit $rc` (3 passed)
- `python -m pytest tests/arnold/conformance/workflow_manifest_runtime/test_existing_behavioral_goldens.py -q` (3 passed)
- `git diff --check`
