### PR TITLE
M11: bind production recovery acceptance

### DIFF
--- a/.megaplan/initiatives/custody-control-plane/briefs/m11-conformance-and-legacy-retirement.md
+++ b/.megaplan/initiatives/custody-control-plane/briefs/m11-conformance-and-legacy-retirement.md
@@ -24,6 +24,188 @@ M11 closes C01–C20 from
 exact accepted M10 launch/effect/replay handoff and revalidates it byte-for-byte
 before initialization, canary, or retirement eligibility.
 
+## Binding 2026-07-27 production-recovery amendment
+
+This amendment is required acceptance scope, not a follow-up ticket. It records
+failures observed while recovering M10 on the installed Hetzner worker and
+supersedes older topology language in this brief where the two conflict.
+
+- The supported production recovery topology is one durable failure occurrence,
+  one non-agent event trigger, one singleton `simple_fixer` operator, at most one
+  canonical target runner, and a three-hour missed-event reconciliation
+  backstop. Do not re-enable watchdog, L1/L2/L3 investigator, repair-loop,
+  meta-repair, periodic audit-agent, or managed-child fanout to satisfy older
+  wording. The immediate trigger and three-hour timer must invoke the same
+  implementation and share the same singleton/occurrence claim.
+- Preserve the existing p95 under-five-minute eligible-blocker-to-accepted-
+  repair-or-typed-escalation requirement with the event trigger. The three-hour
+  timer is only the independently scheduled missed-event backstop; polling every
+  three hours alone does not satisfy the SLO. All older references in this brief
+  to hourly watchdog or six-hour recovery topology are replaced by this
+  immediate-trigger plus three-hour-backstop design.
+- Bind acceptance to the installed path actually used in production:
+  `megaplan-progress-audit.service`,
+  `/usr/local/bin/arnold-progress-auditor`, its exact systemd environment and
+  wrapper hashes, the pinned `MEGAPLAN_SIMPLE_FIXER_SOURCE_ROOT`, the loaded
+  `simple_fixer.py` hash/commit, the target marker, and the target runtime
+  provenance receipt. A source-only test, editable checkout, prompt snapshot,
+  or nominal service status cannot satisfy this canary.
+- Execute M11 with the same existing editable install used to recover M10; this
+  is a continuity requirement, not permission to build a replacement runtime.
+  The bound interpreter is
+  `/workspace/.megaplan/engine-runtimes/d6a7b716-execute-projection/venv/bin/python`
+  and its editable project is
+  `/workspace/runtime-candidates/arnold-5bf11d5a5600`; its measured M10
+  recovery baseline is clean commit
+  `d6a7b71622c601d356189fd1ce17cb2fe1c7b716`. The bound
+  `_editable_impl_arnold.pth` SHA-256 is
+  `0294b47214797e2bd28f6b2b1d8eb77f03a5886d5139fe46d76ee4f320786d28`;
+  the interpreter SHA-256 is
+  `f90d942117b90a2cc1596eb62a0a6eee9c46e832d0b0f1335a48c4bf5da10ba4`.
+  After the M10 boundary, that same editable project worktree may be
+  fast-forwarded in place to the verified merged M10/M11 source commit, with
+  before/after commit provenance recorded. It must not reinstall Arnold, create
+  or select another venv, rewrite the
+  editable `.pth`, switch to a frozen clone/package, or silently cut over the
+  runner. Before M11 initialization and on every resume, fail closed unless the
+  interpreter, editable project path, `.pth` content/hash, imported module
+  roots, clean source lineage, and process command line all prove continuity of
+  this same install. Any intentionally required install change is a separate explicitly
+  authorized migration, not part of this M11 run.
+- At M11 initialization, import, hash, and join the four production recovery
+  cycles `20260727T183804.052936Z`, `20260727T194726.076432Z`, and
+  `20260727T200106.626010Z`, plus the M10 recovery cycle
+  `20260727T204730.361503Z`, from `/workspace/audit-reports/`, including their
+  prompts, operator results, transcripts, reports, before/after fingerprints,
+  target-runtime cutover/provenance receipts, focused-test evidence, and later
+  target events. Preserve the tested target-runtime commit
+  `e25f236d16b420881f4aafe87897e119b8d0dd8a`; fail closed if any cited artifact
+  is missing, mutable, unredacted, or cannot be bound to the exact occurrence.
+- Keep the fixer simple: the model prompt may investigate unknown causes, but a
+  small deterministic envelope must enforce the singleton lock, exact durable
+  occurrence identity, maximum two unchanged-fingerprint mutation attempts,
+  current Run Authority/Custody/WBC action gates before every mutation, one
+  canonical target runner, a hard no-child/no-subagent fence, redacted durable
+  transcript/result, and typed escalation. Prompt text alone is not proof of
+  the no-child fence.
+- The repair actor cannot verify itself. A separate verifier must later read the
+  exact occurrence, runtime/process identity, target state and receipts at 5m,
+  1h, and the next three-hour reconciliation. `state_cursor_advanced` alone is
+  insufficient: repeated identical divergence events, phase churn, status-only
+  rewrites, a fresh PID, or process presence without accepted work are negative
+  controls, not progress. Accepted progress requires a durable task/phase
+  acceptance or a fresh run-bound model/tool heartbeat followed by authoritative
+  forward movement; terminal repair also requires projection agreement.
+- Add the exact divergent-duplicate regression that failed in production.
+  Inject a divergent duplicate while transaction cleanup observes an already
+  ended transaction or commit failure. `DivergentDuplicateError` must remain the
+  primary typed outcome; quarantine must be durable or the result must remain
+  typed `INDETERMINATE`; no second terminal row/effect may exist. Restart/replay
+  of the same fixture must converge to the same typed result without blind
+  retry. A cleanup `OperationalError` may never mask the primary typed failure.
+- Add a cross-field phase-result invariant: `blocked_by_prereq` requires at
+  least one typed `blocked_tasks` entry after filtering stale projections
+  against durably completed task IDs. The producer must reject an empty
+  prerequisite block, and the reducer must emit `invalid_phase_result` /
+  `classification_incompatible` bound to the exact receipt hash. It must never
+  reinterpret the contradiction as a generic quality block or silently retry.
+- Add execution-ownership/scope regressions. Every execute batch must carry
+  complete batch-scope ownership evidence; unrelated operator/probe files must
+  be preserved outside claimed execution ownership. Exact replay must have no
+  added/missing files or unclaimed LOC. Repeated
+  `authority_divergence: batch_scope_missing_batch_scope` followed by phase
+  restart is a failed canary even if a cursor, state hash, or artifact changes.
+- Make execute-attempt receipts append-only across same-slot/same-task retries.
+  A new coordinator fence may not overwrite or restamp a prior canonical task
+  result. Worker-native whole-document checkpoints must use attempt-local
+  scratch paths and may reach canonical authority only through validation and
+  promotion. Regressions must prove that a terminal fence-N receipt remains
+  byte-addressable and discoverable after fence N+1 is prepared, and that the
+  retry does not re-execute a task whose accepted receipt and dependency
+  closure remain valid.
+- Give validation subprocesses explicit process custody. Every suite job must
+  record coordinator PID/birth identity, process-group identity, command hash,
+  receipt path, and adoption/termination policy before launch. Coordinator
+  exit, restart, timeout, or runtime cutover must either re-adopt the exact
+  still-valid job or terminate its entire process group and durably record the
+  typed outcome; it may not leave an orphan pytest process, launch a duplicate
+  suite, or infer success from an unowned raw log. Add SIGTERM/SIGKILL,
+  parent-death, restart, and duplicate-launch negative controls.
+- Make event-journal restart work bounded by new events, not historical journal
+  size. The projection cursor must follow the final event in chronological
+  append order rather than the maximum historical sequence value; a stale or
+  future sidecar cursor must self-heal from a bounded tail read without forcing
+  a full projection rewrite. A fresh transaction UUID must append without
+  scanning or materializing the full canonical journal; recovery may perform a
+  streaming historical membership check only when a pre-existing durable
+  commit marker makes recovery necessary.
+- Add a large-journal restart canary with stale/future sidecar values and
+  sequence resets. It must prove bounded resident memory, bounded bytes read and
+  written per fresh append, no rewrite of an already-current large projection,
+  deterministic recovery after crash, and no repeated rebuild loop. Provide an
+  explicit content-addressed compaction/checkpoint procedure whose retained
+  prefix/tail and legal-hold policy are verifiable; compaction may not silently
+  truncate authority, renumber surviving events, or make an accepted receipt
+  undiscoverable. Cursor advancement or process liveness alone does not pass
+  this canary.
+- Make executor completion-envelope handling deterministic and bounded. A
+  persistent executor may not consume its full reasoning budget and then emit
+  an empty, prose-only, or malformed authority envelope; the coordinator must
+  either reconstruct from exact attempt-local checkpoints under a typed policy
+  or terminate with one actionable occurrence. Structural audit reconstruction
+  must select current run-bound evidence, never a stale tool-read payload or
+  forbidden historical `head_sha`.
+- Validation is an exclusive, hermetic resource. No diagnostic or second pytest
+  process may overlap the authoritative validation job. The command compiler
+  must honor pytest `testpaths` and `python_files`, reject repo-root helper
+  scripts such as `_smoke_trace_test.py`, and prove full-process order
+  hermeticity. Resource acceptance must bound the observed late-suite memory
+  amplification (roughly 4.6–8 GB near 82% completion) and produce a typed
+  resource result rather than an orphan or ambiguous failure.
+- The full-suite backstop and semantic-carrier purity gates may not be skipped
+  during reconciled completion. Resolve or explicitly own the two carried
+  full-suite xfails and ten semantic-carrier xfails before retirement; a green
+  focused suite cannot substitute. Live wrapper and editable-runtime promotion
+  are one atomic operation, and the vendored Shannon fork
+  `arnold_pipelines/megaplan/vendor/shannon/index.ts` is a deployment
+  prerequisite rather than an optional local fallback.
+- Resident/fixer context gathering must be bounded to the target checkout and
+  exact occurrence inputs; recursive `/workspace` scans are forbidden. Add an
+  end-to-end no-amplification regression from one task completion authority
+  envelope through the full validation job and subsequent chain advancement.
+- Add legacy-terminal authority regressions. A legacy `done` label without an
+  evidence-backed accepted kernel decision must remain typed
+  `legacy_terminal_without_authority` / `no_accepted_attempt`; emitting the same
+  divergence once per task, advancing event sequence numbers, rebuilding
+  projections, or cycling execute/review is not productive progress. Recovery
+  must reconcile or replay the authoritative accepted-attempt evidence, or
+  produce one typed escalation bound to the unresolved task/dependency set.
+  It may not manufacture acceptance from `finalize.json`, clear the occurrence,
+  or pass the delayed verifier on divergence churn alone.
+- Add accepted-attempt dependency-closure regressions. An accepted attempt whose
+  prerequisites lack authoritative accepted decisions must remain typed
+  `accepted_task_dependency_unresolved` /
+  `accepted_attempt_dependency_unresolved`, with the exact transitive unresolved
+  dependency set. Re-emitting that divergence across T01–T40, rebuilding a
+  projection, or advancing only the event cursor is a failed recovery canary.
+  The implementation must deterministically repair/replay the missing
+  prerequisite decisions in dependency order or issue one bounded escalation;
+  it may not treat a raw terminal label or the dependent accepted attempt as
+  proof that dependency closure exists.
+- Add installed-runtime symbol and review-routing regressions. Every helper
+  referenced by the execute/review recovery path, including
+  `_attach_next_step_runtime`, must exist in and be exercised from the exact
+  loaded runtime; source-only import success is insufficient. Every review
+  rework item must bind to one concrete known finalize task ID. A generic or
+  unknown ID such as `REVIEW` must become a typed invalid-review/classification
+  result and one actionable escalation; it may not be fed back into execute,
+  consume rerun attempts, or create an execute/review loop.
+- Add cross-surface agreement tests that reject `is_blocked=true` or an
+  attention/repairable-failure card after the authoritative occurrence is
+  cleared and the plan is validly `executed`, `reviewed`, or finalized without
+  a current failure. Conversely, projections may not hide a current durable
+  failure merely because a runner exists.
+
 ## In scope
 
 - Revalidate the exact M10 source/seed/runtime/process launch manifest,
