### PR TITLE
Recover M3 export readiness on top of M4

### DIFF
--- a/.github/workflows/slot-first-quality.yml
+++ b/.github/workflows/slot-first-quality.yml
@@ -26,5 +26,5 @@ jobs:
           node-version: "20.19.0"
           cache: npm
       - run: npm ci --legacy-peer-deps
-      - run: npx playwright install chromium
+      - run: npx playwright install --with-deps
       - run: make slot-first-audit

--- a/docs/extensions/composition-spine/m1b-composition-graph.md
+++ b/docs/extensions/composition-spine/m1b-composition-graph.md
@@ -27,7 +27,7 @@ M1b owns **only** `consumes` edges and shader/ref authority:
 | Composition diagnostics | Canonical `composition/` diagnostic codes with structured detail fields. |
 | Graph preview | Internal `shader.assign` and `shader.remove` preview operations. |
 | Graph-first planner authority | `planRender` derives shader facts from graph nodes/edges/reference states. |
-| Graph-first export authority | `scanExportConfig` derives shader blockers from graph-resolved facts. |
+| Graph-first export scan input | `scanExportConfig` derives guard scanner findings from graph-resolved facts and feeds them to planner readiness; `planRender` remains the final export-readiness reducer. |
 | Graph-first shader validation | `validateShaderComposition` derives projected shaders from graph edges. |
 
 ### Legacy Inputs Are Compatibility Sources
@@ -208,13 +208,18 @@ When a `CompositionGraph` is present in `planRender` input:
 - Legacy snapshot shader refs are **ignored**.
 - Graph-absent callers emit a compatibility warning.
 
-### Export Guard (`exportGuard.ts`)
+### Export Guard Scanner (`exportGuard.ts`)
 
 When a `CompositionGraph` is present:
-- `scanExportConfig` derives shader blockers from `validateShaderComposition` with
-  graph input.
+- `scanExportConfig` derives guard-compatible scanner findings from
+  `validateShaderComposition` with graph input.
 - Legacy timeline shader metadata is **not** read.
 - Graph-absent callers emit a compatibility warning.
+- The scan payload is planner input. `buildExportReadinessPlan()` adapts it into
+  `planRender()`, and planner `RenderBlocker` records are the canonical
+  user-facing readiness vocabulary.
+- Any `export/*` diagnostic code emitted by the scanner is retained as
+  diagnostic metadata, not as independent readiness authority.
 
 ### Shader Validation (`shaderValidation.ts`)
 
@@ -235,7 +240,8 @@ When a `CompositionGraph` is present:
 ### Production Hook (`useRenderState.ts`)
 
 - `extensionRuntime.compositionGraph` is passed to `planRender`, `scanExportConfig`,
-  and `hasTimelineShaderMetadata` calls.
+  and `hasTimelineShaderMetadata` calls. Guard scans remain scanner inputs;
+  blocked readiness text is sourced from planner blockers.
 - Graph propagation is the only change; all other hook behavior is preserved.
 
 ## SDK Exports
@@ -273,8 +279,9 @@ M1b enforces the following guardrails:
    internal graph preview operations, not SDK exports.
 
 4. **No graph authority bypass.** When `compositionGraph` is present, planner,
-   export guard, and shader validation do not fall back to legacy fields for
-   M1b-owned facts.
+   export guard scanning, and shader validation do not fall back to legacy fields
+   for M1b-owned facts. Guard scanner output is then reduced through planner
+   blockers before it becomes user-facing readiness.
 
 5. **No legacy authority leak.** Legacy descriptor arrays are graph-derived
    when a graph is present; they are not a second authority pathway.

--- a/docs/extensions/composition-spine/m3b-live-binding-and-deterministic-capture.md
+++ b/docs/extensions/composition-spine/m3b-live-binding-and-deterministic-capture.md
@@ -2,7 +2,7 @@
 
 **Status:** Active (M3b)
 **Last updated:** 2026-07-04
-**Scope:** End-to-end architecture of the M3b live binding → deterministic capture → graph-owned keyframe pipeline. Covers live preview vs authoritative export, the frozen four-profile V1 scope, graph-owned keyframe op placement, export safety, and sidecar/process exclusions.
+**Scope:** End-to-end architecture of the M3b live binding → deterministic capture → graph-owned keyframe pipeline. Covers live preview vs planner-owned export readiness, the frozen four-profile V1 scope, graph-owned keyframe op placement, export safety, and sidecar/process exclusions.
 **Related:** [Deterministic Capture Profiles](./deterministic-capture-profiles.md) (detailed profile shapes and validation rules).
 
 ---
@@ -60,9 +60,10 @@ M3b extends the composition spine with a deterministic capture pipeline that bri
 
 ---
 
-## 2. Live preview vs authoritative export
+## 2. Live preview vs planner-owned export readiness
 
-M3b introduces a critical distinction between **live preview** and **authoritative export**:
+M3b introduces a critical distinction between **live preview** and
+**planner-owned export readiness**:
 
 ### 2.1 Live preview (non-blocking)
 
@@ -70,9 +71,14 @@ During editing, live bindings feed real-time data into the preview render. Deter
 
 Live preview diagnostics (e.g., `composition/material-live-only`) are **warnings**, not errors. They inform the user that the current state cannot be exported but allow the editing workflow to continue uninterrupted.
 
-### 2.2 Authoritative export (blocking)
+### 2.2 Export readiness (blocking)
 
-When the user initiates an export, the export guard (`exportGuard.ts`) performs an authoritative scan of all live bindings. Bindings are classified into two export target classes:
+When the user initiates an export, the export guard scanner (`exportGuard.ts`)
+performs a structured scan of all live bindings. The scanner classifies
+bindings into two export target classes, then `buildExportReadinessPlan()` feeds
+that scan payload into `planRender()`. Planner `RenderBlocker` records are the
+canonical user-facing readiness vocabulary; scanner diagnostics are planner
+input and debug metadata.
 
 | Export target class | Examples | Clearing condition |
 |---|---|---|
@@ -84,17 +90,19 @@ When the user initiates an export, the export guard (`exportGuard.ts`) performs 
 - Sidecar-only refs leave the export blocked regardless of how many exist.
 - Malformed capture metadata (missing `captureId`, invalid `provenanceHash`, unknown `profile`, empty `routeConstraints`) is surfaced as a `malformed` resolution status and blocks export.
 - Capture refs missing `browser-export` in `routeConstraints` do not clear the blocker for non-media bindings.
-- All five deterministic capture conversion diagnostic codes are blocking and surface as `export/`-prefixed diagnostics with `live-unbaked` blocker reason.
+- All five deterministic capture conversion diagnostic codes are exported as
+  `export/`-prefixed diagnostic metadata. The planner maps those codes to
+  `live-unbaked` blockers for readiness messaging.
 
 ### 2.3 Bake status propagation
 
-Each live binding carries a bake status that informs the export guard:
+Each live binding carries a bake status that informs the guard scan:
 
 | Status | Behavior |
 |---|---|
 | `unbaked` | No deterministic refs exist; export blocked. |
 | `partial` | Some ranges baked, unresolved ranges remain; export blocked. |
-| `complete` | All ranges baked with valid deterministic refs; export unblocked if refs satisfy authoritative rules (§2.2). |
+| `complete` | All ranges baked with valid deterministic refs; export unblocked if refs satisfy planner-owned readiness rules (§2.2). |
 
 ---
 
@@ -166,22 +174,27 @@ All mutations happen on a deep-cloned copy, and the original input remains uncha
 
 ## 5. Export safety
 
-### 5.1 Authoritative export guard behavior
+### 5.1 Export guard scanner behavior
 
-The export guard (`exportGuard.ts`) performs a three-phase scan:
+The export guard (`exportGuard.ts`) performs a three-phase scan that feeds
+planner readiness:
 
 1. **Live binding scan** — `scanTimelineLiveBindings` (in `timeline-domain.ts`) collects all `TimelineLiveBinding` records from the timeline config.
 2. **Resolution classification** — Each binding is classified as `media-like` or `non-media` based on its source kind and channel type.
-3. **Blocker evaluation** — Bindings are checked against the authoritative clearing rules (§2.2).
+3. **Scanner evaluation** — Bindings are checked against the clearing inputs in
+   §2.2 and emitted as guard-compatible findings/diagnostics.
 
-A binding is **unblocked** only when:
+The planner can clear a binding only when:
 - It has a `complete` bake status (no partial ranges).
 - For media-like bindings: at least one deterministic ref is a durable `asset` or `render-material` with a non-empty ref.
 - For non-media bindings: at least one deterministic ref is a structurally valid `deterministic-capture` ref with `browser-export` in its route constraints.
 
 ### 5.2 Composition graph diagnostics
 
-During export, the composition graph's `diagnostics` array is scanned for blocking target codes. All five deterministic capture conversion codes are blocking:
+During export, the composition graph's `diagnostics` array is scanned for target
+codes. All five deterministic capture conversion codes are carried as
+`export/*` diagnostic metadata and mapped by the planner adapter to
+`live-unbaked` readiness blockers:
 
 | Composition diagnostic | Export diagnostic | Blocker reason |
 |---|---|---|
@@ -195,7 +208,12 @@ Each conversion diagnostic carries `captureRef` and `provenanceHash` detail fiel
 
 ### 5.3 Material vs capture diagnostic separation
 
-Material live-only diagnostics (`composition/material-live-only`, `composition/material-stale`, etc.) are **not** in `BLOCKING_TARGET_COMPOSITION_DIAGNOSTIC_CODES`. They are handled separately through the material diagnostic path and never reach the capture-conversion blocking path. This keeps the two diagnostic categories distinct so that the export guard can differentiate between "this material is live-only" (warning) and "this deterministic capture failed conversion" (error/blocker).
+Material live-only diagnostics (`composition/material-live-only`,
+`composition/material-stale`, etc.) are **not** in
+`BLOCKING_TARGET_COMPOSITION_DIAGNOSTIC_CODES`. They are handled separately
+through the material diagnostic path and never reach the capture-conversion scan
+path. This keeps the two diagnostic categories distinct so that the planner can
+map material and capture issues to the correct readiness blockers.
 
 ---
 
@@ -212,11 +230,21 @@ The live event converter (`liveEventConversion.ts`) is intentionally **pure**:
 
 ### 6.2 Sidecar-only refs
 
-A deterministic ref with `kind: 'sidecar'` is recognized as a valid `TimelineLiveDeterministicRefKind` but **does not clear the authoritative export blocker**. Sidecar refs are metadata sidecars (JSON, CSV, etc.) that accompany the export, not durable artifacts that prove the live data has been baked. The export guard explicitly requires `asset`, `render-material`, or validated `deterministic-capture` refs to clear blockers.
+A deterministic ref with `kind: 'sidecar'` is recognized as a valid
+`TimelineLiveDeterministicRefKind` but **does not clear the planner export
+blocker**. Sidecar refs are metadata sidecars (JSON, CSV, etc.) that accompany
+the export, not durable artifacts that prove the live data has been baked. The
+guard scan requires `asset`, `render-material`, or validated
+`deterministic-capture` refs before the planner can clear blockers.
 
 ### 6.3 Process-dependent posture
 
-Captures with `determinism: 'process-dependent'` are accepted through validation (they carry valid provenance, content hash, and body schema) but their determinism posture signals that the captured values depend on host-process state (e.g., system time, random seed from host entropy). The export guard does **not** currently block on this posture alone — it is metadata for downstream consumers to interpret.
+Captures with `determinism: 'process-dependent'` are accepted through
+validation (they carry valid provenance, content hash, and body schema) but
+their determinism posture signals that the captured values depend on
+host-process state (e.g., system time, random seed from host entropy). The guard
+scan does **not** currently emit a blocker for this posture alone; it is
+metadata for downstream consumers to interpret.
 
 ---
 
@@ -271,7 +299,7 @@ This keeps the SDK surface minimal and portable while allowing the host to evolv
 | `src/tools/video-editor/runtime/liveBake.ts` | Live bake planner with deterministic capture metadata threading |
 | `src/tools/video-editor/runtime/composition/patchPreview.ts` | Graph preview operations, clone-and-apply, event metadata |
 | `src/tools/video-editor/runtime/composition/diagnostics.ts` | Composition diagnostic codes (M3b conversion codes at lines 107–123) |
-| `src/tools/video-editor/runtime/exportGuard.ts` | Authoritative export guard with capture diagnostic surfacing |
+| `src/tools/video-editor/runtime/exportGuard.ts` | Export guard scanner with capture diagnostic metadata for planner readiness |
 | `src/tools/video-editor/lib/timeline-domain.ts` | Live binding resolution, deterministic ref validation, malformed detection |
 | `src/sdk/video/liveData.ts` | Public SDK `LiveBakeTargetKind` with `deterministic-capture` discriminant |
 | `src/sdk/index.ts` | SDK barrel re-export |

--- a/docs/extensions/composition-spine/v8-architecture-baseline.md
+++ b/docs/extensions/composition-spine/v8-architecture-baseline.md
@@ -35,7 +35,7 @@ reconstructive source path. No claim depends solely on the absent v8 brief.
 | 9 | artifacts.ts | `src/sdk/video/rendering/artifacts.ts` | `RenderMaterial`, `RenderArtifact`, `RenderArtifactManifest`, `BakeContract` |
 | 10 | renderability.ts | `src/sdk/video/rendering/renderability.ts` | `RenderRoute`, `DeterminismStatus` (5 values), `RenderBlockerReason` (9 values) |
 | 11 | capabilities.ts | `src/sdk/video/rendering/capabilities.ts` | Shader materializer requirement scope |
-| 12 | renderPlanner.ts | `src/tools/video-editor/runtime/renderPlanner.ts` | Canonical render readiness reducer: route plans, blockers, diagnostics, next actions |
+| 12 | renderPlanner.ts | `src/tools/video-editor/runtime/renderPlanner.ts` | Canonical render/export readiness reducer: route plans, planner blockers, diagnostics, next actions, guard-scan adaptation |
 | 13 | phase4-readiness.md | `docs/extensions/phase4-readiness.md` | Phase 4 promotion checklist, render planner participation contract, trust posture |
 | 14 | foundation-closure-assessment.md | `docs/extensions/foundation-closure-assessment.md` | M4 closure gate, satisfied contracts, family maturity snapshot |
 | 15 | process-example.ts | `src/examples/process-example.ts` | Process contribution declaration example |
@@ -150,7 +150,7 @@ direct contribution-index access for all M1b-owned fact families.
 | Composition diagnostics | Canonical `composition/` diagnostic codes with structured detail fields (`nodeId`, `refKey`, `refState`, `scope`, `extensionId`, `contributionId`, `shaderId`). |
 | Graph preview | Internal `shader.assign` and `shader.remove` preview operations applied to a cloned graph; returns updated nodes, edges, reference states, and diagnostics without mutating the original. |
 | Graph-first planner authority | `planRender` derives shader materializer requirements and scope validation from graph nodes/edges/reference states when a graph is present. |
-| Graph-first export authority | `scanExportConfig` derives shader blockers from graph-resolved facts when a graph is present. |
+| Graph-first export scan input | `scanExportConfig` derives guard scanner findings from graph-resolved facts when a graph is present; `buildExportReadinessPlan()` feeds those findings to `planRender()`. |
 | Graph-first shader validation | `validateShaderComposition` derives projected shaders and first-wins occupancy from graph edges when a graph is present. |
 
 #### Legacy Inputs: Compatibility Sources Only
@@ -279,6 +279,17 @@ From `src/sdk/video/rendering/renderability.ts` (lines 40–49):
 
 `missing-contribution`, `route-unsupported`, `preview-only`, `live-unbaked`,
 `process-dependent`, `missing-material`, `materialization-failed`, `inactive-extension`, `unknown`.
+
+### Export Readiness Authority
+
+Export readiness is planner-owned. Guard scans, router/provider checks, and
+output-format diagnostics may contribute structured inputs, but `planRender()`
+is the final reducer and planner `RenderBlocker` records are the canonical
+user-facing readiness vocabulary. `buildExportReadinessPlan()` is a thin adapter
+that passes `scanExportConfig()` payloads into the planner instead of computing
+an independent blocked/unblocked decision. Original `export/*` diagnostic codes
+are preserved in finding detail for diagnostics and debugging; they are
+diagnostic metadata, not readiness authority.
 
 ### Render Routes
 

--- a/docs/extensions/phase4-readiness.md
+++ b/docs/extensions/phase4-readiness.md
@@ -37,11 +37,17 @@ documents.
   Remotion module, and contributed clip content into `CapabilityRequirement`
   entries, calls `planRender()`, and returns a planner-backed route decision.
 - `src/tools/video-editor/runtime/renderPlanner.ts` is the canonical render
-  readiness reducer. It consumes timeline snapshot requirements, explicit
-  requirements, output format descriptors, process descriptors, shader
-  descriptors, material refs/statuses, render groups, request constraints, and
-  diagnostics, then returns route plans, blockers, diagnostics, next actions,
-  and `canBrowserExport`/`canWorkerExport`.
+  and export readiness reducer. It consumes timeline snapshot requirements,
+  explicit requirements, output format descriptors, process descriptors, shader
+  descriptors, material refs/statuses, render groups, request constraints,
+  diagnostics, and guard scan payloads, then returns route plans, planner
+  blockers, diagnostics, next actions, and
+  `canBrowserExport`/`canWorkerExport`.
+- `src/tools/video-editor/runtime/exportGuard.ts` and `scanExportConfig()` are
+  structured scanners, not readiness authorities. Their payloads are adapted by
+  `buildExportReadinessPlan()` into `planRender()`, and planner `RenderBlocker`
+  records provide the canonical user-facing readiness vocabulary. Original
+  `export/*` codes remain diagnostic metadata for diagnostics/debug views.
 
 ## Render Planner Participation Contract
 
@@ -59,7 +65,8 @@ Required contract:
    convert into equivalent requirements.
 3. Unsupported, preview-only, live-unbaked, missing-material, stale-material,
    process-dependent, missing-contribution, and route-unsupported states must
-   produce actionable `RenderBlocker` records rather than silent fallback.
+   produce actionable planner `RenderBlocker` records rather than silent
+   fallback or guard-owned blocked text.
 4. Route decisions must remain planner-backed. For clip routing,
    `renderRouter.ts` already indexes contributed clip records by `clipTypeId`,
    allows browser export only when the contribution explicitly declares a
@@ -77,6 +84,9 @@ Required contract:
 7. Diagnostics published from planner findings must remain source-scoped so
    Extension Manager and diagnostics surfaces can show package/family blockers
    without confusing them with extension-authored runtime diagnostics.
+8. Guard scans and `export/*` diagnostics may provide scanner detail and
+   diagnostic metadata, but user-facing readiness blockers must be planner
+   blockers.
 
 Promotion is blocked for any family whose content can render, mutate timeline
 state, invoke processes, consume live data, or produce export artifacts without

--- a/src/tools/video-editor/examples/extensions/__tests__/flagship-local-m5-effect-live-canary.integration.test.tsx
+++ b/src/tools/video-editor/examples/extensions/__tests__/flagship-local-m5-effect-live-canary.integration.test.tsx
@@ -17,7 +17,10 @@ import {
 } from '@/tools/video-editor/runtime/exportGuard.ts';
 import { normalizeExtensionRuntime } from '@/tools/video-editor/runtime/extensionSurface.ts';
 import { createLiveDataRegistry } from '@/tools/video-editor/runtime/liveDataRegistry.ts';
