### PR TITLE
Fix chain custody completion guards

### DIFF
--- a/arnold_pipelines/megaplan/chain/__init__.py
+++ b/arnold_pipelines/megaplan/chain/__init__.py
@@ -2365,7 +2365,7 @@ def _published_pr_target_from_gh(
                 "view",
                 str(pr_number),
                 "--json",
-                "state,mergeCommit,headRefOid",
+                "state,mergedAt,mergeCommit,headRefOid",
             ],
             cwd=str(root),
             capture_output=True,
@@ -2387,6 +2387,9 @@ def _published_pr_target_from_gh(
     state = _string_value(payload.get("state"))
     if not state or state.lower() != "merged":
         return None, f"gh pr view #{pr_number} state={state!r} is not merged"
+    merged_at = _string_value(payload.get("mergedAt"))
+    if not merged_at:
+        return None, f"gh pr view #{pr_number} has no mergedAt timestamp"
     merge_sha = _sha_from_payload_value(payload.get("mergeCommit"))
     if merge_sha:
         return merge_sha, f"gh.pr#{pr_number}.mergeCommit"
@@ -2399,6 +2402,24 @@ def _published_pr_target_from_gh(
 def _completion_record_is_merged_pr(record: dict[str, Any]) -> bool:
     pr_state = _string_value(record.get("pr_state"))
     return bool(pr_state and pr_state.lower() == "merged")
+
+
+def _published_target_is_in_chain_target(
+    root: Path,
+    target: str,
+    chain_state: ChainState | None,
+) -> tuple[bool | None, str]:
+    if chain_state is None:
+        return None, "chain target unavailable"
+    target_ref = _string_value(chain_state.target_base_ref)
+    if not target_ref:
+        return None, "chain target ref unavailable"
+    if _git_is_ancestor(root, target, target_ref):
+        return True, f"published PR target {target[:12]} is contained in {target_ref}"
+    return (
+        False,
+        f"published PR target {target[:12]} is not contained in chain target {target_ref}",
+    )
 
 
 def _published_pr_semantic_diff_nonempty_from_base(
@@ -2419,6 +2440,13 @@ def _published_pr_semantic_diff_nonempty_from_base(
         target, source = _published_pr_target_from_record(record, chain_state)
     if target is None:
         return None, f"published PR target unavailable: {source}"
+    landed_ok, landed_reason = _published_target_is_in_chain_target(
+        root,
+        target,
+        chain_state,
+    )
+    if landed_ok is False:
+        return False, landed_reason
     return _semantic_diff_nonempty_between_refs(
         root,
         base_sha,
@@ -2490,6 +2518,11 @@ def _chain_completion_guard(
                 chain_state=chain_state,
             )
         )
+        if (
+            published_diff_ok is False
+            and "not contained in chain target" in published_diff_reason
+        ):
+            return False, published_diff_reason
         local_diff_ok = False
         local_diff_reason = ""
         local_raw_diff_ok: bool | None = None
@@ -3887,6 +3920,7 @@ def _reconcile_chain_from_ground_truth(
     }
     completed_by_label = _completed_records_by_label(state)
     reconciled_completed: list[dict[str, Any]] = []
+    removed_completed: dict[str, dict[str, Any]] = {}
 
     for milestone in spec.milestones:
         record = completed_by_label.get(milestone.label)
@@ -3908,6 +3942,9 @@ def _reconcile_chain_from_ground_truth(
                     f"[chain] completed record for {milestone.label} is not "
                     f"authoritative yet: PR #{pr_number} state={live_pr_state}\n"
                 )
+                removed = dict(record)
+                removed["pr_state"] = live_pr_state
+                removed_completed[milestone.label] = removed
                 continue
         reconciled_completed.append(record)
 
@@ -3931,6 +3968,25 @@ def _reconcile_chain_from_ground_truth(
             state.pr_number = None
             state.pr_state = None
             state.last_state = "done"
+    elif state.current_milestone_index > first_incomplete:
+        writer(
+            f"[chain] reconciled cursor index: {state.current_milestone_index} "
+            f"-> {first_incomplete} from completed milestones\n"
+        )
+        state.current_milestone_index = first_incomplete
+        if first_incomplete < len(spec.milestones):
+            milestone = spec.milestones[first_incomplete]
+            removed = removed_completed.get(milestone.label)
+            plan = removed.get("plan") if isinstance(removed, dict) else None
+            state.current_plan_name = plan if isinstance(plan, str) and plan else None
+            state.pr_number = _record_pr_number(removed)
+            pr_state = removed.get("pr_state") if isinstance(removed, dict) else None
+            state.pr_state = pr_state if isinstance(pr_state, str) else None
+            state.last_state = "authority_divergence"
+        else:
+            state.current_plan_name = None
+            state.pr_number = None
+            state.pr_state = None
 
     plan_name = state.current_plan_name
     plan_state = _plan_state_payload_from_name(root, plan_name)

--- a/arnold_pipelines/megaplan/cli/parser.py
+++ b/arnold_pipelines/megaplan/cli/parser.py
@@ -1,5 +1,0 @@
-"""Compatibility import target for the Megaplan CLI parser."""
-
-from arnold_pipelines.megaplan.cli import build_parser
-
-__all__ = ["build_parser"]

--- a/arnold_pipelines/megaplan/cloud/status_snapshot.py
+++ b/arnold_pipelines/megaplan/cloud/status_snapshot.py
@@ -35,6 +35,7 @@ from arnold_pipelines.megaplan.cloud.repair_contract import is_success_outcome
 from arnold_pipelines.megaplan.cloud.session_markers import (
     is_canonical_session_marker_path,
 )
+from arnold_pipelines.megaplan.chain.spec import load_spec as load_chain_spec
 
 # --- canonical paths -------------------------------------------------------
 
@@ -85,6 +86,7 @@ def is_trusted_container() -> bool:
 STALE_ACTIVITY_S = 30 * 60
 # A repair-progress marker older than this no longer counts as "repairing".
 REPAIR_FRESH_S = 6 * 60 * 60
+CHAIN_HEALTH_STALE_GRACE_S = 5
 
 SessionStatus = str  # one of: running | repairing | blocked | complete | attention
 LivenessProbe = Callable[[Mapping[str, Any]], dict[str, bool]]
@@ -664,6 +666,122 @@ def _session_progress(
     return progress
 
 
+def _overlay_newer_chain_state(
+    chain_health: Mapping[str, Any] | None,
+    *,
+    workspace: Path | None,
+    remote_spec: str,
+) -> Mapping[str, Any] | None:
+    state_path, chain_state = _load_latest_chain_state(workspace)
+    if state_path is None or not isinstance(chain_state, Mapping):
+        return chain_health
+
+    health_mtime = _chain_health_mtime(chain_health)
+    try:
+        state_mtime = state_path.stat().st_mtime
+    except OSError:
+        return chain_health
+    if health_mtime is not None and state_mtime <= health_mtime + CHAIN_HEALTH_STALE_GRACE_S:
+        return chain_health
+
+    milestone_count = _chain_milestone_count(remote_spec)
+    if milestone_count is None and isinstance(chain_health, Mapping):
+        milestone_count = _as_int(chain_health.get("milestone_count"))
+    completed = chain_state.get("completed")
+    completed_len = len(completed) if isinstance(completed, list) else 0
+    current_index = _as_int(chain_state.get("current_milestone_index"))
+    last_state = str(chain_state.get("last_state") or "").strip()
+    chain_complete = _chain_state_complete(
+        last_state=last_state,
+        completed_len=completed_len,
+        milestone_count=milestone_count,
+    )
+    custody_mismatch = bool(
+        last_state.lower() in {"done", "complete", "completed"}
+        and milestone_count is not None
+        and completed_len < milestone_count
+    )
+
+    merged: dict[str, Any] = dict(chain_health or {})
+    merged.update(
+        {
+            "chain_complete": chain_complete,
+            "completed_count": completed_len,
+            "current_milestone_index": current_index,
+            "custody_mismatch": custody_mismatch,
+            "last_state": last_state,
+            "updated_at": _isoformat(datetime.fromtimestamp(state_mtime, timezone.utc)),
+            "source": "chain_state",
+            "chain_state_path": str(state_path),
+        }
+    )
+    if milestone_count is not None:
+        merged["milestone_count"] = milestone_count
+    if chain_complete:
+        merged["current_plan_name"] = ""
+    elif isinstance(chain_state.get("current_plan_name"), str):
+        merged["current_plan_name"] = chain_state.get("current_plan_name")
+    completed_pr = completed[-1] if isinstance(completed, list) and completed else {}
+    if chain_state.get("pr_number") is not None:
+        merged["pr_number"] = chain_state.get("pr_number")
+    elif isinstance(completed_pr, Mapping) and completed_pr.get("pr_number") is not None:
+        merged["pr_number"] = completed_pr.get("pr_number")
+    if chain_state.get("pr_state") is not None:
+        merged["pr_state"] = chain_state.get("pr_state")
+    elif isinstance(completed_pr, Mapping) and completed_pr.get("pr_state") is not None:
+        merged["pr_state"] = completed_pr.get("pr_state")
+    return merged
+
+
+def _load_latest_chain_state(workspace: Path | None) -> tuple[Path | None, Mapping[str, Any] | None]:
+    if workspace is None:
+        return None, None
+    chain_dir = workspace / ".megaplan" / "plans" / ".chains"
+    try:
+        candidates = [p for p in chain_dir.glob("*.json") if p.is_file()]
+    except OSError:
+        return None, None
+    if not candidates:
+        return None, None
+    path = max(candidates, key=lambda p: p.stat().st_mtime)
+    payload = _load_json(path)
+    if not isinstance(payload, Mapping):
+        return None, None
+    return path, payload
+
+
+def _chain_health_mtime(chain_health: Mapping[str, Any] | None) -> float | None:
+    if not chain_health:
+        return None
+    updated = _parse_iso(chain_health.get("updated_at"))
+    return updated.timestamp() if updated is not None else None
+
+
+def _chain_milestone_count(remote_spec: str) -> int | None:
+    if not remote_spec:
+        return None
+    try:
+        spec_path = Path(remote_spec)
+        if not spec_path.exists():
+            return None
+        return len(load_chain_spec(spec_path).milestones)
+    except Exception:
+        return None
+
+
+def _chain_state_complete(
+    *,
+    last_state: str,
+    completed_len: int,
+    milestone_count: int | None,
+) -> bool:
+    if last_state.strip().lower() not in {"done", "complete", "completed"}:
+        return False
+    if milestone_count is None:
+        return True
+    return completed_len >= milestone_count
+
+
 # --- per-session classification -------------------------------------------
 
 
@@ -685,6 +803,11 @@ def _build_session_entry(
 
     marker_path = Path(marker.get("_marker_path") or (marker_dir / f"{session}.json"))
     chain_health = _load_json(marker_dir / f"{session}.chain-health.progress.json")
+    chain_health = _overlay_newer_chain_state(
+        chain_health,
+        workspace=workspace,
+        remote_spec=remote_spec,
+    )
     repair_progress = _load_json(marker_dir / f"{session}.repair-progress.json")
     needs_human = _load_json(repair_data_dir / f"{session}.needs-human.json")
     watchdog_item = watchdog_by_session.get(session, {})
@@ -728,6 +851,8 @@ def _build_session_entry(
     plan_state_label = plan_current_state or (
         chain_health.get("last_state") if chain_health else None
     )
+    if isinstance(chain_health, Mapping) and chain_health.get("custody_mismatch"):
+        plan_state_label = None
     latest_activity = _latest_activity(chain_health, marker, plan_state_doc)
     liveness = _augment_liveness_with_plan_state(
         _safe_liveness(liveness_probe, marker),
@@ -834,6 +959,16 @@ def _classify_session(
 
     if _canonical_spec_missing(workspace, remote_spec):
         return "attention", "spec missing or unreadable"
+
+    if isinstance(chain_health, Mapping) and chain_health.get("custody_mismatch"):
+        completed = chain_health.get("completed_count")
+        total = chain_health.get("milestone_count")
+        current_index = chain_health.get("current_milestone_index")
+        return (
+            "attention",
+            "chain custody mismatch: terminal state with "
+            f"completed={completed}/{total} current_milestone_index={current_index}",
+        )
 
     # Fresh repair custody is stronger than a needs-human sidecar. Repair loops
     # can leave old needs-human markers in place while a higher layer is already

--- a/docs/arnold/package-authoring-contract.md
+++ b/docs/arnold/package-authoring-contract.md
@@ -234,7 +234,7 @@ package code.
 ### What The Package Owns
 
 The package module owns:
-- **Topology** — the declared `@workflow`/`@step`/`@decision` call structure.
+- **Topology** - the declared workflow, step, and decision call structure.
 - **Stable identity** — the `id=` values on every invocable and call site.
 - **Declared schemas** — `inputs` and `outputs` at every invocable boundary.
 - **Policy references** — named policy objects bound at call sites.

--- a/tests/cloud/test_status_snapshot.py
+++ b/tests/cloud/test_status_snapshot.py
@@ -799,6 +799,56 @@ def test_session_entry_carries_progress_block(fx):
     assert statuses == ["done", "in_progress", "pending", "pending"]
 
 
+def test_newer_terminal_chain_state_with_missing_completed_records_is_attention(fx):
+    workspace = fx.root / "epic-run"
+    spec_path = fx.root / "chain.yaml"
+    spec_path.write_text(
+        "base_branch: main\n"
+        "milestones:\n"
+        "  - label: m1\n"
+        "    idea: m1.md\n"
+        "  - label: m2\n"
+        "    idea: m2.md\n"
+        "  - label: m3\n"
+        "    idea: m3.md\n"
+        "  - label: m4\n"
+        "    idea: m4.md\n",
+        encoding="utf-8",
+    )
+    fx.add_session("epic-run", workspace=str(workspace), remote_spec=str(spec_path))
+    fx.add_chain_health(
+        "epic-run",
+        chain_complete=True,
+        completed_count=4,
+        milestone_count=4,
+        current_plan_name="",
+        last_state="done",
+        updated_at=NOW - timedelta(minutes=5),
+    )
+    chain_dir = workspace / ".megaplan" / "plans" / ".chains"
+    chain_dir.mkdir(parents=True, exist_ok=True)
+    (chain_dir / "chain.json").write_text(
+        json.dumps(
+            {
+                "current_milestone_index": 4,
+                "last_state": "done",
+                "completed": [{"label": "m1", "pr_number": 93, "pr_state": "merged"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    snap = fx.build()
+    entry = _by_session(snap, "epic-run")
+
+    assert entry["status"] == "attention"
+    assert entry["chain_complete"] is False
+    assert entry["completed_count"] == 1
+    assert entry["milestone_count"] == 4
+    assert entry["progress"]["percent"] == 25
+    assert "chain custody mismatch" in entry["operator_next"]
+
+
 def test_session_entry_progress_none_without_milestones(fx):
     fx.add_session("plan-only", plan_name="planX")
     # chain-health with no milestone_count → nothing to score → progress is None.

--- a/tests/test_chain_completion_guard.py
+++ b/tests/test_chain_completion_guard.py
@@ -226,6 +226,30 @@ def _write_chain_spec(root: Path) -> Path:
     return spec_path
 
 
+def _write_three_milestone_chain_spec(root: Path) -> Path:
+    north_star = root / "NORTHSTAR.md"
+    north_star.write_text("north star\n", encoding="utf-8")
+    spec_path = root / "chain.yaml"
+    lines = [
+        "base_branch: main",
+        "anchors:",
+        "  north_star: NORTHSTAR.md",
+        "milestones:",
+    ]
+    for label in ("m1", "m2", "m3"):
+        idea = root / f"{label}.md"
+        idea.write_text(f"ship {label}\n", encoding="utf-8")
+        lines.extend(
+            [
+                f"  - label: {label}",
+                f"    idea: {idea}",
+                f"    branch: test/{label}",
+            ]
+        )
+    spec_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return spec_path
+
+
 def _write_base_branch_chain_spec(root: Path) -> Path:
     idea = root / "idea.md"
     idea.write_text("ship milestone on base\n", encoding="utf-8")
@@ -2980,6 +3004,90 @@ def test_merged_pr_completion_prefers_gh_merge_commit_over_stale_chain_pr_head(
     assert ok is True
     assert "gh.pr#128.mergeCommit" in reason
     assert stale_pr_head[:12] not in reason
+
+
+def test_completion_guard_rejects_published_pr_target_not_in_chain_target(
+    tmp_path: Path, monkeypatch
+) -> None:
+    base = _init_repo(tmp_path)
+    local_branch = _git(tmp_path, "branch", "--show-current")
+    published_sha = _commit_published_semantic_change(
+        tmp_path,
+        base,
+        branch="published-not-landed",
+        return_to=local_branch,
+    )
+    _write_plan(tmp_path, base_sha=base, finalize_tasks=[{"id": "T1"}])
+
+    def fake_published_target_from_gh(_root: Path, pr_number: int) -> tuple[str, str]:
+        assert pr_number == 95
+        return published_sha, "gh.pr#95.mergeCommit"
+
+    monkeypatch.setattr(
+        chain_module,
+        "_published_pr_target_from_gh",
+        fake_published_target_from_gh,
+    )
+
+    ok, reason = _chain_completion_guard(
+        tmp_path,
+        {**_record(), "pr_number": 95, "pr_state": "merged"},
+        implementation_milestone=True,
+        chain_state=ChainState(target_base_ref=local_branch),
+    )
+
+    assert ok is False
+    assert "not contained in chain target" in reason
+
+
+def test_reconcile_rolls_cursor_back_when_completed_record_not_authoritative(
+    tmp_path: Path,
+) -> None:
+    spec_path = _write_three_milestone_chain_spec(tmp_path)
+    spec = load_spec(spec_path)
+    state = ChainState(
+        current_milestone_index=3,
+        last_state="done",
+        completed=[
+            {
+                "label": "m1",
+                "plan": "plan-m1",
+                "status": "done",
+                "pr_number": 11,
+                "pr_state": "merged",
+            },
+            {
+                "label": "m2",
+                "plan": "plan-m2",
+                "status": "done",
+                "pr_number": 95,
+                "pr_state": "merged",
+            },
+        ],
+    )
+    messages: list[str] = []
+
+    def fake_pr_state(_root: Path, pr_number: int, *, writer=None) -> str:
+        return "closed" if pr_number == 95 else "merged"
+
+    with patch("arnold_pipelines.megaplan.chain._pr_state", fake_pr_state):
+        reconciled = chain_module._reconcile_chain_from_ground_truth(
+            tmp_path,
+            spec_path,
+            spec,
+            state,
+            writer=messages.append,
+            push_enabled=True,
+        )
+
+    assert reconciled.current_milestone_index == 1
+    assert reconciled.current_plan_name == "plan-m2"
+    assert reconciled.pr_number == 95
+    assert reconciled.pr_state == "closed"
+    assert reconciled.last_state == "authority_divergence"
+    assert [record["label"] for record in reconciled.completed] == ["m1"]
+    assert any("not authoritative yet" in message for message in messages)
+    assert any("reconciled cursor index: 3 -> 1" in message for message in messages)
 
 
 def test_missing_milestone_base_sha_blocks_without_waiver(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Adds focused guards for the failure mode that let extension-reality-convergence advance past a non-authoritative M3 publication record:

- require merged PR publication evidence to include `mergedAt`
- reject merged-PR completion proof when the published target is not contained in the chain target ref
- roll the chain cursor back when reconciliation removes non-authoritative completed records
- make cloud status show `attention` for terminal raw chain state with fewer completed records than the spec milestone count

## Validation

On `/workspace/arnold-chain-guard-min`:

- `python3 -m py_compile arnold_pipelines/megaplan/chain/__init__.py arnold_pipelines/megaplan/cloud/status_snapshot.py`
- `python3 -m pytest tests/cloud/test_status_snapshot.py -q` -> 61 passed
- `python3 -m pytest tests/test_chain_completion_guard.py::test_merged_pr_completion_queries_gh_when_only_pr_number_is_recorded tests/test_chain_completion_guard.py::test_merged_pr_completion_prefers_gh_merge_commit_over_stale_chain_pr_head tests/test_chain_completion_guard.py::test_completion_guard_rejects_published_pr_target_not_in_chain_target tests/test_chain_completion_guard.py::test_reconcile_rolls_cursor_back_when_completed_record_not_authoritative -q` -> 4 passed

Note: full `tests/test_chain_completion_guard.py` on current `origin/editible-install` has unrelated pre-existing failures around execute-authority/rerun helpers. This PR validates the incident-specific guard surface plus the full status snapshot suite.