@@ -69,7 +251,8 @@ before initialization, canary, or retirement eligibility.
   T7/T12 and same-basename cross-binding, torn cursor vectors, and orphan custody.
 - Exercise duplicate/late/lost/out-of-order triggers and retries, crash between
   every persistence/effect boundary, restart/replay, projection delete/rebuild,
-  missed-event reconciliation, six-hour backstop, and independent verification.
+  immediate event triggering, three-hour missed-event reconciliation, and
+  delayed independent verification.
 - Verify installed/editable/cloud/runtime revision equality and support-manifest
   coverage; test shadow, canary, promotion, kill switch, and forced rollback.
 - Run storage migration/backfill and mixed-version acceptance across each
@@ -85,18 +268,18 @@ before initialization, canary, or retirement eligibility.
   production deployment, promotion, or destructive removal.
 - Include the captured M5 quality-block chain-of-custody as a named regression:
   structured `failed: <detail>` evidence, canonical classification, eligible
-  trigger, managed-worker provenance, dispatch/launch failure, bounded
-  meta-repair, six-hour reconciliation, and final independent outcome must all
-  remain joinable under one exact occurrence.
+  trigger, single-fixer and canonical-runner provenance, dispatch/launch
+  failure, bounded repair, three-hour missed-event reconciliation, and final
+  independent outcome must all remain joinable under one exact occurrence.
 - For the genuine block, prove durable eligible blocker event, exact signature,