-import { planRender } from '@/tools/video-editor/runtime/renderPlanner.ts';
+import {
+  buildExportReadinessPlan,
+  planRender,
+} from '@/tools/video-editor/runtime/renderPlanner.ts';
 
 const FLAGSHIP_EXTENSION_ID = 'com.reigh.examples.flagship-local';
 const FLAGSHIP_GLOW_CONTRIBUTION_ID = 'flagship-effect-glow';
@@ -136,7 +139,6 @@ describe('flagship-local M5 effect/live canary', () => {
     const unbakedSnapshot = await roundTripSnapshot(unbakedConfig);
 
     const blockedExport = scanExportConfig(unbakedConfig, builtIn, extensionIds);
-    expect(blockedExport.hasBlockingErrors).toBe(true);
     expect(blockedExport.diagnostics).toEqual(expect.arrayContaining([
       expect.objectContaining({
         code: 'export/live-binding-unresolved',
@@ -150,9 +152,10 @@ describe('flagship-local M5 effect/live canary', () => {
       }),
     ]));
 
-    const blockedPlanner = planRender({
+    const blockedPlanner = buildExportReadinessPlan({
       snapshot: unbakedSnapshot,
       extensionRuntime: runtime,
+      guard: blockedExport,
     });
     expect(blockedPlanner.canBrowserExport).toBe(false);
     expect(blockedPlanner.blockers).toEqual(expect.arrayContaining([
@@ -213,7 +216,6 @@ describe('flagship-local M5 effect/live canary', () => {
       graph,
     );
     expect(clearedExport.diagnostics.filter((diagnostic) => diagnostic.code === 'export/live-binding-unresolved')).toEqual([]);
-    expect(clearedExport.hasBlockingErrors).toBe(false);
 
     const clearedPlanner = planRender({
       snapshot: bakedSnapshot,
@@ -222,5 +224,11 @@ describe('flagship-local M5 effect/live canary', () => {
     });
     expect(clearedPlanner.canBrowserExport).toBe(true);
     expect(clearedPlanner.blockers.filter((blocker) => blocker.reason === 'live-unbaked')).toEqual([]);
+    expect(buildExportReadinessPlan({
+      snapshot: bakedSnapshot,
+      compositionGraph: graph,
+      extensionRuntime: runtime,
+      guard: clearedExport,
+    }).canBrowserExport).toBe(true);
   });
 });

--- a/src/tools/video-editor/examples/extensions/__tests__/live-data-bridge.integration.test.tsx
+++ b/src/tools/video-editor/examples/extensions/__tests__/live-data-bridge.integration.test.tsx
@@ -43,6 +43,7 @@ import {
   collectExtensionDeclaredIds,
   scanExportConfig,
 } from '@/tools/video-editor/runtime/exportGuard';
+import { buildExportReadinessPlan } from '@/tools/video-editor/runtime/renderPlanner';
 import { scanTimelineLiveBindings } from '@/tools/video-editor/lib/timeline-domain';
 import type { ResolvedTimelineConfig } from '@/tools/video-editor/types';
 import type {
@@ -441,10 +442,10 @@ describe('M11 live data bridge integration', () => {
       undefined,
       clipTypeSnapshot,
     );
-    expect(blocked.hasBlockingErrors).toBe(true);
     expect(blocked.diagnostics).toEqual(expect.arrayContaining([
       expect.objectContaining({ code: 'export/live-binding-unresolved' }),
     ]));
+    expect(buildExportReadinessPlan({ guard: blocked }).canBrowserExport).toBe(false);
 
     const clearedConfig = removeLiveBindingsFromResolvedConfig(orphanedConfig, WEBCAM_SOURCE_ID);
     expect(clearedConfig).not.toBeNull();
@@ -457,7 +458,7 @@ describe('M11 live data bridge integration', () => {
       clipTypeSnapshot,
     );
     expect(cleared.diagnostics.filter((diagnostic) => diagnostic.code === 'export/live-binding-unresolved')).toEqual([]);
-    expect(cleared.hasBlockingErrors).toBe(false);
+    expect(buildExportReadinessPlan({ guard: cleared }).canBrowserExport).toBe(true);
 
     host.disposeAll();
   });
@@ -539,8 +540,8 @@ describe('M11 live data bridge integration', () => {
       collectBuiltInKnownIds(),
       collectExtensionDeclaredIds([]),
     );
-    expect(liveGuard.hasBlockingErrors).toBe(true);
     expect(liveGuard.findings.map((finding) => finding.detail?.resolutionStatus)).toContain('active');
+    expect(buildExportReadinessPlan({ guard: liveGuard }).canBrowserExport).toBe(false);
 
     const partial = test.controller.bakeAcceptedTake('generated-int-take-main', 'take-main');
     expect(partial.success).toBe(true);
@@ -562,8 +563,8 @@ describe('M11 live data bridge integration', () => {
       collectBuiltInKnownIds(),
       collectExtensionDeclaredIds([]),
     );
-    expect(partialGuard.hasBlockingErrors).toBe(true);
     expect(partialGuard.findings.map((finding) => finding.detail?.resolutionStatus)).toContain('partiallyBaked');
+    expect(buildExportReadinessPlan({ guard: partialGuard }).canBrowserExport).toBe(false);
 
     const asset = test.controller.bakeAsset('generated-int-full-asset');
     const material = test.controller.bakeRenderMaterial('generated-int-full-material');
@@ -591,7 +592,7 @@ describe('M11 live data bridge integration', () => {
       collectExtensionDeclaredIds([]),
     );
     expect(fullGuard.diagnostics.filter((diagnostic) => diagnostic.code === 'export/live-binding-unresolved')).toEqual([]);
-    expect(fullGuard.hasBlockingErrors).toBe(false);
+    expect(buildExportReadinessPlan({ guard: fullGuard }).canBrowserExport).toBe(true);
 
     test.dispose();
   });

--- a/src/tools/video-editor/examples/extensions/__tests__/live-webcam-canary.test.ts
+++ b/src/tools/video-editor/examples/extensions/__tests__/live-webcam-canary.test.ts
@@ -25,6 +25,7 @@ import {
   collectExtensionDeclaredIds,
   scanExportConfig,
 } from '@/tools/video-editor/runtime/exportGuard';
+import { buildExportReadinessPlan } from '@/tools/video-editor/runtime/renderPlanner';
 import { scanTimelineLiveBindings } from '@/tools/video-editor/lib/timeline-domain';
 import type { ResolvedTimelineConfig } from '@/tools/video-editor/types';
 
@@ -326,13 +327,13 @@ describe('live-webcam-canary extension', () => {
       collectBuiltInKnownIds(),
       collectExtensionDeclaredIds([]),
     );
-    expect(exportScan.hasBlockingErrors).toBe(true);
     expect(exportScan.diagnostics).toEqual(expect.arrayContaining([
       expect.objectContaining({
         severity: 'error',
         code: 'export/live-binding-unresolved',
       }),
     ]));
+    expect(buildExportReadinessPlan({ guard: exportScan }).canBrowserExport).toBe(false);
 
     host.disposeAll();
   });

--- a/src/tools/video-editor/examples/extensions/__tests__/m5-composed-examples.browser.test.tsx
+++ b/src/tools/video-editor/examples/extensions/__tests__/m5-composed-examples.browser.test.tsx
@@ -37,7 +37,10 @@ import {
 import { projectCompositionGraph } from '@/tools/video-editor/runtime/composition/graphProjector.ts';
 import { createLiveDataRegistry } from '@/tools/video-editor/runtime/liveDataRegistry.ts';
 import { normalizeExtensionRuntime } from '@/tools/video-editor/runtime/extensionSurface.ts';
-import type { RenderPlannerResult } from '@/tools/video-editor/runtime/renderPlanner.ts';
+import {
+  buildExportReadinessPlan,
+  type RenderPlannerResult,
+} from '@/tools/video-editor/runtime/renderPlanner.ts';
 import type {
   ResolvedTimelineConfig,
   TimelineLiveBinding,
@@ -287,6 +290,7 @@ interface EffectShellState {
   hasConsumesEdge: boolean;
   hasBindsLiveEdge: boolean;
   exportBlocked: boolean;
+  scannerDiagnosticCode: string | null;
   blockerMessage: string | null;
 }
 
@@ -301,6 +305,7 @@ function EffectLiveAcceptanceShell({
     hasConsumesEdge: false,
     hasBindsLiveEdge: false,
     exportBlocked: false,
+    scannerDiagnosticCode: null,
     blockerMessage: null,
   });
 
@@ -322,6 +327,15 @@ function EffectLiveAcceptanceShell({
         undefined,
         graph,
       );
+      const exportReadiness = buildExportReadinessPlan({
+        snapshot,
+        compositionGraph: graph,
+        extensionRuntime: FLAGSHIP_RUNTIME,
+        guard: exportResult,
+      });
+      const liveBindingDiagnostic = exportResult.diagnostics.find((diagnostic) => (
+        diagnostic.code === 'export/live-binding-unresolved'
+      ));
 
       if (cancelled) {
         return;
@@ -343,8 +357,12 @@ function EffectLiveAcceptanceShell({
           && edge.detail?.targetKind === 'effect-param'
           && edge.detail?.targetPath === 'intensity'
         )),
-        exportBlocked: exportResult.hasBlockingErrors,
-        blockerMessage: exportResult.diagnostics.find((diagnostic) => diagnostic.code === 'export/live-binding-unresolved')?.message ?? null,
+        exportBlocked: !exportReadiness.canBrowserExport,
+        scannerDiagnosticCode: liveBindingDiagnostic?.code ?? null,
+        blockerMessage: exportReadiness.blockers.find((blocker) => (
+          blocker.route === 'browser-export'
+          && blocker.reason === 'live-unbaked'
+        ))?.message ?? null,
       });
     }
 
@@ -371,10 +389,10 @@ function EffectLiveAcceptanceShell({
       <div data-testid="ex02-consumes">{String(state.hasConsumesEdge)}</div>
       <div data-testid="ex02-binds-live">{String(state.hasBindsLiveEdge)}</div>
       <div data-testid="ex02-export-blocked">{String(state.exportBlocked)}</div>
-      {state.blockerMessage ? (
+      {state.blockerMessage && state.scannerDiagnosticCode ? (
         <BlockerActionCard
           severity="error"
-          code="export/live-binding-unresolved"
+          code={state.scannerDiagnosticCode}
           message={state.blockerMessage}
           nextAction={{
             kind: 'bake',

--- a/src/tools/video-editor/hooks/useRenderState.test.tsx
+++ b/src/tools/video-editor/hooks/useRenderState.test.tsx
@@ -19,20 +19,112 @@ import {
   type VideoEditorRuntimeContextValue,
 } from '@/tools/video-editor/contexts/DataProviderContext';
 import { createDiagnosticCollection } from '@reigh/editor-sdk';
+import type { RenderPlannerResult } from '@/tools/video-editor/runtime/renderPlanner';
 
 const mocks = vi.hoisted(() => ({
   startClientRender: vi.fn(),
 }));
 
+const renderPlannerMocks = vi.hoisted(() => ({
+  buildExportReadinessPlan: vi.fn(),
+  planRender: vi.fn(),
+}));
+
+vi.mock('@/tools/video-editor/runtime/renderPlanner', async () => {
+  const actual = await vi.importActual<typeof import('@/tools/video-editor/runtime/renderPlanner')>(
+    '@/tools/video-editor/runtime/renderPlanner',
+  );
+  renderPlannerMocks.buildExportReadinessPlan.mockImplementation(actual.buildExportReadinessPlan);
+  renderPlannerMocks.planRender.mockImplementation(actual.planRender);
+  return {
+    ...actual,
+    buildExportReadinessPlan: renderPlannerMocks.buildExportReadinessPlan,
+    planRender: renderPlannerMocks.planRender,
+  };
+});
+
+function makePlannerResult(blockers: RenderPlannerResult['blockers'] = []): RenderPlannerResult {
+  const routes = ['preview', 'browser-export', 'worker-export', 'sidecar-export'] as const;
+  return {
+    guard: {
+      diagnostics: [],
+      findings: [],
+      blockers,
+      unknownClipTypes: [],
+      unknownEffects: [],
+      unknownTransitions: [],
+      inactiveExtensionIds: {
+        effectIds: new Set(),
+        transitionIds: new Set(),
+        clipTypeIds: new Set(),
+      },
+      hasBlockingErrors: blockers.length > 0,
+    },
+    findings: blockers,
+    blockers,
+    routes: routes.map((route) => ({
+      route,
+      blockerCount: blockers.filter((blocker) => blocker.route === route).length,
+      findingCount: blockers.filter((blocker) => blocker.route === route).length,
+      blocked: blockers.some((blocker) => blocker.route === route),
+    })),
+    routePlans: routes.map((route) => ({
+      route,
+      blockerCount: blockers.filter((blocker) => blocker.route === route).length,
+      findingCount: blockers.filter((blocker) => blocker.route === route).length,
+      blocked: blockers.some((blocker) => blocker.route === route),
+      requiredCapabilities: [],
+      determinism: 'deterministic',
+      blockers: blockers.filter((blocker) => blocker.route === route),
+      diagnostics: blockers.filter((blocker) => blocker.route === route),
+      outputFormatIds: [],
+      processRequirements: [],
+      nextActions: [],
+      artifactCompletion: {
+        status: 'complete',
+        requiredProfiles: [],
+        completeProfiles: [],
+        incompleteProfiles: [],
+        blockedProfiles: [],
+        profiles: [],
+      },
+    })),
+    diagnostics: blockers,
+    nextActions: [],
+    canBrowserExport: !blockers.some((blocker) => blocker.route === 'browser-export'),
+    canWorkerExport: !blockers.some((blocker) => blocker.route === 'worker-export'),
+    canSidecarExport: !blockers.some((blocker) => blocker.route === 'sidecar-export'),
+  };
+}
+
 const renderRouterMocks = vi.hoisted(() => ({
   decideRenderRoute: vi.fn((timeline: ResolvedTimelineConfig | null | undefined) => {
     const clip = timeline?.clips?.[0];
     if (clip?.generation?.sequence_lane === 'remotion_module' && !clip?.generation?.artifact_id) {
+      const message = `Generated remotion_module clip "${clip.id}" is missing artifact metadata.`;
       return {
         route: 'preview-only',
         hasThemedClip: false,
         hasMediaClip: false,
+        hasContributedClip: false,
         reason: 'remotion_module_missing_artifact',
+        planner: {
+          selectedPlannerRoute: 'preview',
+          plannerResult: makePlannerResult([
+            {
+              id: `router.generatedModule.${clip.id}.missingArtifact.preview`,
+              severity: 'error',
+              route: 'preview',
+              reason: 'missing-material',
+              message,
+              clipId: clip.id,
+              detail: {
+                source: 'render-router',
+                legacyReason: 'remotion_module_missing_artifact',
+              },
+            },
+          ]),
+        },
       };
     }
 
@@ -41,7 +133,12 @@ const renderRouterMocks = vi.hoisted(() => ({
         route: 'worker-banodoco',
         hasThemedClip: false,
         hasMediaClip: false,
+        hasContributedClip: false,
         reason: 'generated_remotion_module',
+        planner: {
+          selectedPlannerRoute: 'worker-export',
+          plannerResult: makePlannerResult(),
+        },
       };
     }
 
@@ -49,7 +146,12 @@ const renderRouterMocks = vi.hoisted(() => ({
       route: 'browser-remotion',
       hasThemedClip: false,
       hasMediaClip: true,
+      hasContributedClip: false,
       reason: 'pure_native_clips',
+      planner: {
+        selectedPlannerRoute: 'browser-export',
+        plannerResult: makePlannerResult(),
+      },
     };
   }),
 }));
@@ -582,6 +684,172 @@ describe('useRenderState render routing', () => {
     });
     expect(result.current.renderLog).toBe(plannerDiagnostic?.message);
   });
+
+  it('surfaces generated-module preview blocks from router planner context', async () => {
+    const plannerMessage = 'Planner context says generated module artifact "artifact-missing" is absent.';
+    renderRouterMocks.decideRenderRoute.mockImplementationOnce(() => ({
+      route: 'preview-only',
+      hasThemedClip: false,
+      hasMediaClip: false,
+      hasContributedClip: false,
+      reason: 'remotion_module_missing_artifact',
+      planner: {
+        selectedPlannerRoute: 'preview',
+        plannerResult: makePlannerResult([
+          {
+            id: 'router.generatedModule.clip-module-bad.missingArtifact.preview',
+            severity: 'error',
+            route: 'preview',
+            reason: 'missing-material',
+            message: plannerMessage,
+            clipId: 'clip-module-bad',
+            detail: {
+              source: 'render-router',
+              legacyReason: 'remotion_module_missing_artifact',
+            },
+          },
+        ]),
+      },
+    }));
+
+    const { result } = renderHook(() => useRenderState(
+      buildConfig({
+        id: 'clip-module-bad',
+        clipType: 'media',
+        track: 'V1',
+        at: 0,
+        hold: 1,
+        generation: {
+          sequence_lane: 'remotion_module',
+        },
+      }),
+      null,
+    ));
+
+    await act(async () => {
+      await result.current.startRender();
+    });
+
+    expect(result.current.renderStatus).toBe('error');
+    expect(result.current.renderLog).toContain(plannerMessage);
+    expect(result.current.renderLog).not.toContain('Render route "remotion_module_missing_artifact" is not exportable.');
+    expect(mocks.startClientRender).not.toHaveBeenCalled();
+  });
+
+  it('uses planner blocker text for worker provider unavailability', async () => {
+    const plannerMessage = 'Planner worker blocker text from route availability.';
+    renderPlannerMocks.planRender.mockReturnValueOnce(makePlannerResult([
+      {
+        id: 'planner.request.worker-export.worker-banodoco.unavailable',
+        severity: 'error',
+        route: 'worker-export',
+        reason: 'process-dependent',
+        message: plannerMessage,
+        detail: {
+          source: 'render-request',
+          routeAvailability: 'unavailable',
+          providerId: 'worker-banodoco',
+        },
+      },
+    ]));
+
+    const { result } = renderHook(() => useRenderState(
+      buildConfig({
+        id: 'clip-module-good',
+        clipType: 'generated-module',
+        track: 'V1',
+        at: 0,
+        hold: 1,
+        generation: {
+          sequence_lane: 'remotion_module',
+          artifact_id: 'artifact-1',
+        },
+      }),
+      null,
+    ));
+
+    await act(async () => {
+      await result.current.startRender();
+    });
+
+    expect(result.current.renderStatus).toBe('error');
+    expect(result.current.renderLog).toContain(plannerMessage);
+    expect(result.current.renderLog).not.toContain('Render provider unavailable');
+    expect(renderPlannerMocks.planRender).toHaveBeenCalledWith(expect.objectContaining({
+      request: expect.objectContaining({
+        route: 'worker-export',
+        routeAvailability: [
+          expect.objectContaining({
+            route: 'worker-export',
+            available: false,
+            providerId: 'worker-banodoco',
+          }),
+        ],
+      }),
+    }));
+    expect(mocks.startClientRender).not.toHaveBeenCalled();
+  });
+
+  it('uses planner blocker text for external provider unavailability', async () => {
+    const plannerMessage = 'Planner sidecar blocker text from route availability.';
+    renderRouterMocks.decideRenderRoute.mockImplementationOnce(() => ({
+      route: 'external',
+      hasThemedClip: false,
+      hasMediaClip: false,
+      hasContributedClip: false,
+      reason: 'external_provider_required',
+      planner: {
+        selectedPlannerRoute: 'sidecar-export',
+        plannerResult: makePlannerResult(),
+      },
+    }));
+    renderPlannerMocks.planRender.mockReturnValueOnce(makePlannerResult([
+      {
+        id: 'planner.request.sidecar-export.external.unavailable',
+        severity: 'error',
+        route: 'sidecar-export',
+        reason: 'route-unsupported',
+        message: plannerMessage,
+        detail: {
+          source: 'render-request',
+          routeAvailability: 'unavailable',
+          providerId: 'external',
+        },
+      },
+    ]));
+
+    const { result } = renderHook(() => useRenderState(
+      buildConfig({
+        id: 'clip-external',
+        clipType: 'media',
+        track: 'V1',
+        at: 0,
+        hold: 1,
+      }),
+      null,
+    ));
+
+    await act(async () => {
+      await result.current.startRender();
+    });
+
+    expect(result.current.renderStatus).toBe('error');
+    expect(result.current.renderLog).toContain(plannerMessage);
+    expect(result.current.renderLog).not.toContain('Render provider unavailable');
+    expect(renderPlannerMocks.planRender).toHaveBeenCalledWith(expect.objectContaining({
+      request: expect.objectContaining({
+        route: 'sidecar-export',
+        routeAvailability: [
+          expect.objectContaining({
+            route: 'sidecar-export',
+            available: false,
+            providerId: 'external',
+          }),
+        ],
+      }),
+    }));
+    expect(mocks.startClientRender).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -836,10 +1104,11 @@ describe('useRenderState export guard', () => {
 
       // Render was blocked
       expect(result.current.renderStatus).toBe('error');
-      expect(result.current.renderLog).toContain('Export guard');
+      expect(result.current.renderLog).toContain('Export readiness blocked by the render planner');
       expect(result.current.renderLog).toContain('alien-format');
       // Native routing was preserved — client render was NOT invoked
       expect(mocks.startClientRender).not.toHaveBeenCalled();
+      expect(renderPlannerMocks.buildExportReadinessPlan).toHaveBeenCalledTimes(1);
     });
 
     it('blocks exporter render too when guard finds blocking errors', async () => {
@@ -897,7 +1166,8 @@ describe('useRenderState export guard', () => {
       });
 
       expect(result.current.renderStatus).toBe('error');
-      expect(result.current.renderLog).toContain('Export guard');
+      expect(result.current.renderLog).toContain('Export readiness blocked by the render planner');
+      expect(result.current.renderLog).toContain('crazy-spin');
       expect(exporter.render).not.toHaveBeenCalled();
     });
 
@@ -965,13 +1235,11 @@ describe('useRenderState export guard', () => {
 
       expect(result.current.renderStatus).toBe('error');
       const log = result.current.renderLog;
-      // Summary line
-      expect(log).toContain('Export guard: 3 issue(s) — 2 error(s), 1 warning(s)');
-      // Error diagnostics shown first
-      expect(log).toContain('[export/unknown-clip-type]');
-      expect(log).toContain('[export/unknown-effect-type]');
-      // Warning still shown
-      expect(log).toContain('[export/unknown-transition-type]');
+      expect(log).toContain('Export readiness blocked by the render planner');
+      expect(log).toContain('[browser-export/missing-contribution]');
+      expect(log).toContain('alien-format');
+      expect(log).toContain('hyperspace');
+      expect(log).not.toContain('star-wipe');
     });
 
     it('publishes export and planner diagnostics to the provider collection during guard execution', async () => {
@@ -1090,6 +1358,70 @@ describe('useRenderState export guard', () => {
       expect(result.current.renderStatus).toBe('error');
       expect(mocks.startClientRender).not.toHaveBeenCalled();
     });
+
+    it('does not use raw guard diagnostic text when planner blockers exist', async () => {
+      const rawGuardMessage = 'RAW GUARD DIAGNOSTIC SHOULD STAY OUT OF THE USER LOG';
+      const plannerMessage = 'Planner blocker says the export contribution is missing.';
+      const extRuntime = makeExtensionRuntime({
+        extensions: [
+          {
+            manifest: {
+              id: 'test-ext' as any,
+              version: '1.0.0',
+              contributions: [],
+            },
+          } as any,
+        ],
+      });
+
+      guardMocks.scanExportConfig.mockReturnValue({
+        ...cleanGuardResult(),
+        diagnostics: [
+          {
+            severity: 'error',
+            code: 'export/unknown-effect-type',
+            message: rawGuardMessage,
+            detail: { clipId: 'c1', effectType: 'raw-effect' },
+          },
+        ],
+        hasBlockingErrors: true,
+      });
+      renderPlannerMocks.buildExportReadinessPlan.mockReturnValueOnce(makePlannerResult([
+        {
+          id: 'planner.compat.effect.browser-export.missing',
+          severity: 'error',
+          route: 'browser-export',
+          reason: 'missing-contribution',
+          message: plannerMessage,
+          detail: {
+            source: 'render-planner',
+            effectType: 'raw-effect',
+          },
+        },
+      ]));
+
+      const { result } = renderHook(() => useRenderState(
+        buildConfig({
+          id: 'c1',
+          clipType: 'media',
+          track: 'V1',
+          at: 0,
+          hold: 1,
+        }),
+        null,
+        null,
+        extRuntime,
+      ));
+
+      await act(async () => {
+        await result.current.startRender();
+      });
+
+      expect(result.current.renderStatus).toBe('error');
+      expect(result.current.renderLog).toContain(plannerMessage);
+      expect(result.current.renderLog).not.toContain(rawGuardMessage);
+      expect(mocks.startClientRender).not.toHaveBeenCalled();
+    });
   });
 
   describe('export guard — warnings only (preserve native routing)', () => {
@@ -1151,10 +1483,7 @@ describe('useRenderState export guard', () => {
 
       // Native routing preserved — client render invoked
       expect(mocks.startClientRender).toHaveBeenCalledTimes(1);
-      // But diagnostics are still emitted in the render log
-      expect(result.current.renderLog).toContain('Export guard');
-      expect(result.current.renderLog).toContain('future-transition');
-      expect(result.current.renderLog).toContain('warning');
+      expect(result.current.renderLog).toBe('');
     });
 
     it('allows render when guard finds no issues at all', async () => {
@@ -1201,7 +1530,7 @@ describe('useRenderState export guard', () => {
       });
 
       expect(mocks.startClientRender).toHaveBeenCalledTimes(1);
-      expect(result.current.renderLog).toContain('Export guard: no issues found.');
+      expect(result.current.renderLog).toBe('');
     });
   });
 
@@ -1256,9 +1585,7 @@ describe('useRenderState export guard', () => {
       // Guard passed but preview-only blocked it — native routing preserved
       expect(result.current.renderStatus).toBe('error');
       expect(result.current.renderLog).toContain('Render blocked');
-      expect(result.current.renderLog).toContain('remotion_module_missing_artifact');
-      // But guard log was set first (then overwritten by the route block)
-      // The route block's log takes precedence
+      expect(result.current.renderLog).toContain('missing artifact metadata');
       expect(mocks.startClientRender).not.toHaveBeenCalled();
     });
 
@@ -1519,7 +1846,7 @@ describe('useRenderState export guard', () => {
       expect(mocks.startClientRender).not.toHaveBeenCalled();
       expect(result.current.renderStatus).toBe('error');
       expect(result.current.renderLog).toContain('Render blocked');
-      expect(result.current.renderLog).toContain('remotion_module_missing_artifact');
+      expect(result.current.renderLog).toContain('missing artifact metadata');
     });
   });
 
@@ -1586,7 +1913,7 @@ describe('useRenderState export guard', () => {
       });
 
       expect(result.current.renderStatus).toBe('idle');
-      expect(result.current.renderLog).toContain('Export guard: no issues found.');
+      expect(result.current.renderLog).toBe('');
       expect(mocks.startClientRender).toHaveBeenCalledTimes(1);
     });
 
@@ -1654,7 +1981,7 @@ describe('useRenderState export guard', () => {
 
       // Blocked because the effect is not declared by any extension and not built-in
       expect(result.current.renderStatus).toBe('error');
-      expect(result.current.renderLog).toContain('Export guard');
+      expect(result.current.renderLog).toContain('Export readiness blocked by the render planner');
       expect(result.current.renderLog).toContain('missing-effect');
       expect(mocks.startClientRender).not.toHaveBeenCalled();
     });
@@ -1723,9 +2050,7 @@ describe('useRenderState export guard', () => {
 
       // Not blocked — warning only, routing preserved
       expect(result.current.renderStatus).toBe('idle');
-      expect(result.current.renderLog).toContain('Export guard');
-      expect(result.current.renderLog).toContain('future-effect');
-      expect(result.current.renderLog).toContain('warning');
+      expect(result.current.renderLog).toBe('');
       expect(mocks.startClientRender).toHaveBeenCalledTimes(1);
     });
 
@@ -1809,10 +2134,7 @@ describe('useRenderState export guard', () => {
       // Guard invoked (extensions present), warnings emitted, routing preserved
       expect(guardMocks.scanExportConfig).toHaveBeenCalledTimes(1);
       expect(result.current.renderStatus).toBe('idle');
-      expect(result.current.renderLog).toContain('Export guard');
-      expect(result.current.renderLog).toContain('custom-fx');
-      expect(result.current.renderLog).toContain('custom-transition');
-      expect(result.current.renderLog).toContain('warning');
+      expect(result.current.renderLog).toBe('');
       expect(mocks.startClientRender).toHaveBeenCalledTimes(1);
     });
   });
@@ -1906,7 +2228,7 @@ describe('useRenderState export guard', () => {
       expect(firstSnapshot.records).toHaveLength(0);
       expect(secondSnapshot.has('late-provider-effect')).toBe(true);
       expect(secondSnapshot.records).toHaveLength(1);
-      expect(result.current.renderLog).toContain('Export guard: no issues found.');
+      expect(result.current.renderLog).toBe('');
       expect(mocks.startClientRender).toHaveBeenCalledTimes(1);
     });
   });
@@ -2122,6 +2444,72 @@ describe('useRenderState — M6 export behavior', () => {
 
     expect(result.current.exportStatus).toBe('error');
     expect(result.current.exportLog).toContain('no compile-only output handlers registered');
+    expect(exportMocks.executeCompileOnlyOutput).not.toHaveBeenCalled();
+  });
+
+  it('surfaces compile-only missing-handler planner text before guard or execution', async () => {
+    const plannerMessage = 'Planner compile-only blocker text before execution.';
+    renderPlannerMocks.planRender.mockReturnValueOnce(makePlannerResult([
+      {
+        id: 'planner.outputFormat.ext-a.fmt-json.browser-export.compile-handler-missing',
+        severity: 'error',
+        route: 'browser-export',
+        reason: 'missing-contribution',
+        message: plannerMessage,
+        extensionId: 'ext-a',
+        contributionId: 'fmt-json',
+        detail: {
+          source: 'render-request',
+          outputFormatId: 'fmt-json',
+          requestedRoute: 'browser-export',
+          compileOnlyHandlerAvailable: false,
+        },
+      },
+    ]));
+    guardMocks.scanExportConfig.mockImplementation(() => {
+      throw new Error('guard should not run before compile-only handler availability blocks');
+    });
+    const extRuntime = makeExtensionRuntime({
+      extensions: [
+        {
+          manifest: {
+            id: 'test-ext' as any,
+            version: '1.0.0',
+            contributions: [],
+          },
+        } as any,
+      ],
+      config: {
+        slots: {},
+        dialogHost: { dialogs: [] },
+        registry: { panels: [], inspectorSections: [] },
+        outputFormats: [
+          { id: 'fmt-json', extensionId: 'ext-a', label: 'JSON', requiresRender: false, outputExtension: 'json', disabled: false },
+        ],
+      } as any,
+    });
+
+    const { result } = renderHook(() => useRenderState(
+      buildConfig({ id: 'c1', clipType: 'media', track: 'V1', at: 0, hold: 1 }),
+      null,
+      null,
+      extRuntime,
+    ));
+
+    await act(async () => {
+      await result.current.startExport('fmt-json', new Map());
+    });
+
+    expect(result.current.exportStatus).toBe('error');
+    expect(result.current.exportLog).toContain(plannerMessage);
+    expect(renderPlannerMocks.planRender).toHaveBeenCalledWith(expect.objectContaining({
+      request: expect.objectContaining({
+        outputFormatId: 'fmt-json',
+        routes: ['browser-export'],
+        compileOnlyHandlerAvailable: false,
+      }),
+    }));
+    expect(guardMocks.scanExportConfig).not.toHaveBeenCalled();
     expect(exportMocks.executeCompileOnlyOutput).not.toHaveBeenCalled();
   });
 
@@ -2583,7 +2971,7 @@ describe('useRenderState — M6 export behavior', () => {
 
     // Render was blocked by guard despite having export formats
     expect(result.current.renderStatus).toBe('error');
-    expect(result.current.renderLog).toContain('Export guard');
+    expect(result.current.renderLog).toContain('Export readiness blocked by the render planner');
     expect(result.current.renderLog).toContain('alien-format');
     expect(mocks.startClientRender).not.toHaveBeenCalled();
   });
@@ -2773,9 +3161,9 @@ describe('useRenderState export guard — clip-type registry snapshot', () => {
     });
 
     expect(result.current.renderStatus).toBe('error');
-    expect(result.current.renderLog).toContain('Export guard');
+    expect(result.current.renderLog).toContain('Export readiness blocked by the render planner');
     expect(result.current.renderLog).toContain('stale-clip-type');
-    expect(result.current.renderLog).toContain('export/unrenderable-clip-type');
+    expect(result.current.renderLog).toContain('route-unsupported');
     expect(result.current.renderLog).toContain('inactive');
     expect(mocks.startClientRender).not.toHaveBeenCalled();
   });
@@ -2825,9 +3213,7 @@ describe('useRenderState export guard — clip-type registry snapshot', () => {
 
     // Warning only — native routing preserved
     expect(mocks.startClientRender).toHaveBeenCalledTimes(1);
-    expect(result.current.renderLog).toContain('Export guard');
-    expect(result.current.renderLog).toContain('future-clip');
-    expect(result.current.renderLog).toContain('warning');
+    expect(result.current.renderLog).toBe('');
   });
 
   it('publishes clip-type diagnostics to the provider collection', async () => {

--- a/src/tools/video-editor/hooks/useRenderState.ts
+++ b/src/tools/video-editor/hooks/useRenderState.ts
@@ -7,6 +7,7 @@ import type { ExtensionRuntime, VideoEditorOutputFormatDescriptor } from '@/tool
 import {
   createCompileOnlyOutputFormatRegistry,
   executeCompileOnlyOutput,
+  formatScopedKey,
   type CompileOnlyOutputFormatEntry,
   type CompileOnlyOutputFormatRegistry,
 } from '@/tools/video-editor/runtime/outputFormatRegistry.ts';
@@ -20,16 +21,17 @@ import {
   scanExportConfig,
 } from '@/tools/video-editor/runtime/exportGuard.ts';
 import {
+  buildExportReadinessPlan,
   planRender,
   type RenderPlannerResult,
 } from '@/tools/video-editor/runtime/renderPlanner.ts';
+import type { PlannerBackedRenderRouteDecision } from '@/tools/video-editor/lib/renderRouter.ts';
 import {
   DataProviderContext,
   type VideoEditorRuntimeContextValue,
 } from '@/tools/video-editor/contexts/DataProviderContext.tsx';
 import { syncPlannerDiagnosticsToCollection } from '@/tools/video-editor/runtime/diagnosticCollectionSync.ts';
 import type {
-  CapabilityFinding,
   Diagnostic,
   ExportDiagnostic,
   RenderBlocker,
@@ -103,84 +105,6 @@ function buildExtensionContributions(extRuntime: ExtensionRuntime) {
   return allContributions;
 }
 
-/**
- * Create a concise render log line from export guard diagnostics.
- * Emits a single summary line plus per-diagnostic error lines for blocking issues.
- */
-function formatExportGuardLog(
-  guardResult: ReturnType<typeof scanExportConfig>,
-): string {
-  const lines: string[] = [];
-
-  const totalDiags = guardResult.diagnostics.length;
-  const errorCount = guardResult.diagnostics.filter((d) => d.severity === 'error').length;
-  const warningCount = guardResult.diagnostics.filter((d) => d.severity === 'warning').length;
-  const infoCount = totalDiags - errorCount - warningCount;
-
-  if (totalDiags === 0) {
-    lines.push('Export guard: no issues found.');
-    return lines.join('\n');
-  }
-
-  lines.push(
-    `Export guard: ${totalDiags} issue(s) — ${errorCount} error(s), ${warningCount} warning(s), ${infoCount} info(s).`,
-  );
-
-  // Show blocking errors first, naming the effect/transition and route when available
-  for (const diag of guardResult.diagnostics) {
-    if (diag.severity === 'error') {
-      const name = diag.detail?.effectType
-        ? ` effect "${diag.detail.effectType}"`
-        : diag.detail?.transitionType
-          ? ` transition "${diag.detail.transitionType}"`
-          : diag.detail?.clipType
-            ? ` clip type "${diag.detail.clipType}"`
-            : diag.detail?.shaderId
-              ? ` shader "${diag.detail.shaderId}"`
-            : '';
-      const route = diag.detail?.renderRoute ? ` (${diag.detail.renderRoute})` : '';
-      lines.push(`  [${diag.code}]${name}${route}: ${diag.message}`);
-    }
-  }
-
-  // Then warnings — also name effects/transitions/clip types
-  for (const diag of guardResult.diagnostics) {
-    if (diag.severity === 'warning') {
-      const name = diag.detail?.effectType
-        ? ` effect "${diag.detail.effectType}"`
-        : diag.detail?.transitionType
-          ? ` transition "${diag.detail.transitionType}"`
-          : diag.detail?.clipType
-            ? ` clip type "${diag.detail.clipType}"`
-            : diag.detail?.shaderId
-              ? ` shader "${diag.detail.shaderId}"`
-            : '';
-      const route = diag.detail?.renderRoute ? ` (${diag.detail.renderRoute})` : '';
-      lines.push(`  [${diag.code}]${name}${route}: ${diag.message}`);
-    }
-  }
-
-  // Append per-route blocker summaries from findings (when available)
-  const blockerFindings = (guardResult.findings ?? []).filter((f) => f.severity === 'error');
-  if (blockerFindings.length > 0) {
-    lines.push('');
-    lines.push('Route blockers:');
-    for (const finding of blockerFindings) {
-      const name = finding.detail?.effectType
-        ? `"${finding.detail.effectType}"`
-        : finding.detail?.transitionType
-          ? `"${finding.detail.transitionType}"`
-          : finding.detail?.shaderId
-            ? `"${finding.detail.shaderId}"`
-          : 'unknown';
-      const route = finding.route ?? 'unknown-route';
-      lines.push(`  ${name} blocked on ${route}: ${finding.message}`);
-    }
-  }
-
-  return lines.join('\n');
-}
-
 function exportDiagnosticId(diagnostic: ReturnType<typeof scanExportConfig>['diagnostics'][number], index: number): string {
   const detail = diagnostic.detail ?? {};
   return [
@@ -193,46 +117,6 @@ function exportDiagnosticId(diagnostic: ReturnType<typeof scanExportConfig>['dia
   ].join(':');
 }
 
-function blockerReasonForExportDiagnostic(diagnostic: ExportDiagnostic): RenderBlockerReason {
-  if (diagnostic.code.includes('unknown') || diagnostic.code.includes('missing')) {
-    return 'missing-contribution';
-  }
-  if (diagnostic.code.includes('inactive')) {
-    return 'inactive-extension';
-  }
-  if (diagnostic.code.includes('live-binding')) {
-    return 'live-unbaked';
-  }
-  if (diagnostic.code.includes('shader')) {
-    return 'missing-material';
-  }
-  return 'route-unsupported';
-}
-
-function exportDiagnosticToPlannerFinding(diagnostic: ExportDiagnostic, index: number): CapabilityFinding {
-  const route = diagnostic.detail?.renderRoute === 'worker-export' || diagnostic.detail?.renderRoute === 'preview'
-    ? diagnostic.detail.renderRoute
-    : 'browser-export';
-  const reason = diagnostic.severity === 'error'
-    ? blockerReasonForExportDiagnostic(diagnostic)
-    : undefined;
-
-  return {
-    id: exportDiagnosticId(diagnostic, index),
-    severity: diagnostic.severity,
-    route,
-    ...(reason ? { reason } : {}),
-    message: diagnostic.message,
-    ...(diagnostic.extensionId ? { extensionId: diagnostic.extensionId } : {}),
-    ...(diagnostic.contributionId ? { contributionId: diagnostic.contributionId } : {}),
-    detail: {
-      ...(diagnostic.detail ?? {}),
-      source: 'export-guard-compat',
-      code: diagnostic.code,
-    },
-  };
-}
-
 function planFromExportGuardResult(
   guardResult: ReturnType<typeof scanExportConfig>,
   options?: {
@@ -241,13 +125,8 @@ function planFromExportGuardResult(
     readonly processResultAttachRecords?: VideoEditorRuntimeContextValue['processResultAttachRecords'];
   },
 ): RenderPlannerResult {
-  const diagnostics: CapabilityFinding[] = [
-    ...(guardResult.findings ?? []),
-    ...(guardResult.blockers ?? []),
-    ...guardResult.diagnostics.map(exportDiagnosticToPlannerFinding),
-  ];
-  return planRender({
-    diagnostics,
+  return buildExportReadinessPlan({
+    guard: guardResult,
     extensionRuntime: options?.extensionRuntime,
     outputFormats: outputFormatsForPlanning(options?.extensionRuntime),
     processStatuses: options?.processStatuses,
@@ -322,6 +201,25 @@ function firstPlannerBlockerForDecision(
     ?? plannerResult.blockers[0];
 }
 
+function routeDecisionBlockerForLog(
+  blocker: RenderBlocker | undefined,
+  decision: RenderRouteDecisionForPlanning,
+): RenderBlocker | undefined {
+  if (!blocker) return undefined;
+  const message = decision.route === 'preview-only' && !blocker.message.startsWith('Render blocked')
+    ? `Render blocked: ${blocker.message}`
+    : blocker.message;
+  return {
+    ...blocker,
+    message,
+    detail: {
+      ...(blocker.detail ?? {}),
+      legacyReason: decision.reason,
+      providerRoute: decision.route,
+    },
+  };
+}
+
 function outputFormatsForPlanning(extensionRuntime: ExtensionRuntime | undefined): readonly VideoEditorOutputFormatDescriptor[] {
   const outputFormats = extensionRuntime?.outputFormats
     ?? extensionRuntime?.config?.outputFormats
@@ -373,6 +271,54 @@ function categorizeExportFormats(
     }
   }
   return { compileOnly, renderDependent };
+}
+
+function hasCompileOnlyHandler(
+  registry: CompileOnlyOutputFormatRegistry | undefined,
+  format: VideoEditorOutputFormatDescriptor,
+): boolean {
+  if (!registry) return false;
+  return registry.has(formatScopedKey(format.extensionId, format.id)) || registry.has(format.id);
+}
+
+function plannerBlockerMessage(
+  plan: RenderPlannerResult | undefined,
+  fallback: string,
+  route?: 'browser-export' | 'worker-export' | 'sidecar-export' | 'preview',
+): string {
+  const routeBlocker = route && route !== 'preview'
+    ? plan?.routePlans.find((routePlan) => routePlan.route === route)?.blockers[0]
+    : undefined;
+  return routeBlocker?.message ?? plan?.blockers[0]?.message ?? fallback;
+}
+
+function plannerRouteAvailabilityBlockerMessage(
+  plan: RenderPlannerResult,
+  route: 'worker-export' | 'sidecar-export',
+  fallback: string,
+): string {
+  const availabilityBlocker = plan.blockers.find((blocker) =>
+    blocker.route === route
+    && blocker.detail?.source === 'render-request'
+    && blocker.detail.routeAvailability === 'unavailable');
+  return availabilityBlocker?.message ?? plannerBlockerMessage(plan, fallback, route);
+}
+
+function formatPlannerReadinessBlockLog(plan: RenderPlannerResult): string {
+  if (plan.blockers.length === 0) {
+    return 'Export readiness blocked by the render planner.';
+  }
+
+  const lines = ['Export readiness blocked by the render planner:'];
+  for (const blocker of plan.blockers) {
+    lines.push(`  [${blocker.route}/${blocker.reason}] ${blocker.message}`);
+  }
+  return lines.join('\n');
+}
+
+interface ExportGuardRunResult {
+  readonly passed: boolean;
+  readonly plannerResult?: RenderPlannerResult;
 }
 
 export function useRenderState(
@@ -442,7 +388,7 @@ export function useRenderState(
     },
   });
 
-  const runExportGuard = useCallback((): boolean => {
+  const runExportGuard = useCallback((): ExportGuardRunResult => {
     diagnosticCollection?.remove((diagnostic) => diagnostic.detail?.source === 'export-guard');
     diagnosticCollection?.remove((diagnostic) => diagnostic.detail?.source === 'render-planner');
 
@@ -456,11 +402,11 @@ export function useRenderState(
       && clipTypeRegistrySnapshot.records.length === 0
       && !hasTimelineShaderMetadata(resolvedConfig, compositionGraph)
     ) {
-      return true; // no blocker
+      return { passed: true };
     }
 
     if (!resolvedConfig || resolvedConfig.clips.length === 0) {
-      return true; // nothing to scan
+      return { passed: true };
     }
 
     const builtIn = collectBuiltInKnownIds();
@@ -487,20 +433,17 @@ export function useRenderState(
     });
     syncPlannerDiagnosticsToCollection(diagnosticCollection, plannerResult.blockers);
 
-    // Emit structured diagnostics as concise render log output
-    const log = formatExportGuardLog(guardResult);
-    setRenderLog(log);
-
     if (plannerResult.blockers.length > 0) {
       // Planner-owned blockers are the canonical readiness decision.
       setRenderStatus('error');
       setRenderProgress(null);
       setRenderDirty(false);
-      return false; // blocker
+      setRenderLog(formatPlannerReadinessBlockLog(plannerResult));
+      return { passed: false, plannerResult };
     }
 
-    // Extension-declared warnings only — preserve native routing
-    return true; // no blocker
+    setRenderLog('');
+    return { passed: true, plannerResult };
   }, [
     diagnosticCollection,
     effectRegistrySnapshot,
@@ -514,46 +457,45 @@ export function useRenderState(
 
   const startRender = useCallback(async () => {
     // ---- export guard: scan for unknown IDs before routing ------------------
-    if (!runExportGuard()) {
-      return; // blocked by export guard
+    const guardResult = runExportGuard();
+    if (!guardResult.passed) {
+      return; // blocked by planner-owned export readiness
     }
 
-    let decision = getFastRenderRouteDecision(resolvedConfig);
-    if (!decision) {
-      let importedDecision: {
-      route: 'browser-remotion' | 'worker-banodoco' | 'preview-only' | 'external';
-      reason: string;
-      };
-      try {
-        const renderRouter = await import('@/tools/video-editor/lib/renderRouter');
-        importedDecision = renderRouter.decideRenderRoute(
-          resolvedConfig,
-          undefined,
-          {
-            compositionGraph: extensionRuntime?.compositionGraph,
-            processes: extensionRuntime?.processes,
-            processStatuses,
-            processResultAttachRecords,
-          },
-        );
-      } catch (error) {
-        setRenderStatus('error');
-        setRenderProgress(null);
-        setRenderDirty(false);
-        setRenderLog(error instanceof Error
-          ? `Render routing unavailable: ${error.message}`
-          : 'Render routing unavailable.');
-        return;
-      }
-      decision = importedDecision;
+    let decision: PlannerBackedRenderRouteDecision;
+    try {
+      const renderRouter = await import('@/tools/video-editor/lib/renderRouter');
+      decision = renderRouter.decideRenderRoute(
+        resolvedConfig,
+        undefined,
+        {
+          compositionGraph: extensionRuntime?.compositionGraph,
+          processes: extensionRuntime?.processes,
+          processStatuses,
+          processResultAttachRecords,
+        },
+      );
+    } catch (error) {
+      setRenderStatus('error');
+      setRenderProgress(null);
+      setRenderDirty(false);
+      setRenderLog(error instanceof Error
+        ? `Render routing unavailable: ${error.message}`
+        : 'Render routing unavailable.');
+      return;
     }
+
     if (decision.route === 'preview-only') {
-      const plannerResult = planRouteDecisionBlocker(decision, {
+      const plannerResult = decision.planner?.plannerResult ?? planRouteDecisionBlocker(decision, {
         extensionRuntime,
         processStatuses,
         processResultAttachRecords,
       });
-      const blocker = firstPlannerBlockerForDecision(plannerResult, decision);
+      const selectedRoute = decision.planner?.selectedPlannerRoute;
+      const blocker = routeDecisionBlockerForLog(selectedRoute
+        ? plannerResult.routePlans.find((routePlan) => routePlan.route === selectedRoute)?.blockers[0]
+          ?? plannerResult.blockers[0]
+        : firstPlannerBlockerForDecision(plannerResult, decision), decision);
       syncPlannerDiagnosticsToCollection(diagnosticCollection, blocker ? [blocker] : plannerResult.blockers);
       setRenderStatus('error');
       setRenderProgress(null);
@@ -563,17 +505,38 @@ export function useRenderState(
     }
 
     if (decision.route === 'worker-banodoco' || decision.route === 'external') {
-      const plannerResult = planRouteDecisionBlocker(decision, {
+      const plannerRoute = decision.route === 'external' ? 'sidecar-export' : 'worker-export';
+      const providerId = decision.route === 'external' ? 'external' : 'worker-banodoco';
+      const plannerResult = planRender({
         extensionRuntime,
+        outputFormats: outputFormatsForPlanning(extensionRuntime),
         processStatuses,
         processResultAttachRecords,
+        request: {
+          route: plannerRoute,
+          routeAvailability: [{
+            route: plannerRoute,
+            available: false,
+            providerId,
+            reason: blockerReasonForRouteDecision(decision),
+            message: blockerMessageForRouteDecision(decision),
+            detail: {
+              source: 'render-route-decision',
+              legacyReason: decision.reason,
+            },
+          }],
+        },
       });
-      const blocker = firstPlannerBlockerForDecision(plannerResult, decision);
-      syncPlannerDiagnosticsToCollection(diagnosticCollection, blocker ? [blocker] : plannerResult.blockers);
+      const blockers = plannerResult.blockers.map((blocker) => routeDecisionBlockerForLog(blocker, decision) ?? blocker);
+      syncPlannerDiagnosticsToCollection(diagnosticCollection, blockers);
       setRenderStatus('error');
       setRenderProgress(null);
       setRenderDirty(false);
-      setRenderLog(blocker?.message ?? blockerMessageForRouteDecision(decision));
+      setRenderLog(blockers[0]?.message ?? plannerRouteAvailabilityBlockerMessage(
+        plannerResult,
+        plannerRoute,
+        blockerMessageForRouteDecision(decision),
+      ));
       return;
     }
 
@@ -661,6 +624,7 @@ export function useRenderState(
     }
 
     const plannerOutputFormats = outputFormatsForPlanning(extensionRuntime);
+    const requestedOutputFormat = plannerOutputFormats.find((candidate) => candidate.id === formatId);
     const outputPlan = planRender({
       extensionRuntime,
       outputFormats: plannerOutputFormats,
@@ -672,32 +636,21 @@ export function useRenderState(
       request: {
         outputFormatId: formatId,
         routes: ['browser-export'],
+        compileOnlyHandlerAvailable: requestedOutputFormat
+          ? hasCompileOnlyHandler(compileOnlyRegistry, requestedOutputFormat)
+          : undefined,
       },
-      diagnostics: plannerOutputFormats.find((candidate) => candidate.id === formatId)?.disabled
-        ? [{
-            id: `planner.outputFormat.${formatId}.disabled`,
-            severity: 'error',
-            route: 'browser-export',
-            reason: 'inactive-extension',
-            message: plannerOutputFormats.find((candidate) => candidate.id === formatId)?.disabledReason
-              ?? `Export format "${formatId}" is disabled.`,
-            contributionId: formatId,
-            detail: { source: 'output-format', outputFormatId: formatId },
-          }]
-        : [],
     });
     const browserOutputPlan = outputPlan.routePlans.find((routePlan) => routePlan.route === 'browser-export');
     const fmt = plannerOutputFormats.find((f) => f.id === formatId && !f.requiresRender && !f.disabled);
     if (!fmt || browserOutputPlan?.blocked) {
-      const requestedFormat = plannerOutputFormats.find((f) => f.id === formatId);
-      const blocker = outputPlan.blockers.find((candidate) => candidate.id === `planner.outputFormat.${formatId}.disabled`)
-        ?? browserOutputPlan?.blockers[0]
+      const blocker = browserOutputPlan?.blockers[0]
         ?? outputPlan.blockers[0];
       setExportStatus('error');
       if (blocker) {
         setExportLogState(`Export blocked: ${blocker.message}`);
-      } else if (requestedFormat) {
-        setExportLogState(`Export blocked: "${requestedFormat.label}" is not available for browser export.`);
+      } else if (requestedOutputFormat) {
+        setExportLogState(`Export blocked: "${requestedOutputFormat.label}" is not available for browser export.`);
       } else {
         setExportLogState(`Export format "${formatId}" not found.`);
       }
@@ -710,20 +663,16 @@ export function useRenderState(
     // because the exported data would be invalid.  Route-specific capability
     // blockers (browser-export blocked, worker-export blocked) are surfaced
     // as warnings but do not prevent compile-only export.
-    const guardPassed = runExportGuard();
-    if (!guardPassed) {
-      // Export guard found blocking errors (e.g. truly unknown effects).
-      // Surface the guard log as the export error.
+    const guardResult = runExportGuard();
+    if (!guardResult.passed) {
       setExportStatus('error');
       setExportLogState(
-        `Export blocked by readiness scan. See render log for details.`,
+        `Export blocked: ${plannerBlockerMessage(
+          guardResult.plannerResult,
+          'Export readiness is blocked by the render planner.',
+          'browser-export',
+        )}`,
       );
-      return;
-    }
-
-    if (!compileOnlyRegistry || compileOnlyRegistry.size === 0) {
-      setExportStatus('error');
-      setExportLogState(`Export unavailable: no compile-only output handlers registered. Format "${fmt.label}" (${fmt.id}) requires a handler registered via ctx.export.registerOutputFormat().`);
       return;
     }
 

--- a/src/tools/video-editor/lib/renderRouter.test.ts
+++ b/src/tools/video-editor/lib/renderRouter.test.ts
@@ -10,6 +10,25 @@ import {
 } from '@/tools/video-editor/lib/renderRouter';
 import { executeRenderPipeline } from '@/tools/video-editor/render/renderPipeline';
 
+function expectPlannerBlocker(
+  blockers: readonly unknown[],
+  expected: {
+    readonly id: string;
+    readonly route: string;
+    readonly reason: string;
+    readonly message: string;
+    readonly detail: Readonly<Record<string, unknown>>;
+  },
+): void {
+  expect(blockers).toContainEqual(expect.objectContaining({
+    id: expected.id,
+    route: expected.route,
+    reason: expected.reason,
+    message: expected.message,
+    detail: expect.objectContaining(expected.detail),
+  }));
+}
+
 describe('Sprint 8 render-button router (decideRenderRoute)', () => {
   it('routes a pure-media timeline to the client renderer', () => {
     const decision = decideRenderRoute({
@@ -148,24 +167,64 @@ describe('Sprint 8 render-button router (decideRenderRoute)', () => {
       route: 'preview-only',
       reason: 'remotion_module_missing_artifact',
     });
-    expect(missingArtifact.planner.selectedPlannerRoute).toBe('sidecar-export');
+    expect(missingArtifact.planner.selectedPlannerRoute).toBe('preview');
     expect(missingArtifact.planner.plannerResult.canBrowserExport).toBe(false);
     expect(missingArtifact.planner.plannerResult.canWorkerExport).toBe(false);
-    expect(missingArtifact.planner.plannerResult.canSidecarExport).toBe(true);
+    expect(missingArtifact.planner.plannerResult.canSidecarExport).toBe(false);
+    const missingArtifactMessage = 'Clip type "media" cannot be rendered until remotion_module_missing_artifact is resolved.';
+    expectPlannerBlocker(missingArtifact.planner.plannerResult.blockers, {
+      id: 'router.clip.0.media.browser-export.browser-export.missing-material',
+      route: 'browser-export',
+      reason: 'missing-material',
+      message: missingArtifactMessage,
+      detail: {
+        source: 'render-router',
+        clipType: 'media',
+        legacyReason: 'remotion_module_missing_artifact',
+      },
+    });
+    expectPlannerBlocker(missingArtifact.planner.plannerResult.blockers, {
+      id: 'router.clip.0.media.worker-export.worker-export.missing-material',
+      route: 'worker-export',
+      reason: 'missing-material',
+      message: missingArtifactMessage,
+      detail: {
+        source: 'render-router',
+        clipType: 'media',
+        legacyReason: 'remotion_module_missing_artifact',
+      },
+    });
+    expectPlannerBlocker(missingArtifact.planner.plannerResult.blockers, {
+      id: 'router.clip.0.media.sidecar-export.sidecar-export.missing-material',
+      route: 'sidecar-export',
+      reason: 'missing-material',
+      message: missingArtifactMessage,
+      detail: {
+        source: 'render-router',
+        clipType: 'media',
+        legacyReason: 'remotion_module_missing_artifact',
+      },
+    });
 
-    expect(decideRenderRoute({
+    const emptyArtifact = decideRenderRoute({
       clips: [{ clipType: 'image-jump', generation: { sequence_lane: 'remotion_module', artifact_id: '' } }],
-    })).toMatchObject({
+    });
+    expect(emptyArtifact).toMatchObject({
       route: 'preview-only',
       reason: 'remotion_module_invalid_artifact',
     });
+    expect(emptyArtifact.planner.selectedPlannerRoute).toBe('preview');
+    expect(emptyArtifact.planner.plannerResult.canSidecarExport).toBe(false);
 
-    expect(decideRenderRoute({
+    const nonStringArtifact = decideRenderRoute({
       clips: [{ clipType: 'unknown', generation: { sequence_lane: 'remotion_module', artifact_id: 42 } }],
-    })).toMatchObject({
+    });
+    expect(nonStringArtifact).toMatchObject({
       route: 'preview-only',
       reason: 'remotion_module_invalid_artifact',
     });
+    expect(nonStringArtifact.planner.selectedPlannerRoute).toBe('preview');
+    expect(nonStringArtifact.planner.plannerResult.canSidecarExport).toBe(false);
   });
 
   it('does not treat non-module generation lanes as generated Remotion modules', () => {
@@ -194,16 +253,16 @@ describe('Sprint 8 render-button router (decideRenderRoute)', () => {
 // ---------------------------------------------------------------------------
 
 describe('M7b T2 sidecar-export route selection', () => {
-  it('selects sidecar-export in selectPlannerRoute when browser and worker are blocked but sidecar is unblocked', () => {
-    // Blocked remotion_module blocks browser + worker but not sidecar.
+  it('selects preview when a router-generated hard blocker blocks all export routes', () => {
+    // Blocked remotion_module artifact metadata is a hard router-fed
+    // planner blocker: browser, worker, and sidecar are all unavailable.
     const decision = decideRenderRoute({
       clips: [{ clipType: 'media', generation: { sequence_lane: 'remotion_module' } }],
     });
-    expect(decision.planner.selectedPlannerRoute).toBe('sidecar-export');
+    expect(decision.planner.selectedPlannerRoute).toBe('preview');
     expect(decision.planner.plannerResult.canBrowserExport).toBe(false);
     expect(decision.planner.plannerResult.canWorkerExport).toBe(false);
-    expect(decision.planner.plannerResult.canSidecarExport).toBe(true);
-    // Clip-level block still forces preview-only for the UI route.
+    expect(decision.planner.plannerResult.canSidecarExport).toBe(false);
     expect(decision.route).toBe('preview-only');
   });
 
@@ -282,9 +341,7 @@ describe('M7b T2 sidecar-export route selection', () => {
     expect(decision.planner.plannerResult.canWorkerExport).toBe(false);
     expect(decision.planner.plannerResult.canSidecarExport).toBe(false);
     expect(decision.planner.selectedPlannerRoute).toBe('preview');
-    // Native media clips → browser-remotion is the clip logic fallback,
-    // but when all routes are blocked, the planner context shows preview.
-    expect(decision.route).toBe('browser-remotion');
+    expect(decision.route).toBe('preview-only');
   });
 
   it('maps sidecar-export planner route to external for native clips with browser/worker blocked', () => {
@@ -440,6 +497,45 @@ describe('M9 T11 contributed clip routing (decideRenderRoute)', () => {
     expect(decision.route).toBe('preview-only');
     expect(decision.hasContributedClip).toBe(true);
     expect(decision.reason).toBe('contributed_blocked_no_browser_capability');
+    expect(decision.planner.selectedPlannerRoute).toBe('preview');
+    expect(decision.planner.plannerResult.canBrowserExport).toBe(false);
+    expect(decision.planner.plannerResult.canWorkerExport).toBe(false);
+    expect(decision.planner.plannerResult.canSidecarExport).toBe(false);
+
+    const message = 'Clip type "ext-preview-only" cannot be rendered until contributed_blocked_no_browser_capability is resolved.';
+    expectPlannerBlocker(decision.planner.plannerResult.blockers, {
+      id: 'router.clip.0.ext-preview-only.browser-export.browser-export.route-unsupported',
+      route: 'browser-export',
+      reason: 'route-unsupported',
+      message,
+      detail: {
+        source: 'render-router',
+        clipType: 'ext-preview-only',
+        legacyReason: 'contributed_blocked_no_browser_capability',
+      },
+    });
+    expectPlannerBlocker(decision.planner.plannerResult.blockers, {
+      id: 'router.clip.0.ext-preview-only.worker-export.worker-export.route-unsupported',
+      route: 'worker-export',
+      reason: 'route-unsupported',
+      message,
+      detail: {
+        source: 'render-router',
+        clipType: 'ext-preview-only',
+        legacyReason: 'contributed_blocked_no_browser_capability',
+      },
+    });
+    expectPlannerBlocker(decision.planner.plannerResult.blockers, {
+      id: 'router.clip.0.ext-preview-only.sidecar-export.sidecar-export.route-unsupported',
+      route: 'sidecar-export',
+      reason: 'route-unsupported',
+      message,
+      detail: {
+        source: 'render-router',
+        clipType: 'ext-preview-only',
+        legacyReason: 'contributed_blocked_no_browser_capability',
+      },
+    });
   });
 
   it('blocks a contributed clip with only worker-export capability (worker routes blocked for contributed code)', () => {
@@ -450,6 +546,8 @@ describe('M9 T11 contributed clip routing (decideRenderRoute)', () => {
     expect(decision.route).toBe('preview-only');
     expect(decision.hasContributedClip).toBe(true);
     expect(decision.reason).toBe('contributed_blocked_no_browser_capability');
+    expect(decision.planner.selectedPlannerRoute).toBe('preview');
+    expect(decision.planner.plannerResult.canSidecarExport).toBe(false);
   });
 
   it('blocks a contributed clip with no capabilities at all', () => {
@@ -460,6 +558,8 @@ describe('M9 T11 contributed clip routing (decideRenderRoute)', () => {
     expect(decision.route).toBe('preview-only');
     expect(decision.hasContributedClip).toBe(true);
     expect(decision.reason).toBe('contributed_blocked_no_browser_capability');
+    expect(decision.planner.selectedPlannerRoute).toBe('preview');
+    expect(decision.planner.plannerResult.canSidecarExport).toBe(false);
   });
 
   it('blocks mixed contributed (browser-capable) + themed clips due to worker route conflict', () => {
@@ -476,6 +576,34 @@ describe('M9 T11 contributed clip routing (decideRenderRoute)', () => {
     expect(decision.hasContributedClip).toBe(true);
     expect(decision.hasThemedClip).toBe(true);
     expect(decision.reason).toBe('contributed_blocked_worker_route_conflict');
+    expect(decision.planner.selectedPlannerRoute).toBe('preview');
+    expect(decision.planner.plannerResult.canBrowserExport).toBe(false);
+    expect(decision.planner.plannerResult.canWorkerExport).toBe(false);
+    expect(decision.planner.plannerResult.canSidecarExport).toBe(false);
+
+    const message = 'Clip type "image-jump" cannot be rendered until contributed_blocked_worker_route_conflict is resolved.';
+    expectPlannerBlocker(decision.planner.plannerResult.blockers, {
+      id: 'router.clip.1.image-jump.browser-export.browser-export.route-unsupported',
+      route: 'browser-export',
+      reason: 'route-unsupported',
+      message,
+      detail: {
+        source: 'render-router',
+        clipType: 'image-jump',
+        legacyReason: 'contributed_blocked_worker_route_conflict',
+      },
+    });
+    expectPlannerBlocker(decision.planner.plannerResult.blockers, {
+      id: 'router.clip.1.image-jump.sidecar-export.sidecar-export.route-unsupported',
+      route: 'sidecar-export',
+      reason: 'route-unsupported',
+      message,
+      detail: {
+        source: 'render-router',
+        clipType: 'image-jump',
+        legacyReason: 'contributed_blocked_worker_route_conflict',
+      },
+    });
   });
 
   it('blocks contributed clip mixed with generated remotion module due to worker route conflict', () => {
@@ -497,6 +625,34 @@ describe('M9 T11 contributed clip routing (decideRenderRoute)', () => {
     expect(decision.route).toBe('preview-only');
     expect(decision.hasContributedClip).toBe(true);
     expect(decision.reason).toBe('contributed_blocked_worker_route_conflict');
+    expect(decision.planner.selectedPlannerRoute).toBe('preview');
+    expect(decision.planner.plannerResult.canBrowserExport).toBe(false);
+    expect(decision.planner.plannerResult.canWorkerExport).toBe(false);
+    expect(decision.planner.plannerResult.canSidecarExport).toBe(false);
+
+    const message = 'Clip type "generated-remotion-module" cannot be rendered until contributed_blocked_worker_route_conflict is resolved.';
+    expectPlannerBlocker(decision.planner.plannerResult.blockers, {
+      id: 'router.generated.contributed-conflict.browser-export.browser-export.route-unsupported',
+      route: 'browser-export',
+      reason: 'route-unsupported',
+      message,
+      detail: {
+        source: 'render-router',
+        clipType: 'generated-remotion-module',
+        legacyReason: 'contributed_blocked_worker_route_conflict',
+      },
+    });
+    expectPlannerBlocker(decision.planner.plannerResult.blockers, {
+      id: 'router.generated.contributed-conflict.sidecar-export.sidecar-export.route-unsupported',
+      route: 'sidecar-export',
+      reason: 'route-unsupported',
+      message,
+      detail: {
+        source: 'render-router',
+        clipType: 'generated-remotion-module',
+        legacyReason: 'contributed_blocked_worker_route_conflict',
+      },
+    });
   });
 
   it('multiple browser-capable contributed clips all route to browser-remotion', () => {
@@ -572,6 +728,8 @@ describe('M9 T11 contributed clip routing (decideRenderRoute)', () => {
     expect(decision.route).toBe('preview-only');
     expect(decision.hasContributedClip).toBe(true);
     expect(decision.reason).toBe('contributed_blocked_no_browser_capability');
+    expect(decision.planner.selectedPlannerRoute).toBe('preview');
+    expect(decision.planner.plannerResult.canSidecarExport).toBe(false);
   });
 
   it('no_clips decision reports hasContributedClip false', () => {
@@ -593,6 +751,8 @@ describe('M9 T11 contributed clip routing (decideRenderRoute)', () => {
     );
     expect(decision.route).toBe('preview-only');
     expect(decision.reason).toBe('remotion_module_missing_artifact');
+    expect(decision.planner.selectedPlannerRoute).toBe('preview');
+    expect(decision.planner.plannerResult.canSidecarExport).toBe(false);
   });
 });
 

--- a/src/tools/video-editor/lib/renderRouter.ts
+++ b/src/tools/video-editor/lib/renderRouter.ts
@@ -280,6 +280,12 @@ function requirementsForBrowserOnlyClip(
       legacyReason: reason,
       message: `Clip type "${clipType ?? 'contributed'}" cannot run on worker export.`,
     }),
+    routeRequirement(`${id}.sidecar-export`, 'sidecar-export', clipType, {
+      blocking: true,
+      reason: 'route-unsupported',
+      legacyReason: reason,
+      message: `Clip type "${clipType ?? 'contributed'}" cannot run on sidecar export.`,
+    }),
   ];
 }
 
@@ -289,18 +295,25 @@ function requirementsForBlockedClip(
   reason: RenderRouteDecision['reason'],
   blockerReason: RenderBlockerReason,
 ): CapabilityRequirement[] {
+  const message = `Clip type "${clipType ?? 'generated'}" cannot be rendered until ${reason} is resolved.`;
   return [
     routeRequirement(`${id}.browser-export`, 'browser-export', clipType, {
       blocking: true,
       reason: blockerReason,
       legacyReason: reason,
-      message: `Clip type "${clipType ?? 'generated'}" cannot be rendered until ${reason} is resolved.`,
+      message,
     }),
     routeRequirement(`${id}.worker-export`, 'worker-export', clipType, {
       blocking: true,
       reason: blockerReason,
       legacyReason: reason,
-      message: `Clip type "${clipType ?? 'generated'}" cannot be rendered until ${reason} is resolved.`,
+      message,
+    }),
+    routeRequirement(`${id}.sidecar-export`, 'sidecar-export', clipType, {
+      blocking: true,
+      reason: blockerReason,
+      legacyReason: reason,
+      message,
     }),
   ];
 }
@@ -316,6 +329,19 @@ function selectPlannerRoute(result: RenderPlannerResult): PlannerRouteDecisionCo
     return { plannerResult: result, selectedPlannerRoute: 'sidecar-export' };
   }
   return { plannerResult: result, selectedPlannerRoute: 'preview' };
+}
+
+function routeForPlannerSelection(
+  planner: PlannerRouteDecisionContext,
+  preferredRoute: RenderRoute,
+): RenderRoute {
+  if (planner.selectedPlannerRoute === 'preview') {
+    return 'preview-only';
+  }
+  if (planner.selectedPlannerRoute === 'sidecar-export') {
+    return 'external';
+  }
+  return preferredRoute;
 }
 
 /** Pure-decision routing — call this from a hook or test. */
@@ -338,7 +364,7 @@ export function decideRenderRoute(
       materialStatuses: plannerInput?.materialStatuses,
     } satisfies RenderPlannerInput));
     return {
-      route: emptyPlanner.selectedPlannerRoute === 'sidecar-export' ? 'external' : 'browser-remotion',
+      route: routeForPlannerSelection(emptyPlanner, 'browser-remotion'),
       hasThemedClip: false,
       hasMediaClip: false,
       hasContributedClip: false,
@@ -359,6 +385,11 @@ export function decideRenderRoute(
   let blockedHasThemedClip = false;
   let blockedHasMediaClip = false;
   let blockedHasContributedClip = false;
+
+  // M3 export-readiness category audit:
+  // Generated-module artifact failures and contributed route conflicts are
+  // router-fed planner requirements; later coverage should assert them through
+  // decision.planner.plannerResult.blockers rather than router reason strings.
 
   clips.forEach((clip, index) => {
     if (blockedReason) return;
@@ -386,7 +417,7 @@ export function decideRenderRoute(
 
     // M9 T11: Check contributed clip records first. Contributed clip
     // code is only allowed in browser-remotion when it explicitly
-    // declares browser-export capability. Worker routes are always
+    // declares browser-export capability. Non-browser export routes are
     // blocked for contributed code (SD1).
     const clipType = clip?.clipType;
     if (typeof clipType === 'string') {
@@ -398,8 +429,8 @@ export function decideRenderRoute(
           requirements.push(...requirementsForBrowserOnlyClip(clipType, requirementId, 'browser_capable_contributed'));
         } else {
           // Contributed clip without browser-export capability is
-          // immediately blocked — worker routes are out of scope
-          // for contributed code and no other route is available.
+          // immediately blocked — non-browser export routes are out
+          // of scope for contributed code and no other route is available.
           requirements.push(...requirementsForBlockedClip(
             clipType,
             requirementId,
@@ -505,7 +536,7 @@ export function decideRenderRoute(
       };
     }
     return {
-      route: 'worker-banodoco',
+      route: routeForPlannerSelection(planner, 'worker-banodoco'),
       hasThemedClip,
       hasMediaClip,
       hasContributedClip: false,
@@ -534,7 +565,7 @@ export function decideRenderRoute(
       // Mixed browser-capable contributed + native → browser-remotion
       // handles both, unless sidecar-export is the selected planner route.
       return {
-        route: planner.selectedPlannerRoute === 'sidecar-export' ? 'external' : 'browser-remotion',
+        route: routeForPlannerSelection(planner, 'browser-remotion'),
         hasThemedClip: false,
         hasMediaClip: true,
         hasContributedClip: true,
@@ -544,7 +575,7 @@ export function decideRenderRoute(
     }
     // Pure browser-capable contributed clips
     return {
-      route: planner.selectedPlannerRoute === 'sidecar-export' ? 'external' : 'browser-remotion',
+      route: routeForPlannerSelection(planner, 'browser-remotion'),
       hasThemedClip: false,
       hasMediaClip: false,
       hasContributedClip: true,
@@ -555,7 +586,7 @@ export function decideRenderRoute(
 
   if (hasThemedClip && hasMediaClip) {
     return {
-      route: 'worker-banodoco',
+      route: routeForPlannerSelection(planner, 'worker-banodoco'),
       hasThemedClip,
       hasMediaClip,
       hasContributedClip: false,
@@ -565,7 +596,7 @@ export function decideRenderRoute(
   }
   if (hasThemedClip) {
     return {
-      route: 'worker-banodoco',
+      route: routeForPlannerSelection(planner, 'worker-banodoco'),
       hasThemedClip,
       hasMediaClip,
       hasContributedClip: false,
@@ -574,7 +605,7 @@ export function decideRenderRoute(
     };
   }
   return {
-    route: planner.selectedPlannerRoute === 'sidecar-export' ? 'external' : 'browser-remotion',
+    route: routeForPlannerSelection(planner, 'browser-remotion'),
     hasThemedClip,
     hasMediaClip,
     hasContributedClip: false,

--- a/src/tools/video-editor/runtime/exportGuard.test.ts
+++ b/src/tools/video-editor/runtime/exportGuard.test.ts
@@ -11,7 +11,7 @@ import {
   referenceStateSeverity,
 } from '@/tools/video-editor/runtime/composition/diagnostics.ts';
 import { createProcessResultAttachRecord } from '@/tools/video-editor/runtime/composition/processResultAttach.ts';
-import { planRender } from '@/tools/video-editor/runtime/renderPlanner.ts';
+import { buildExportReadinessPlan } from '@/tools/video-editor/runtime/renderPlanner.ts';
 import {
   getVideoFamilyDefinition,
   getVideoFamilyLegacyBridgeStatus,
@@ -60,6 +60,10 @@ function makeConfig(
     clips,
     registry: {},
   };
+}
+
+function buildPlannerReadiness(scan: ExportGuardResult) {
+  return buildExportReadinessPlan({ guard: scan });
 }
 
 function makeProcessDescriptor(): VideoEditorProcessDescriptor {
@@ -962,23 +966,23 @@ describe('scanExportConfig — unknown effects', () => {
     ]);
   });
 
-  it('keeps scan output as planner-compatible compatibility input', () => {
+  it('keeps scan output as planner-wrapper compatibility input', () => {
     const clip = makeClip('c1', {
       clipType: 'media',
       entrance: { type: 'crazy-spin', duration: 0.5 },
     });
     const scan = scanExportConfig(makeConfig([clip]), builtIn, extIds);
-    const planned = planRender({ diagnostics: [...scan.findings, ...scan.blockers] });
+    const planned = buildPlannerReadiness(scan);
 
     expect(planned.canBrowserExport).toBe(false);
     expect(planned.routePlans.find((routePlan) => routePlan.route === 'browser-export')).toMatchObject({
       blocked: true,
-      blockers: [
+      blockers: expect.arrayContaining([
         expect.objectContaining({
           id: 'export.effect.c1.entrance.crazy-spin.missing',
           reason: 'missing-contribution',
         }),
-      ],
+      ]),
     });
   });
 
@@ -1818,7 +1822,7 @@ describe('scanExportConfig — clip-type registry snapshot', () => {
         message: postprocessShaderMessage,
       }),
     ]));
-    expect(planRender({ diagnostics: result.findings }).canBrowserExport).toBe(false);
+    expect(buildPlannerReadiness(result).canBrowserExport).toBe(false);
   });
 
   it('blocks graph-absent legacy shader metadata through compatibility only', () => {
@@ -1882,7 +1886,7 @@ describe('scanExportConfig — clip-type registry snapshot', () => {
     expect(result.blockers).not.toEqual(expect.arrayContaining([
       expect.objectContaining({ reason: 'missing-material' }),
     ]));
-    expect(planRender({ diagnostics: result.findings }).canBrowserExport).toBe(false);
+    expect(buildPlannerReadiness(result).canBrowserExport).toBe(false);
   });
 
   it('suppresses graph shader materializer blockers when a completed process attach already returned the matching material', () => {
@@ -2211,7 +2215,7 @@ describe('scanExportConfig — composition graph target diagnostics', () => {
       },
     },
   ])(
-    'promotes $graphCode to blocking export and planning findings',
+    'emits scanner blockers for $graphCode and planner-wrapper findings',
     ({ graphCode, exportCode, reason, detail }) => {
       const graph = makeCompositionGraph({
         diagnostics: [makeCompositionDiagnostic(graphCode, detail)],
@@ -2258,7 +2262,7 @@ describe('scanExportConfig — composition graph target diagnostics', () => {
       ]));
       expect(result.hasBlockingErrors).toBe(true);
 
-      const planner = planRender({ compositionGraph: graph });
+      const planner = buildPlannerReadiness(result);
       expect(planner.canBrowserExport).toBe(false);
       expect(planner.canWorkerExport).toBe(false);
       expect(planner.findings).toEqual(expect.arrayContaining([
@@ -2268,7 +2272,7 @@ describe('scanExportConfig — composition graph target diagnostics', () => {
           reason,
           detail: expect.objectContaining({
             source: 'composition-graph',
-            code: graphCode,
+            graphDiagnosticCode: graphCode,
             targetKind: detail.targetKind,
             targetPath: detail.targetPath,
           }),
@@ -2379,7 +2383,7 @@ describe('scanExportConfig — composition graph M5 diagnostics', () => {
     };
   }
 
-  it('blocks export for effect error diagnostic (EFFECT_DISABLED_REF) with blockers', () => {
+  it('emits scanner blockers for effect error diagnostic (EFFECT_DISABLED_REF)', () => {
     const graph = makeM5CompositionGraph([
       makeCompositionDiagnostic(
         COMPOSITION_DIAGNOSTIC_CODE.EFFECT_DISABLED_REF,
@@ -2477,7 +2481,7 @@ describe('scanExportConfig — composition graph M5 diagnostics', () => {
     expect(result.hasBlockingErrors).toBe(false);
   });
 
-  it('blocks export for transition error diagnostic (TRANSITION_DISABLED_REF) with blockers', () => {
+  it('emits scanner blockers for transition error diagnostic (TRANSITION_DISABLED_REF)', () => {
     const graph = makeM5CompositionGraph([
       makeCompositionDiagnostic(
         COMPOSITION_DIAGNOSTIC_CODE.TRANSITION_DISABLED_REF,
@@ -2585,8 +2589,8 @@ describe('scanExportConfig — composition graph M5 diagnostics', () => {
     expect(result.hasBlockingErrors).toBe(false);
   });
 
-  it('integrates with planRender: effect error blocks export, resolved clears', () => {
-    // With error diagnostic — export blocked
+  it('feeds M5 scanner output into planner wrapper readiness', () => {
+    // With error diagnostic - planner wrapper marks export blocked.
     const blockedGraph = makeM5CompositionGraph([
       makeCompositionDiagnostic(
         COMPOSITION_DIAGNOSTIC_CODE.EFFECT_DISABLED_REF,
@@ -2605,7 +2609,16 @@ describe('scanExportConfig — composition graph M5 diagnostics', () => {
       ),
     ]);
 
-    const blockedPlanner = planRender({ compositionGraph: blockedGraph });
+    const blockedScan = scanExportConfig(
+      makeConfig([makeClip('c1')]),
+      builtIn,
+      extIds,
+      undefined,
+      undefined,
+      undefined,
+      blockedGraph,
+    );
+    const blockedPlanner = buildPlannerReadiness(blockedScan);
     expect(blockedPlanner.canBrowserExport).toBe(false);
     expect(blockedPlanner.canWorkerExport).toBe(false);
     expect(blockedPlanner.findings).toEqual(expect.arrayContaining([
@@ -2615,19 +2628,28 @@ describe('scanExportConfig — composition graph M5 diagnostics', () => {
         reason: 'inactive-extension',
         detail: expect.objectContaining({
           source: 'composition-graph',
-          code: COMPOSITION_DIAGNOSTIC_CODE.EFFECT_DISABLED_REF,
+          graphDiagnosticCode: COMPOSITION_DIAGNOSTIC_CODE.EFFECT_DISABLED_REF,
         }),
       }),
     ]));
 
-    // With no diagnostics (resolved) — export cleared
+    // With no diagnostics (resolved) - planner wrapper clears export.
     const resolvedGraph = makeM5CompositionGraph([]);
-    const resolvedPlanner = planRender({ compositionGraph: resolvedGraph });
+    const resolvedScan = scanExportConfig(
+      makeConfig([makeClip('c1')]),
+      builtIn,
+      extIds,
+      undefined,
+      undefined,
+      undefined,
+      resolvedGraph,
+    );
+    const resolvedPlanner = buildPlannerReadiness(resolvedScan);
     expect(resolvedPlanner.canBrowserExport).toBe(true);
     expect(resolvedPlanner.canWorkerExport).toBe(true);
   });
 
-  it('blocks export for transition invalid package ref with inactive-extension reason', () => {
+  it('emits inactive-extension scanner blockers for transition invalid package refs', () => {
     const graph = makeM5CompositionGraph([
       makeCompositionDiagnostic(
         COMPOSITION_DIAGNOSTIC_CODE.TRANSITION_INVALID_PACKAGE_REF,
@@ -2720,7 +2742,7 @@ describe('scanExportConfig — composition graph M5 diagnostics', () => {
       'export/effect-unresolved-ref',
       'export/transition-unresolved-ref',
     ]);
-    // Only the effect error blocks
+    // Only the effect error emits scanner blockers.
     expect(result.blockers).toHaveLength(2); // 2 routes for the blocking effect
     expect(result.findings).toHaveLength(4); // 2 routes × 2 diagnostics
     expect(result.hasBlockingErrors).toBe(true);

--- a/src/tools/video-editor/runtime/phase4ReadinessDocs.test.ts
+++ b/src/tools/video-editor/runtime/phase4ReadinessDocs.test.ts
@@ -5,6 +5,9 @@ import { resolve } from 'node:path';
 
 const repoRoot = resolve(import.meta.dirname, '..', '..', '..', '..');
 
+const readDoc = (relativePath: string): string =>
+  readFileSync(resolve(repoRoot, relativePath), 'utf8');
+
 describe('M5-021: trust-and-security.md', () => {
   const docPath = resolve(repoRoot, 'docs/extensions/trust-and-security.md');
   const trustEnvelopePath = resolve(repoRoot, 'docs/video-editor/extensions-trust-envelope.md');
@@ -60,6 +63,55 @@ describe('M5-021: trust-and-security.md', () => {
     const content = readFileSync(docPath, 'utf8');
     const lines = content.split('\n').filter((l) => l.trim().length > 0);
     expect(lines.length).toBeGreaterThanOrEqual(130);
+  });
+});
+
+describe('M3 export readiness documentation contracts', () => {
+  const readinessDocs = [
+    'docs/extensions/composition-spine/m1b-composition-graph.md',
+    'docs/extensions/composition-spine/m3b-live-binding-and-deterministic-capture.md',
+    'docs/extensions/composition-spine/v8-architecture-baseline.md',
+    'docs/extensions/phase4-readiness.md',
+  ];
+
+  const readAllReadinessDocs = (): string =>
+    readinessDocs.map((docPath) => readDoc(docPath)).join('\n\n');
+
+  it('keeps guard scans as planner inputs and planner blockers as the user-facing readiness vocabulary', () => {
+    const content = readAllReadinessDocs();
+
+    expect(content).toMatch(/The scan payload is planner input/i);
+    expect(content).toMatch(/scanner diagnostics are planner\s+input/i);
+    expect(content).toMatch(/buildExportReadinessPlan\(\).*planRender\(\)/s);
+    expect(content).toMatch(/planner `RenderBlocker` records are the canonical\s+user-facing readiness vocabulary/i);
+    expect(content).toMatch(/user-facing readiness blockers must be planner\s+blockers/i);
+    expect(content).toMatch(/`export\/\*` diagnostic codes?.*diagnostic metadata/is);
+  });
+
+  it('does not reintroduce guard-as-authority readiness wording', () => {
+    const content = readAllReadinessDocs();
+
+    expect(content).not.toMatch(/scanExportConfig[^.\n]*(?:authoritative|authority)/i);
+    expect(content).not.toMatch(/(?:authoritative|authority)[^.\n]*scanExportConfig/i);
+    expect(content).not.toMatch(/export guard[^.\n]*(?:authoritative|authority)/i);
+    expect(content).not.toMatch(/(?:authoritative|authority)[^.\n]*export guard/i);
+    expect(content).not.toMatch(/authoritative export guard/i);
+    expect(content).not.toMatch(/Graph-first export authority/i);
+    expect(content).not.toMatch(/exportGuard[^.\n]*authority/i);
+  });
+
+  it('keeps broader trust and release gate prohibitions in the readiness docs', () => {
+    const baselineContent = readDoc(
+      'docs/extensions/composition-spine/v8-architecture-baseline.md',
+    );
+    const phase4Content = readDoc('docs/extensions/phase4-readiness.md');
+
+    expect(baselineContent).toMatch(/No sandbox, marketplace/i);
+    expect(baselineContent).toMatch(/trusted, unsandboxed code/i);
+    expect(baselineContent).toMatch(/not runtime enforcement, sandbox isolation, code signing, or a permission broker/i);
+    expect(baselineContent).toMatch(/No marketplace, remote install, or signing claims/i);
+    expect(phase4Content).toMatch(/`npm run test:readiness` command validates/i);
+    expect(phase4Content).toMatch(/A missing or renamed anchor causes the\s+command to fail/i);
   });
 });
 

--- a/src/tools/video-editor/runtime/renderPlanner.test.ts
+++ b/src/tools/video-editor/runtime/renderPlanner.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { planRender } from '@/tools/video-editor/runtime/renderPlanner.ts';
+import {
+  buildExportReadinessPlan,
+  planRender,
+} from '@/tools/video-editor/runtime/renderPlanner.ts';
 import { projectHostMaterialRuntime } from '@/tools/video-editor/runtime/composition/materialRuntime.ts';
 import { createProcessResultAttachRecord } from '@/tools/video-editor/runtime/composition/processResultAttach.ts';
 import { projectCompositionGraph } from '@/tools/video-editor/runtime/composition/graphProjector.ts';
@@ -11,6 +14,7 @@ import {
 import type {
   CapabilityFinding,
   CapabilityRequirement,
+  ExportDiagnostic,
   RenderArtifact,
   RenderBlocker,
   RenderArtifactSidecarDescriptor,
@@ -132,6 +136,59 @@ function requirement(input: Partial<CapabilityRequirement> & Pick<CapabilityRequ
     determinism: 'deterministic',
     ...input,
   };
+}
+
+function routerRequirement(input: {
+  readonly id: string;
+  readonly route: RenderRoute;
+  readonly clipType: string;
+  readonly reason: RenderBlocker['reason'];
+  readonly legacyReason: string;
+  readonly message: string;
+  readonly requiredCapabilities?: readonly string[];
+}): CapabilityRequirement {
+  return {
+    id: input.id,
+    sourceRef: { source: 'registry', contributionId: input.clipType },
+    route: input.route,
+    requiredCapabilities: input.requiredCapabilities ?? [input.route],
+    determinism: input.route === 'worker-export' ? 'process-dependent' : 'deterministic',
+    blocking: true,
+    routeFit: {
+      route: input.route,
+      fit: 'blocked',
+      reason: input.reason,
+      message: input.message,
+    },
+    findings: [
+      {
+        id: `${input.id}.${input.route}.${input.reason}`,
+        severity: 'error',
+        route: input.route,
+        reason: input.reason,
+        message: input.message,
+        detail: {
+          source: 'render-router',
+          clipType: input.clipType,
+          legacyReason: input.legacyReason,
+        },
+      },
+    ],
+  };
+}
+
+function expectPlannerBlocker(
+  blockers: readonly RenderBlocker[],
+  expected: Pick<RenderBlocker, 'id' | 'route' | 'reason' | 'message'> & {
+    readonly detail?: unknown;
+  },
+): void {
+  const blocker = blockers.find((candidate) => candidate.id === expected.id);
+  expect(blocker).toBeDefined();
+  expect(blocker).toMatchObject({
+    severity: 'error',
+    ...expected,
+  });
 }
 
 interface RenderDependentOutputOptions {
@@ -502,7 +559,643 @@ function attachResult(
   };
 }
 
+function exportDiagnostic(
+  overrides: Pick<ExportDiagnostic, 'code' | 'message' | 'severity'> & Partial<ExportDiagnostic>,
+): ExportDiagnostic {
+  return overrides;
+}
+
 describe('planRender', () => {
+  it('emits router-fed generated-module missing-artifact blockers with complete planner metadata', () => {
+    const message = 'Clip type "generated-remotion-module" cannot be rendered until remotion_module_missing_artifact is resolved.';
+    const result = planRender({
+      requirements: [
+        routerRequirement({
+          id: 'router.clip.0.generated-remotion-module.browser-export',
+          route: 'browser-export',
+          clipType: 'generated-remotion-module',
+          reason: 'missing-material',
+          legacyReason: 'remotion_module_missing_artifact',
+          message,
+        }),
+        routerRequirement({
+          id: 'router.clip.0.generated-remotion-module.worker-export',
+          route: 'worker-export',
+          clipType: 'generated-remotion-module',
+          reason: 'missing-material',
+          legacyReason: 'remotion_module_missing_artifact',
+          message,
+          requiredCapabilities: ['worker-export'],
+        }),
+      ],
+    });
+
+    expectPlannerBlocker(result.blockers, {
+      id: 'router.clip.0.generated-remotion-module.browser-export.browser-export.missing-material',
+      route: 'browser-export',
+      reason: 'missing-material',
+      message,
+      detail: {
+        source: 'render-router',
+        clipType: 'generated-remotion-module',
+        legacyReason: 'remotion_module_missing_artifact',
+      },
+    });
+    expectPlannerBlocker(result.blockers, {
+      id: 'router.clip.0.generated-remotion-module.worker-export.worker-export.missing-material',
+      route: 'worker-export',
+      reason: 'missing-material',
+      message,
+      detail: {
+        source: 'render-router',
+        clipType: 'generated-remotion-module',
+        legacyReason: 'remotion_module_missing_artifact',
+      },
+    });
+    expect(result.canBrowserExport).toBe(false);
+    expect(result.canWorkerExport).toBe(false);
+  });
+
+  it('emits router-fed contributed clip conflict blockers with route and legacy reason metadata', () => {
+    const message = 'Clip type "generated-remotion-module" cannot be rendered until contributed_blocked_worker_route_conflict is resolved.';
+    const result = planRender({
+      requirements: [
+        routerRequirement({
+          id: 'router.generated.contributed-conflict.browser-export',
+          route: 'browser-export',
+          clipType: 'generated-remotion-module',
+          reason: 'route-unsupported',
+          legacyReason: 'contributed_blocked_worker_route_conflict',
+          message,
+        }),
+        routerRequirement({
+          id: 'router.generated.contributed-conflict.worker-export',
+          route: 'worker-export',
+          clipType: 'generated-remotion-module',
+          reason: 'route-unsupported',
+          legacyReason: 'contributed_blocked_worker_route_conflict',
+          message,
+          requiredCapabilities: ['worker-export'],
+        }),
+      ],
+    });
+
+    expectPlannerBlocker(result.blockers, {
+      id: 'router.generated.contributed-conflict.browser-export.browser-export.route-unsupported',
+      route: 'browser-export',
+      reason: 'route-unsupported',
+      message,
+      detail: {
+        source: 'render-router',
+        clipType: 'generated-remotion-module',
+        legacyReason: 'contributed_blocked_worker_route_conflict',
+      },
+    });
+    expectPlannerBlocker(result.blockers, {
+      id: 'router.generated.contributed-conflict.worker-export.worker-export.route-unsupported',
+      route: 'worker-export',
+      reason: 'route-unsupported',
+      message,
+      detail: {
+        source: 'render-router',
+        clipType: 'generated-remotion-module',
+        legacyReason: 'contributed_blocked_worker_route_conflict',
+      },
+    });
+    expect(result.canBrowserExport).toBe(false);
+    expect(result.canWorkerExport).toBe(false);
+  });
+
+  it('emits request-owned worker, disabled-format, and compile-only handler blockers with detail metadata', () => {
+    const disabledFormat: VideoEditorOutputFormatDescriptor = {
+      ...renderDependentOutput({ availableRoutes: ['browser-export'] }),
+      requiresRender: false,
+      disabled: true,
+      disabledReason: 'Encoder is disabled by policy.',
+      routeRequirements: [],
+      processRequirements: [],
+      blockers: [],
+      nextActions: [],
+      capabilities: undefined,
+    };
+    const compileOnlyFormat: VideoEditorOutputFormatDescriptor = {
+      ...disabledFormat,
+      disabled: false,
+    };
+
+    const workerUnavailable = planRender({
+      request: {
+        route: 'worker-export',
+        routeAvailability: [{
+          route: 'worker-export',
+          available: false,
+          providerId: 'worker-banodoco',
+          message: 'Worker render unavailable for route "generated_remotion_module".',
+          detail: { legacyReason: 'generated_remotion_module' },
+        }],
+      },
+    });
+    expectPlannerBlocker(workerUnavailable.blockers, {
+      id: 'planner.request.worker-export.worker-banodoco.unavailable',
+      route: 'worker-export',
+      reason: 'process-dependent',
+      message: 'Worker render unavailable for route "generated_remotion_module".',
+      detail: expect.objectContaining({
+        source: 'render-request',
+        routeAvailability: 'unavailable',
+        providerId: 'worker-banodoco',
+        requestedRoute: 'worker-export',
+        legacyReason: 'generated_remotion_module',
+      }),
+    });
+
+    const disabled = planRender({
+      outputFormats: [disabledFormat],
+      request: { outputFormatId: 'dataset.zip', route: 'browser-export' },
+    });
+    expectPlannerBlocker(disabled.blockers, {
+      id: 'planner.outputFormat.ext.dataset.dataset.zip.browser-export.disabled',
+      route: 'browser-export',
+      reason: 'inactive-extension',
+      message: 'Encoder is disabled by policy.',
+      detail: expect.objectContaining({
+        source: 'render-request',
+        outputFormatId: 'dataset.zip',
+        requestedRoute: 'browser-export',
+        disabled: true,
+      }),
+    });
+
+    const compileOnlyMissing = planRender({
+      outputFormats: [compileOnlyFormat],
+      request: {
+        outputFormatId: 'dataset.zip',
+        route: 'browser-export',
+        compileOnlyHandlerAvailable: false,
+      },
+    });
+    expectPlannerBlocker(compileOnlyMissing.blockers, {
+      id: 'planner.outputFormat.ext.dataset.dataset.zip.browser-export.compile-handler-missing',
+      route: 'browser-export',
+      reason: 'missing-contribution',
+      message: 'Export format "Dataset bundle" has no compile-only output handlers registered.',
+      detail: expect.objectContaining({
+        source: 'render-request',
+        outputFormatId: 'dataset.zip',
+        requestedRoute: 'browser-export',
+        compileOnlyHandlerAvailable: false,
+      }),
+    });
+  });
+
+  it('emits guard-fed unknown contribution and export diagnostic blockers with preserved detail metadata', () => {
+    const liveBindingDiagnostic = exportDiagnostic({
+      severity: 'error',
+      code: 'export/live-binding-unresolved',
+      message: 'Live binding webcam-1 must be baked before export.',
+      extensionId: 'ext.live',
+      contributionId: 'clip.webcam',
+      detail: {
+        clipId: 'clip-live',
+        clipType: 'webcam-live',
+        renderRoute: 'browser-export',
+        sourceId: 'webcam-1',
+      },
+    });
+    const result = buildExportReadinessPlan({
+      guard: {
+        unknownClipTypes: ['clip.unknown'],
+        unknownEffects: ['effect.unknown'],
+        unknownTransitions: ['transition.unknown'],
+        diagnostics: [liveBindingDiagnostic],
+      },
+    });
+
+    expectPlannerBlocker(result.blockers, {
+      id: 'planner.guard.unknown-clip-type.clip.unknown.browser-export',
+      route: 'browser-export',
+      reason: 'missing-contribution',
+      message: 'Unknown clip type "clip.unknown" cannot be exported on browser-export.',
+      detail: expect.objectContaining({
+        source: 'export-guard-compat',
+        code: 'export/unknown-clip-type',
+        contributionKind: 'clip-type',
+        contributionId: 'clip.unknown',
+        renderRoute: 'browser-export',
+      }),
+    });
+    expectPlannerBlocker(result.blockers, {
+      id: 'planner.guard.unknown-effect.effect.unknown.worker-export',
+      route: 'worker-export',
+      reason: 'missing-contribution',
+      message: 'Unknown effect "effect.unknown" cannot be exported on worker-export.',
+      detail: expect.objectContaining({
+        source: 'export-guard-compat',
+        code: 'export/unknown-effect',
+        contributionKind: 'effect',
+        contributionId: 'effect.unknown',
+        renderRoute: 'worker-export',
+      }),
+    });
+    expectPlannerBlocker(result.blockers, {
+      id: 'planner.guard.unknown-transition.transition.unknown.sidecar-export',
+      route: 'sidecar-export',
+      reason: 'missing-contribution',
+      message: 'Unknown transition "transition.unknown" cannot be exported on sidecar-export.',
+      detail: expect.objectContaining({
+        source: 'export-guard-compat',
+        code: 'export/unknown-transition',
+        contributionKind: 'transition',
+        contributionId: 'transition.unknown',
+        renderRoute: 'sidecar-export',
+      }),
+    });
+    expectPlannerBlocker(result.blockers, {
+      id: 'export-guard:export/live-binding-unresolved:ext.live:clip.webcam:clip-live:webcam-live',
+      route: 'browser-export',
+      reason: 'live-unbaked',
+      message: 'Live binding webcam-1 must be baked before export.',
+      detail: expect.objectContaining({
+        source: 'export-guard-compat',
+        code: 'export/live-binding-unresolved',
+        diagnosticDetail: {
+          clipId: 'clip-live',
+          clipType: 'webcam-live',
+          renderRoute: 'browser-export',
+          sourceId: 'webcam-1',
+        },
+      }),
+    });
+  });
+
+  it('emits existing planner-owned output and process blockers with stable blocker fields', () => {
+    const missingOutput = planRender({
+      outputFormats: [renderDependentOutput()],
+      request: { outputFormatId: 'missing.format', route: 'sidecar-export' },
+    });
+    expectPlannerBlocker(missingOutput.blockers, {
+      id: 'planner.outputFormat.missing.format.missing',
+      route: 'sidecar-export',
+      reason: 'missing-contribution',
+      message: 'Output format "missing.format" is not registered.',
+      detail: {
+        source: 'render-request',
+        outputFormatId: 'missing.format',
+      },
+    });
+
+    const unsupportedOutputRoute = planRender({
+      outputFormats: [renderDependentOutput({ availableRoutes: ['sidecar-export'] })],
+      request: { outputFormatId: 'dataset.zip', route: 'browser-export' },
+    });
+    expectPlannerBlocker(unsupportedOutputRoute.blockers, {
+      id: 'planner.outputFormat.ext.dataset.dataset.zip.browser-export.route-unsupported',
+      route: 'browser-export',
+      reason: 'route-unsupported',
+      message: 'Output format "Dataset bundle" is not available on browser-export.',
+      detail: expect.objectContaining({
+        source: 'render-request',
+        outputFormatId: 'dataset.zip',
+        requestedRoute: 'browser-export',
+      }),
+    });
+
+    const processNotInstalled = planRender({
+      outputFormats: [renderDependentOutput()],
+      processes: [processDescriptor()],
+      processStatuses: [{
+        processId: 'dataset-process',
+        state: 'not-installed',
+        installHint: 'Install the dataset bridge.',
+      }],
+      request: { outputFormatId: 'dataset.zip' },
+    });
+    expectPlannerBlocker(processNotInstalled.blockers, {
+      id: 'planner.outputFormat.ext.dataset.dataset.zip.sidecar-export.dataset-process.exportDataset.process-not-installed',
+      route: 'sidecar-export',
+      reason: 'process-not-installed',
+      message: 'Process "dataset-process" is not installed for sidecar-export. Hint: Install the dataset bridge.',
+      detail: expect.objectContaining({
+        source: 'output-format',
+        outputFormatId: 'dataset.zip',
+        outputLabel: 'Dataset bundle',
+        processId: 'dataset-process',
+        operationId: 'exportDataset',
+        routeScope: 'sidecar-export',
+        processProtocol: 'stdio-jsonrpc',
+        installHint: 'Install the dataset bridge.',
+        processState: 'not-installed',
+        lifecycleState: 'not-installed',
+      }),
+    });
+  });
+
+  it('preserves guard-fed unknown IDs as planner-owned missing-contribution blockers', () => {
+    const result = buildExportReadinessPlan({
+      guard: {
+        unknownClipTypes: ['clip.z', 'clip.a'],
+        unknownEffects: ['effect.z', 'effect.a'],
+        unknownTransitions: ['transition.z', 'transition.a'],
+        inactiveExtensionIds: {
+          effectIds: new Set(['effect.reserved']),
+          transitionIds: new Set(['transition.reserved']),
+          clipTypeIds: new Set(['clip.reserved']),
+        },
+      },
+    });
+
+    expect(result.guard.unknownClipTypes).toEqual(['clip.a', 'clip.z']);
+    expect(result.guard.unknownEffects).toEqual(['effect.a', 'effect.z']);
+    expect(result.guard.unknownTransitions).toEqual(['transition.a', 'transition.z']);
+    expect(result.guard.inactiveExtensionIds.effectIds).toEqual(new Set(['effect.reserved']));
+    expect(result.guard.inactiveExtensionIds.transitionIds).toEqual(new Set(['transition.reserved']));
+    expect(result.guard.inactiveExtensionIds.clipTypeIds).toEqual(new Set(['clip.reserved']));
+    expect(result.guard.hasBlockingErrors).toBe(true);
+    expect(result.blockers).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: 'planner.guard.unknown-clip-type.clip.a.browser-export',
+        route: 'browser-export',
+        reason: 'missing-contribution',
+        contributionId: 'clip.a',
+        detail: expect.objectContaining({
+          source: 'export-guard-compat',
+          code: 'export/unknown-clip-type',
+        }),
+      }),
+      expect.objectContaining({
+        id: 'planner.guard.unknown-effect.effect.a.worker-export',
+        route: 'worker-export',
+        reason: 'missing-contribution',
+        contributionId: 'effect.a',
+        detail: expect.objectContaining({
+          source: 'export-guard-compat',
+          code: 'export/unknown-effect',
+        }),
+      }),
+      expect.objectContaining({
+        id: 'planner.guard.unknown-transition.transition.a.sidecar-export',
+        route: 'sidecar-export',
+        reason: 'missing-contribution',
+        contributionId: 'transition.a',
+        detail: expect.objectContaining({
+          source: 'export-guard-compat',
+          code: 'export/unknown-transition',
+        }),
+      }),
+    ]));
+    expect(result.canBrowserExport).toBe(false);
+    expect(result.canWorkerExport).toBe(false);
+    expect(result.canSidecarExport).toBe(false);
+  });
+
+  it('keeps warning-only inactive extension diagnostics non-blocking', () => {
+    const warning = exportDiagnostic({
+      severity: 'warning',
+      code: 'export/unsupported-reserved-target',
+      message: 'Effect effect.reserved is reserved by an inactive extension.',
+      extensionId: 'ext.inactive',
+      contributionId: 'effect.reserved',
+      detail: {
+        effectType: 'effect.reserved',
+        renderRoute: 'browser-export',
+        blockerReason: 'inactive-extension',
+      },
+    });
+
+    const result = buildExportReadinessPlan({
+      guard: {
+        diagnostics: [warning],
+        inactiveExtensionIds: {
+          effectIds: new Set(['effect.reserved']),
+          transitionIds: new Set(['transition.reserved']),
+          clipTypeIds: new Set(['clip.reserved']),
+        },
+      },
+    });
+
+    expect(result.guard.unknownClipTypes).toEqual([]);
+    expect(result.guard.unknownEffects).toEqual([]);
+    expect(result.guard.unknownTransitions).toEqual([]);
+    expect(result.guard.inactiveExtensionIds.effectIds).toEqual(new Set(['effect.reserved']));
+    expect(result.guard.inactiveExtensionIds.transitionIds).toEqual(new Set(['transition.reserved']));
+    expect(result.guard.inactiveExtensionIds.clipTypeIds).toEqual(new Set(['clip.reserved']));
+    expect(result.guard.hasBlockingErrors).toBe(false);
+
+    const finding = result.findings.find((item) => item.detail?.code === 'export/unsupported-reserved-target');
+    expect(finding).toMatchObject({
+      severity: 'warning',
+      route: 'browser-export',
+      message: 'Effect effect.reserved is reserved by an inactive extension.',
+      extensionId: 'ext.inactive',
+      contributionId: 'effect.reserved',
+      detail: {
+        source: 'export-guard-compat',
+        code: 'export/unsupported-reserved-target',
+        diagnosticDetail: {
+          effectType: 'effect.reserved',
+          renderRoute: 'browser-export',
+          blockerReason: 'inactive-extension',
+        },
+      },
+    });
+    expect(finding?.reason).toBeUndefined();
+    expect(result.blockers).toEqual([]);
+    expect(result.canBrowserExport).toBe(true);
+    expect(result.canWorkerExport).toBe(true);
+    expect(result.canSidecarExport).toBe(true);
+  });
+
+  it('maps known and unknown export diagnostics to planner reasons while preserving diagnostic metadata', () => {
+    const knownDiagnostic = exportDiagnostic({
+      severity: 'error',
+      code: 'export/unrenderable-effect',
+      message: 'Effect effect.preview cannot render on worker export.',
+      extensionId: 'ext.effects',
+      contributionId: 'effect.preview',
+      detail: {
+        clipId: 'clip-1',
+        effectType: 'effect.preview',
+        renderRoute: 'worker-export',
+        blockerReason: 'live-unbaked',
+      },
+    });
+    const unknownDiagnostic = exportDiagnostic({
+      severity: 'error',
+      code: 'export/vendor-specific' as `export/${string}`,
+      message: 'Vendor-specific export readiness failed.',
+      extensionId: 'ext.vendor',
+      contributionId: 'vendor.effect',
+      detail: {
+        clipId: 'clip-2',
+        effectType: 'vendor.effect',
+        renderRoute: 'sidecar-export',
+        vendorDetail: 'preserved',
+      },
+    });
+    const liveBindingDiagnostic = exportDiagnostic({
+      severity: 'error',
+      code: 'export/live-binding-unresolved',
+      message: 'Live binding webcam-1 must be baked before export.',
+      extensionId: 'ext.live',
+      contributionId: 'clip.webcam',
+      detail: {
+        clipId: 'clip-live',
+        clipType: 'webcam-live',
+        renderRoute: 'browser-export',
+        sourceId: 'webcam-1',
+      },
+    });
+
+    const result = buildExportReadinessPlan({
+      guard: {
+        diagnostics: [
+          unknownDiagnostic,
+          liveBindingDiagnostic,
+          knownDiagnostic,
+        ],
+      },
+    });
+    const findingForCode = (code: string): CapabilityFinding | undefined =>
+      result.findings.find((finding) => finding.detail?.code === code);
+
+    expect(findingForCode('export/unrenderable-effect')).toMatchObject({
+      severity: 'error',
+      route: 'worker-export',
+      reason: 'route-unsupported',
+      message: 'Effect effect.preview cannot render on worker export.',
+      extensionId: 'ext.effects',
+      contributionId: 'effect.preview',
+      detail: {
+        source: 'export-guard-compat',
+        code: 'export/unrenderable-effect',
+        diagnosticDetail: {
+          clipId: 'clip-1',
+          effectType: 'effect.preview',
+          renderRoute: 'worker-export',
+          blockerReason: 'live-unbaked',
+        },
+      },
+    });
+    expect(findingForCode('export/vendor-specific')).toMatchObject({
+      severity: 'error',
+      route: 'sidecar-export',
+      reason: 'unknown',
+      detail: {
+        source: 'export-guard-compat',
+        code: 'export/vendor-specific',
+        diagnosticDetail: {
+          clipId: 'clip-2',
+          effectType: 'vendor.effect',
+          renderRoute: 'sidecar-export',
+          vendorDetail: 'preserved',
+        },
+      },
+    });
+    expect(findingForCode('export/live-binding-unresolved')).toMatchObject({
+      severity: 'error',
+      route: 'browser-export',
+      reason: 'live-unbaked',
+      detail: {
+        source: 'export-guard-compat',
+        code: 'export/live-binding-unresolved',
+        diagnosticDetail: {
+          clipId: 'clip-live',
+          clipType: 'webcam-live',
+          renderRoute: 'browser-export',
+          sourceId: 'webcam-1',
+        },
+      },
+    });
+    expect(result.blockers).toEqual(expect.arrayContaining([
+      expect.objectContaining({ reason: 'route-unsupported', route: 'worker-export' }),
+      expect.objectContaining({ reason: 'unknown', route: 'sidecar-export' }),
+      expect.objectContaining({ reason: 'live-unbaked', route: 'browser-export' }),
+    ]));
+    expect(result.guard.hasBlockingErrors).toBe(true);
+    expect(result.canBrowserExport).toBe(false);
+    expect(result.canWorkerExport).toBe(false);
+    expect(result.canSidecarExport).toBe(false);
+  });
+
+  it('keeps buildExportReadinessPlan wrapper readiness identical to direct planRender reduction', () => {
+    const guardDiagnostic = exportDiagnostic({
+      severity: 'error',
+      code: 'export/live-binding-unresolved',
+      message: 'Live binding webcam-1 must be baked before export.',
+      extensionId: 'ext.live',
+      contributionId: 'clip.webcam',
+      detail: {
+        clipId: 'clip-live',
+        clipType: 'webcam-live',
+        renderRoute: 'browser-export',
+        sourceId: 'webcam-1',
+      },
+    });
+    const adaptedGuardDiagnostic: CapabilityFinding = {
+      id: 'export-guard:export/live-binding-unresolved:ext.live:clip.webcam:clip-live:webcam-live',
+      severity: 'error',
+      route: 'browser-export',
+      reason: 'live-unbaked',
+      message: 'Live binding webcam-1 must be baked before export.',
+      extensionId: 'ext.live',
+      contributionId: 'clip.webcam',
+      detail: {
+        source: 'export-guard-compat',
+        code: 'export/live-binding-unresolved',
+        diagnosticDetail: {
+          clipId: 'clip-live',
+          clipType: 'webcam-live',
+          renderRoute: 'browser-export',
+          sourceId: 'webcam-1',
+        },
+      },
+    };
+    const guardFinding: CapabilityFinding = {
+      id: 'guard.finding.worker-warning',
+      severity: 'warning',
+      route: 'worker-export',
+      reason: 'unknown',
+      message: 'Worker support was not proven by the guard scan.',
+      detail: { source: 'export-guard' },
+    };
+    const guardBlocker: RenderBlocker = {
+      id: 'guard.blocker.sidecar',
+      severity: 'error',
+      route: 'sidecar-export',
+      reason: 'unknown',
+      message: 'Sidecar export was blocked by guard input.',
+      detail: { source: 'export-guard' },
+    };
+
+    const wrapperResult = buildExportReadinessPlan({
+      guard: {
+        diagnostics: [guardDiagnostic],
+        findings: [guardFinding],
+        blockers: [guardBlocker],
+      },
+    });
+    const directResult = planRender({
+      diagnostics: [
+        adaptedGuardDiagnostic,
+        guardFinding,
+        guardBlocker,
+      ],
+    });
+
+    expect(wrapperResult.guard.diagnostics).toEqual([adaptedGuardDiagnostic]);
+    expect(wrapperResult.guard.findings).toEqual([guardFinding]);
+    expect(wrapperResult.guard.blockers).toEqual([guardBlocker]);
+    expect(wrapperResult.findings).toEqual(directResult.findings);
+    expect(wrapperResult.blockers).toEqual(directResult.blockers);
+    expect(wrapperResult.routes).toEqual(directResult.routes);
+    expect(wrapperResult.routePlans).toEqual(directResult.routePlans);
+    expect(wrapperResult.diagnostics).toEqual(directResult.diagnostics);
+    expect(wrapperResult.nextActions).toEqual(directResult.nextActions);
+    expect(wrapperResult.canBrowserExport).toBe(directResult.canBrowserExport);
+    expect(wrapperResult.canWorkerExport).toBe(directResult.canWorkerExport);
+    expect(wrapperResult.canSidecarExport).toBe(directResult.canSidecarExport);
+  });
+
   it('derives route blockers from a public TimelineSnapshot without registry inputs', () => {
     const result = planRender({ snapshot: snapshotWithLiveBinding() });
 
@@ -1070,6 +1763,118 @@ describe('planRender', () => {
         contributionId: 'missing.format',
       }),
     ]);
+  });
+
+  it('blocks only explicitly requested disabled output formats', () => {
+    const disabledFormat: VideoEditorOutputFormatDescriptor = {
+      ...renderDependentOutput({ availableRoutes: ['browser-export'] }),
+      requiresRender: false,
+      disabled: true,
+      disabledReason: 'Encoder is disabled by policy.',
+      routeRequirements: [],
+      processRequirements: [],
+      blockers: [],
+      nextActions: [],
+      capabilities: undefined,
+    };
+
+    const generalPlan = planRender({
+      outputFormats: [disabledFormat],
+    });
+    expect(generalPlan.canBrowserExport).toBe(true);
+    expect(generalPlan.blockers).toEqual([]);
+
+    const requestedPlan = planRender({
+      outputFormats: [disabledFormat],
+      request: { outputFormatId: 'dataset.zip', route: 'browser-export' },
+    });
+    expect(requestedPlan.blockers).toEqual([
+      expect.objectContaining({
+        id: 'planner.outputFormat.ext.dataset.dataset.zip.browser-export.disabled',
+        route: 'browser-export',
+        reason: 'inactive-extension',
+        message: 'Encoder is disabled by policy.',
+        detail: expect.objectContaining({
+          source: 'render-request',
+          outputFormatId: 'dataset.zip',
+          disabled: true,
+        }),
+      }),
+    ]);
+  });
+
+  it('blocks compile-only handler absence only for the requested format', () => {
+    const compileOnlyFormat: VideoEditorOutputFormatDescriptor = {
+      ...renderDependentOutput({ availableRoutes: ['browser-export'] }),
+      requiresRender: false,
+      disabled: false,
+      routeRequirements: [],
+      processRequirements: [],
+      blockers: [],
+      nextActions: [],
+      capabilities: undefined,
+    };
+
+    const generalPlan = planRender({
+      outputFormats: [compileOnlyFormat],
+      request: { compileOnlyHandlerAvailable: false },
+    });
+    expect(generalPlan.blockers).toEqual([]);
+
+    const requestedPlan = planRender({
+      outputFormats: [compileOnlyFormat],
+      request: {
+        outputFormatId: 'dataset.zip',
+        route: 'browser-export',
+        compileOnlyHandlerAvailable: false,
+      },
+    });
+    expect(requestedPlan.blockers).toEqual([
+      expect.objectContaining({
+        id: 'planner.outputFormat.ext.dataset.dataset.zip.browser-export.compile-handler-missing',
+        route: 'browser-export',
+        reason: 'missing-contribution',
+        message: 'Export format "Dataset bundle" has no compile-only output handlers registered.',
+        detail: expect.objectContaining({
+          source: 'render-request',
+          outputFormatId: 'dataset.zip',
+          compileOnlyHandlerAvailable: false,
+        }),
+      }),
+    ]);
+  });
+
+  it('uses request-scoped route availability blockers without blocking unrelated routes', () => {
+    const result = planRender({
+      request: {
+        route: 'worker-export',
+        routeAvailability: [{
+          route: 'worker-export',
+          available: false,
+          providerId: 'worker-banodoco',
+          message: 'Worker render unavailable for route "generated_remotion_module".',
+        }],
+      },
+    });
+
+    expect(result.routePlans.find((routePlan) => routePlan.route === 'worker-export')).toMatchObject({
+      blocked: true,
+      blockers: [
+        expect.objectContaining({
+          id: 'planner.request.worker-export.worker-banodoco.unavailable',
+          route: 'worker-export',
+          reason: 'process-dependent',
+          message: 'Worker render unavailable for route "generated_remotion_module".',
+          detail: expect.objectContaining({
+            source: 'render-request',
+            routeAvailability: 'unavailable',
+            providerId: 'worker-banodoco',
+          }),
+        }),
+      ],
+    });
+    expect(result.routePlans.find((routePlan) => routePlan.route === 'browser-export')?.blocked).toBe(false);
+    expect(result.routePlans.find((routePlan) => routePlan.route === 'sidecar-export')?.blocked).toBe(false);
   });
 
   it('surfaces requested route support and request-level capabilities in route plans', () => {

--- a/src/tools/video-editor/runtime/renderPlanner.ts
+++ b/src/tools/video-editor/runtime/renderPlanner.ts
@@ -13,6 +13,7 @@ import {
   RENDER_ROUTES,
   type TimelineSnapshot,
   type TimelineShaderSummary,
+  type ExportDiagnostic,
   getCapabilityRequirements,
 } from '@reigh/editor-sdk';
 import type { ProcessStatus } from '@/sdk/video/families/processes';
@@ -69,6 +70,17 @@ export interface RenderPlannerRequest {
   readonly routes?: readonly RenderRoute[];
   readonly outputFormatId?: string;
   readonly requiredCapabilities?: readonly string[];
+  readonly compileOnlyHandlerAvailable?: boolean;
+  readonly routeAvailability?: readonly RenderPlannerRouteAvailability[];
+}
+
+export interface RenderPlannerRouteAvailability {
+  readonly route: RenderRoute;
+  readonly available: boolean;
+  readonly providerId?: string;
+  readonly reason?: RenderBlockerReason;
+  readonly message?: string;
+  readonly detail?: Readonly<Record<string, unknown>>;
 }
 
 export type RenderPlannerMaterialState = RenderMaterialStatusState;
@@ -93,6 +105,23 @@ export interface RenderPlannerInput {
   readonly materialRuntime?: HostMaterialRuntimeProjection;
   readonly request?: RenderPlannerRequest;
   readonly diagnostics?: readonly CapabilityFinding[];
+}
+
+export type RenderPlannerGuardDiagnosticInput = CapabilityFinding | ExportDiagnostic;
+
+export interface RenderPlannerGuardScanPayload {
+  readonly diagnostics?: readonly RenderPlannerGuardDiagnosticInput[];
+  readonly findings?: readonly CapabilityFinding[];
+  readonly blockers?: readonly RenderBlocker[];
+  readonly unknownClipTypes?: readonly string[];
+  readonly unknownEffects?: readonly string[];
+  readonly unknownTransitions?: readonly string[];
+  readonly inactiveExtensionIds?: RenderPlannerGuardCompatibility['inactiveExtensionIds'];
+  readonly hasBlockingErrors?: boolean;
+}
+
+export interface ExportReadinessPlannerInput extends RenderPlannerInput {
+  readonly guard?: RenderPlannerGuardScanPayload | null;
 }
 
 export interface RenderRouteSummary {
@@ -216,6 +245,12 @@ const GRAPH_PLANNER_ROUTES = [
   'worker-export',
 ] as const satisfies readonly RenderRoute[];
 
+const EXPORT_BLOCKING_ROUTES = [
+  'browser-export',
+  'worker-export',
+  'sidecar-export',
+] as const satisfies readonly RenderRoute[];
+
 const LEGACY_GRAPH_COMPATIBILITY_BLOCKER_ID = 'planner.compositionGraph.legacy-shader-ref-compatibility';
 
 const PROCESS_NON_DEGRADED_CAPABILITY_IDS = new Set([
@@ -226,6 +261,46 @@ const PROCESS_NON_DEGRADED_CAPABILITY_IDS = new Set([
 const TRUSTED_LOCAL_PROCESS_PROTOCOLS = new Set<VideoEditorProcessDescriptor['protocol']>([
   'stdio-jsonrpc',
 ]);
+
+const EXPORT_DIAGNOSTIC_REASON_BY_CODE = Object.freeze({
+  'export/unknown-clip-type': 'missing-contribution',
+  'export/unknown-effect-type': 'missing-contribution',
+  'export/unknown-transition-type': 'missing-contribution',
+  'export/unrenderable-clip-type': 'route-unsupported',
+  'export/unrenderable-effect': 'route-unsupported',
+  'export/unrenderable-transition': 'route-unsupported',
+  'export/unrenderable-shader': 'missing-material',
+  'export/missing-shader-materializer': 'missing-material',
+  'export/shader-no-materializer': 'missing-material',
+  'export/live-binding-unresolved': 'live-unbaked',
+  'export/unknown-route-support': 'unknown',
+  'export/missing-extension': 'missing-contribution',
+  'export/effect-preview-only': 'preview-only',
+  'export/preview-only': 'preview-only',
+  'export/route-unsupported': 'route-unsupported',
+  'export/unresolved-ref': 'unknown',
+  'export/effect-unresolved-ref': 'unknown',
+  'export/transition-unresolved-ref': 'unknown',
+  'export/invalid-target-path': 'unknown',
+  'export/unsupported-reserved-target': 'inactive-extension',
+  'export/unknown-target-ref': 'missing-contribution',
+  'export/unknown-uniform': 'unknown',
+  'export/non-bindable-target': 'unknown',
+  'export/target-value-type-error': 'unknown',
+  'export/target-interpolation-gap': 'unknown',
+  'export/deterministic-capture-conversion-failed': 'live-unbaked',
+  'export/deterministic-capture-target-path-unresolvable': 'live-unbaked',
+  'export/deterministic-capture-value-normalization-failed': 'live-unbaked',
+  'export/deterministic-capture-timing-failed': 'live-unbaked',
+  'export/deterministic-capture-provenance-mismatch': 'live-unbaked',
+} satisfies Partial<Record<ExportDiagnostic['code'], RenderBlockerReason>>);
+
+// M3 export-readiness category audit:
+// Existing planner-owned paths: missing output formats, route-unsupported output
+// formats, process dependency states, shader/material blockers, and live-binding
+// blockers. Missing/normalized inputs still needed: disabled formats,
+// request-scoped compile handler absence, worker/provider availability, and
+// unknown contribution IDs.
 
 const DETERMINISM_RANK: Record<DeterminismStatus, number> = {
   deterministic: 0,
@@ -1260,6 +1335,47 @@ function collectRequestCapabilities(acc: PlanAccumulator, request: RenderPlanner
   }
 }
 
+function requestedAvailabilityApplies(
+  request: RenderPlannerRequest | undefined,
+  route: RenderRoute,
+): boolean {
+  const routes = requestedRoutes(request);
+  return routes.length === 0 || routes.includes(route);
+}
+
+function collectRequestRouteAvailability(
+  acc: PlanAccumulator,
+  request: RenderPlannerRequest | undefined,
+): void {
+  if (!request?.routeAvailability?.length) return;
+
+  for (const availability of request.routeAvailability) {
+    if (availability.available || !requestedAvailabilityApplies(request, availability.route)) {
+      continue;
+    }
+    const reason = availability.reason ?? (
+      availability.route === 'worker-export' ? 'process-dependent' : 'route-unsupported'
+    );
+    const blocker: RenderBlocker = {
+      id: `planner.request.${availability.route}.${availability.providerId ?? 'provider'}.unavailable`,
+      severity: 'error',
+      route: availability.route,
+      reason,
+      message: availability.message
+        ?? `Render provider "${availability.providerId ?? availability.route}" is unavailable for ${availability.route}.`,
+      detail: {
+        source: 'render-request',
+        routeAvailability: 'unavailable',
+        providerId: availability.providerId,
+        requestedRoute: availability.route,
+        ...(availability.detail ?? {}),
+      },
+    };
+    acc.findings.push(blocker);
+    acc.blockers.push(blocker);
+  }
+}
+
 function descriptorBlockerToFinding(
   blocker: VideoEditorPlannerBlockerDescriptor,
   fallbackRoute: RenderRoute,
@@ -2082,6 +2198,71 @@ function collectRequestedOutputRouteSupport(
   }
 }
 
+function collectRequestedOutputAvailability(
+  acc: PlanAccumulator,
+  outputFormat: VideoEditorOutputFormatDescriptor | undefined,
+  request: RenderPlannerRequest | undefined,
+): void {
+  if (!outputFormat || request?.outputFormatId !== outputFormat.id) return;
+  const routes = requestedRoutes(request);
+  const targetRoutes = routes.length > 0
+    ? routes
+    : (outputFormat.availableRoutes.length > 0
+      ? canonicalRenderRoutes(outputFormat.availableRoutes)
+      : (['browser-export'] as const));
+
+  if (outputFormat.disabled) {
+    for (const route of targetRoutes) {
+      const blocker: RenderBlocker = {
+        id: `planner.outputFormat.${outputFormat.extensionId}.${outputFormat.id}.${route}.disabled`,
+        severity: 'error',
+        route,
+        reason: 'inactive-extension',
+        message: outputFormat.disabledReason ?? `Output format "${outputFormat.label}" is disabled.`,
+        extensionId: outputFormat.extensionId,
+        contributionId: outputFormat.id,
+        detail: {
+          source: 'render-request',
+          outputFormatId: outputFormat.id,
+          requestedRoute: route,
+          disabled: true,
+        },
+      };
+      acc.findings.push(blocker);
+      acc.blockers.push(blocker);
+    }
+    return;
+  }
+
+  if (
+    outputFormat.requiresRender
+    || request?.compileOnlyHandlerAvailable !== false
+  ) {
+    return;
+  }
+
+  for (const route of targetRoutes) {
+    const blocker: RenderBlocker = {
+      id: `planner.outputFormat.${outputFormat.extensionId}.${outputFormat.id}.${route}.compile-handler-missing`,
+      severity: 'error',
+      route,
+      reason: 'missing-contribution',
+      message:
+        `Export format "${outputFormat.label}" has no compile-only output handlers registered.`,
+      extensionId: outputFormat.extensionId,
+      contributionId: outputFormat.id,
+      detail: {
+        source: 'render-request',
+        outputFormatId: outputFormat.id,
+        requestedRoute: route,
+        compileOnlyHandlerAvailable: false,
+      },
+    };
+    acc.findings.push(blocker);
+    acc.blockers.push(blocker);
+  }
+}
+
 function collectProcess(
   acc: PlanAccumulator,
   process: VideoEditorProcessDescriptor,
@@ -2503,6 +2684,142 @@ function emptyGuard(
   });
 }
 
+function freezeInactiveExtensionIds(
+  ids: RenderPlannerGuardCompatibility['inactiveExtensionIds'] | undefined,
+): RenderPlannerGuardCompatibility['inactiveExtensionIds'] {
+  if (!ids) return EMPTY_IDS;
+  return Object.freeze({
+    effectIds: Object.freeze(new Set(ids.effectIds)),
+    transitionIds: Object.freeze(new Set(ids.transitionIds)),
+    clipTypeIds: Object.freeze(new Set(ids.clipTypeIds)),
+  });
+}
+
+function exportDiagnosticId(diagnostic: ExportDiagnostic, index: number): string {
+  const detail = diagnostic.detail ?? {};
+  return [
+    'export-guard',
+    diagnostic.code,
+    diagnostic.extensionId ?? 'host',
+    diagnostic.contributionId ?? 'timeline',
+    detail.clipId ?? 'no-clip',
+    detail.effectType ?? detail.transitionType ?? detail.clipType ?? detail.shaderId ?? index,
+  ].join(':');
+}
+
+function blockerReasonForExportDiagnostic(diagnostic: ExportDiagnostic): RenderBlockerReason {
+  return EXPORT_DIAGNOSTIC_REASON_BY_CODE[diagnostic.code] ?? 'unknown';
+}
+
+function routeForExportDiagnostic(diagnostic: ExportDiagnostic): RenderRoute {
+  const detailRoute = diagnostic.detail?.renderRoute;
+  return isCanonicalRenderRoute(typeof detailRoute === 'string' ? detailRoute : undefined)
+    ? detailRoute
+    : 'browser-export';
+}
+
+function exportDiagnosticToPlannerFinding(diagnostic: ExportDiagnostic, index: number): CapabilityFinding {
+  const reason = diagnostic.severity === 'error'
+    ? blockerReasonForExportDiagnostic(diagnostic)
+    : undefined;
+
+  return {
+    id: exportDiagnosticId(diagnostic, index),
+    severity: diagnostic.severity,
+    route: routeForExportDiagnostic(diagnostic),
+    ...(reason ? { reason } : {}),
+    message: diagnostic.message,
+    ...(diagnostic.extensionId ? { extensionId: diagnostic.extensionId } : {}),
+    ...(diagnostic.contributionId ? { contributionId: diagnostic.contributionId } : {}),
+    detail: {
+      source: 'export-guard-compat',
+      code: diagnostic.code,
+      diagnosticDetail: Object.freeze({ ...(diagnostic.detail ?? {}) }),
+    },
+  };
+}
+
+function isCapabilityFinding(input: RenderPlannerGuardDiagnosticInput): input is CapabilityFinding {
+  return 'id' in input && typeof input.id === 'string';
+}
+
+function guardDiagnosticToPlannerFinding(
+  diagnostic: RenderPlannerGuardDiagnosticInput,
+  index: number,
+): CapabilityFinding {
+  return isCapabilityFinding(diagnostic)
+    ? diagnostic
+    : exportDiagnosticToPlannerFinding(diagnostic, index);
+}
+
+function unknownContributionFindings(
+  kind: 'clip-type' | 'effect' | 'transition',
+  ids: readonly string[] | undefined,
+): CapabilityFinding[] {
+  const uniqueIds = [...new Set(ids ?? [])].sort();
+  const label = kind === 'clip-type' ? 'clip type' : kind;
+  return uniqueIds.flatMap((id) =>
+    EXPORT_BLOCKING_ROUTES.map((route): CapabilityFinding => ({
+      id: `planner.guard.unknown-${kind}.${id}.${route}`,
+      severity: 'error',
+      route,
+      reason: 'missing-contribution',
+      message: `Unknown ${label} "${id}" cannot be exported on ${route}.`,
+      contributionId: id,
+      detail: {
+        source: 'export-guard-compat',
+        code: `export/unknown-${kind}`,
+        contributionKind: kind,
+        contributionId: id,
+        renderRoute: route,
+      },
+    })),
+  );
+}
+
+function buildGuardCompatibility(
+  guard: RenderPlannerGuardScanPayload,
+): {
+  readonly guard: RenderPlannerGuardCompatibility;
+  readonly plannerDiagnostics: readonly CapabilityFinding[];
+} {
+  const unknownIdFindings = sortedFindings([
+    ...unknownContributionFindings('clip-type', guard.unknownClipTypes),
+    ...unknownContributionFindings('effect', guard.unknownEffects),
+    ...unknownContributionFindings('transition', guard.unknownTransitions),
+  ]);
+  const diagnostics = sortedFindings(
+    (guard.diagnostics ?? []).map(guardDiagnosticToPlannerFinding),
+  );
+  const findings = sortedFindings(guard.findings ?? []);
+  const blockers = sortedBlockers(guard.blockers ?? []);
+  const hasBlockingErrors = guard.hasBlockingErrors
+    ?? (
+      unknownIdFindings.length > 0
+      || blockers.length > 0
+      || diagnostics.some((diagnostic) => diagnostic.severity === 'error')
+    );
+
+  return Object.freeze({
+    guard: Object.freeze({
+      diagnostics,
+      findings,
+      blockers,
+      unknownClipTypes: Object.freeze([...(guard.unknownClipTypes ?? [])].sort()),
+      unknownEffects: Object.freeze([...(guard.unknownEffects ?? [])].sort()),
+      unknownTransitions: Object.freeze([...(guard.unknownTransitions ?? [])].sort()),
+      inactiveExtensionIds: freezeInactiveExtensionIds(guard.inactiveExtensionIds),
+      hasBlockingErrors,
+    }),
+    plannerDiagnostics: Object.freeze([
+      ...unknownIdFindings,
+      ...diagnostics,
+      ...findings,
+      ...blockers,
+    ]),
+  });
+}
+
 export function planRender(input: RenderPlannerInput): RenderPlannerResult {
   const acc = createAccumulator();
   const requestRouteFindings = renderRequestRouteScopeFindings(input.request);
@@ -2581,10 +2898,12 @@ export function planRender(input: RenderPlannerInput): RenderPlannerResult {
     collectRequirement(acc, requirement);
   }
   collectRequestCapabilities(acc, input.request);
+  collectRequestRouteAvailability(acc, input.request);
   for (const outputFormat of plannedOutputFormats) {
     collectOutputFormat(acc, outputFormat, processStatusById, processById);
   }
   collectRequestedOutputRouteSupport(acc, requestedOutputFormat, input.request);
+  collectRequestedOutputAvailability(acc, requestedOutputFormat, input.request);
   for (const process of processes) {
     collectProcess(acc, process, processStatusById.get(process.processId));
   }
@@ -2672,5 +2991,26 @@ export function planRender(input: RenderPlannerInput): RenderPlannerResult {
     canBrowserExport: !browserRoute?.blocked,
     canWorkerExport: !workerRoute?.blocked,
     canSidecarExport: !sidecarRoute?.blocked,
+  });
+}
+
+export function buildExportReadinessPlan(input: ExportReadinessPlannerInput): RenderPlannerResult {
+  const { guard, ...plannerInput } = input;
+  if (!guard) {
+    return planRender(plannerInput);
+  }
+
+  const guardCompatibility = buildGuardCompatibility(guard);
+  const plannerResult = planRender({
+    ...plannerInput,
+    diagnostics: [
+      ...(plannerInput.diagnostics ?? []),
+      ...guardCompatibility.plannerDiagnostics,
+    ],
+  });
+
+  return Object.freeze({
+    ...plannerResult,
+    guard: guardCompatibility.guard,
   });
 }


### PR DESCRIPTION
## Summary

Recover the M3 export-readiness convergence work onto the actual local/extension-foundation-completion target after the chain advanced past a non-authoritative M3 publication record.

This preserves the recovered M3 product changes while keeping M4's planner-route evidence behavior intact.

## Validation

In /workspace/extension-reality-m3-m4-recovery:

- node scripts/quality/check-readiness.mjs --strict passed: 23/23 readiness rows cleared, 0 failures.
- npx vitest run --config config/testing/vitest.config.ts scripts/quality/check-trust-model-truth.test.mjs src/tools/video-editor/runtime/composition/shaderRefAuthority.test.ts src/tools/video-editor/runtime/composition/compositionGraphProjector.test.ts src/tools/video-editor/runtime/renderPlanner.test.ts src/tools/video-editor/runtime/exportGuard.test.ts src/tools/video-editor/hooks/useRenderState.test.tsx passed: 5 files, 248 tests.

## Recovery Notes

- Preserved the original M3 work at recovery/m3-export-readiness-salvage.
- Replayed the product commit onto the current target in a clean recovery worktree.
- Excluded .megaplan runtime/telemetry metadata from the recovery PR.
- Resolved the only product conflict in useRenderState by preserving M4's planner-route provenance and route-availability proof path.
