### PR TITLE
Fix bundled subagent fan legacy imports

### DIFF
--- a/arnold/conformance/legacy_reference_allowlist.json
+++ b/arnold/conformance/legacy_reference_allowlist.json
@@ -655,12 +655,6 @@
       "reason": "Subagent launcher skill documents the legacy Hermes runtime location during the Arnold package migration."
     },
     {
-      "path": "arnold_pipelines/megaplan/skills/subagent-launcher/fan.py",
-      "pattern": "arnold.pipelines.megaplan",
-      "category": "scanner-target",
-      "reason": "Legacy fan launcher fallback imports the old Hermes runtime only when the modern launcher path is unavailable."
-    },
-    {
       "path": "pyproject.toml",
       "pattern": "arnold/pipelines/megaplan",
       "category": "historical-non-shipped",

--- a/arnold_pipelines/megaplan/skills/subagent-launcher/fan.py
+++ b/arnold_pipelines/megaplan/skills/subagent-launcher/fan.py
@@ -227,8 +227,8 @@ try:
             if vendored_agent_str not in sys.path:
                 sys.path.insert(0, vendored_agent_str)
         from arnold.agent.run_agent import AIAgent
-        from arnold.pipelines.megaplan.agent.hermes_state import SessionDB
-        from arnold.pipelines.megaplan.runtime.key_pool import resolve_model
+        from arnold_pipelines.megaplan.agent.hermes_state import SessionDB
+        from arnold_pipelines.megaplan.runtime.key_pool import resolve_model
 except Exception:
     _eprint("[fan] FATAL: could not import megaplan/hermes runtime:")
     _eprint(traceback.format_exc())


### PR DESCRIPTION
## Summary
- update the bundled subagent `fan.py` legacy fallback imports to use the current `arnold_pipelines.megaplan` package path
- matches the already-landed `launch_hermes_agent.py` import fix

## Validation
- `python -m py_compile arnold_pipelines/megaplan/skills/subagent-launcher/fan.py arnold_pipelines/megaplan/skills/subagent-launcher/launch_hermes_agent.py`
- `git diff --check`