-  current Run Authority fence, current Custody lease/epoch, one managed repair,
-  accepted repair or typed escalation within
-  the p95 SLO, authoritative resumed progress, independent 5m/1h/6h checks,
+  current Run Authority fence, current Custody lease/epoch, one singleton fixer
+  occurrence claim, accepted repair or typed escalation within
+  the p95 SLO, authoritative resumed progress, independent 5m/1h/3h checks,
   projection agreement, and no duplicate/replayed effect.
 - Prove both outcomes for that regression: a repairable deterministic block
   reaches one accepted repair, while an unapproved or genuinely incoherent case
   reaches one typed human gate. Neither may stall as unknown due to prefix
-  parsing, disappear because L1 was never launched, or count as recovered
+  parsing, disappear because the immediate trigger was lost, or count as recovered
   without authoritative progress and independent verification.
 - Mark raw-state/status/process/marker/sidecar/wrapper/compatibility authority
   bypasses eligible for removal only after their gates pass; preserve required
@@ -148,10 +331,10 @@ and may not restore legacy write authority.
 
 - One integrated launch/cutover test joins source and seed binding, target
   checkout/HEAD, runtime vector, marker CAS, supervisor receipt, resident and
-  watchdog process identity, worker preflight, fresh gate, A→B, and independently
+  single-fixer process identity, worker preflight, fresh gate, A→B, and independently
   verified B→A. Component-only helper tests cannot satisfy this case.
 - One canonical acceptance adapter and target-bound chain loader drive status,
-  watchdog, advancement, successor admission, resident, and Discord; all C16
+  fixer, advancement, successor admission, resident, and Discord; all C16
   contradictions remain visible and cannot render `done` or accepted progress.
 - Static call-site equality and runtime traces prove every provider/effect path
   uses C13's WBC protocol; all C20 retirement predicates pass per path before a
@@ -189,6 +372,23 @@ and may not restore legacy write authority.
 - One genuine blocked-run acceptance—not a fixture, mocked status, nominal
   manifest, fresh PID, or local repair commit—meets recovery, custody, resumed-
   progress, delayed-verification, and projection-agreement gates.
+- Named installed-runtime cases prove: divergent duplicate rollback never masks
+  its typed outcome; restart/replay is deterministic; empty
+  `blocked_by_prereq` is rejected by producer and reducer; stale blocked
+  projections cannot override durable completion; execution ownership/batch
+  scope is complete; repeated authority divergence cannot count as progress;
+  execute/review recovery has no missing loaded-runtime symbol; review rework
+  IDs bind to concrete finalize tasks; and status/attention projections agree
+  with the authoritative current occurrence.
+- One production-path canary proves durable occurrence → immediate trigger →
+  one singleton fixer claim → current action gates → at most one canonical
+  runner → accepted progress or one typed escalation → separate delayed
+  verification. A second canary drops the immediate trigger and proves the
+  three-hour reconciliation catches the same occurrence without duplication.
+- The installed canary proves the exact systemd unit, wrapper, pinned fixer
+  source, prompt/input digest, target runtime and marker identities; zero new
+  managed-agent or legacy-repair manifests/processes; deterministic child-launch
+  denial; and the unchanged-fingerprint circuit breaker.
 - Productive-versus-replayed ledger coverage exposes unknowns and preserves
   legitimate workload; exact projection-I/O and compaction measurements are
   recorded or remain explicitly unknown rather than inferred as zero.

--- a/.megaplan/initiatives/custody-control-plane/chain.yaml
+++ b/.megaplan/initiatives/custody-control-plane/chain.yaml
@@ -278,6 +278,19 @@ milestones:
   prep_clarify: false
   prep_direction: 'Apply the final F01-F17/R1-R3 acceptance allocation in the
     amendment decision and C01-C20 in the July 23 structural conformance closure.
+    Treat the Binding 2026-07-27 production-recovery amendment in the M11 brief
+    as load-bearing acceptance scope, not a follow-up. Preserve the simple
+    production topology: one durable occurrence, one immediate non-agent trigger,
+    one singleton simple_fixer operator, at most one canonical target runner,
+    a hard no-child fence, delayed independent verification, and the same fixer
+    on a three-hour missed-event backstop; do not restore watchdog/L1/L2/L3,
+    repair-loop, meta-repair, or managed-agent fanout.
+    Execute M11 through the existing editable install at
+    /workspace/.megaplan/engine-runtimes/d6a7b716-execute-projection/venv/bin/python,
+    still bound by _editable_impl_arnold.pth to
+    /workspace/runtime-candidates/arnold-5bf11d5a5600. The project worktree may
+    fast-forward in place after M10 merges, but do not reinstall Arnold, replace
+    the venv, rewrite the .pth, or cut over to another runtime.
     First revalidate every predecessor hash, manifest,
     inventory row, dependency, and compatibility expiry from one clean pinned
     vector before canary or deletion eligibility. Close every residual migration-matrix and WBC boundary-inventory


### PR DESCRIPTION
Applies the required post-M10 M11 source amendment, preserves the existing editable runtime binding, and adds the executor-envelope, validation exclusivity/hermeticity, memory-bound, full-suite/xfail, Shannon-vendor, atomic-promotion, and bounded-context failures discovered during final M10 recovery.